### PR TITLE
fix: click focus on panes running TUIs with mouse reporting

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2336,10 +2336,7 @@ impl AppState {
                 }
             }
 
-            MouseEventKind::Up(MouseButton::Middle)
-            | MouseEventKind::Up(MouseButton::Right)
-            | MouseEventKind::Drag(MouseButton::Middle)
-            | MouseEventKind::Drag(MouseButton::Right)
+            MouseEventKind::Up(MouseButton::Middle) | MouseEventKind::Drag(MouseButton::Middle)
                 if !in_sidebar =>
             {
                 if let Some(info) = self.pane_mouse_target(mouse.column, mouse.row).cloned() {
@@ -2440,9 +2437,7 @@ impl AppState {
 
             MouseEventKind::Down(MouseButton::Right) if !in_sidebar => {
                 if let Some(info) = self.pane_mouse_target(mouse.column, mouse.row).cloned() {
-                    if self.forward_pane_mouse_button(&info, mouse) {
-                        return None;
-                    }
+                    self.focus_pane(info.id);
                     self.context_menu = Some(ContextMenuState {
                         kind: ContextMenuKind::Pane,
                         x: mouse.column,
@@ -4639,4 +4634,76 @@ mod tests {
         assert_eq!(app.state.mode, Mode::Terminal);
     }
 
+    #[tokio::test]
+    async fn clicking_unfocused_pane_with_mouse_reporting_focuses_it_via_right_button() {
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let first_pane = ws.tabs[0].root_pane;
+        let second_pane = ws.test_split(ratatui::layout::Direction::Vertical);
+
+        let terminal_area = Rect::new(26, 2, 80, 18);
+        let pane_infos = ws.tabs[0].layout.panes(terminal_area);
+        let first_info = pane_infos
+            .iter()
+            .find(|p| p.id == first_pane)
+            .expect("first pane info")
+            .clone();
+        let second_info = pane_infos
+            .iter()
+            .find(|p| p.id == second_pane)
+            .expect("second pane info")
+            .clone();
+
+        ws.tabs[0].runtimes.insert(
+            first_pane,
+            crate::pane::PaneRuntime::test_with_screen_bytes(
+                first_info.inner_rect.width.max(1),
+                first_info.inner_rect.height.max(1),
+                b"",
+            ),
+        );
+        ws.tabs[0].runtimes.insert(
+            second_pane,
+            crate::pane::PaneRuntime::test_with_screen_bytes(
+                second_info.inner_rect.width.max(1),
+                second_info.inner_rect.height.max(1),
+                b"\x1b[?1002h",
+            ),
+        );
+
+        ws.tabs[0].layout.focus_pane(first_pane);
+
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.view.pane_infos = pane_infos;
+
+        assert_eq!(
+            app.state.workspaces[0].tabs[0].layout.focused(),
+            first_pane,
+            "first pane should be focused before click"
+        );
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            second_info.inner_rect.x + 2,
+            second_info.inner_rect.y + 2,
+        ));
+
+        assert_eq!(
+            app.state.workspaces[0].tabs[0].layout.focused(),
+            second_pane,
+            "right-clicking a pane with mouse reporting should move focus to it"
+        );
+        assert_eq!(
+            app.state.mode,
+            Mode::ContextMenu,
+            "right-click should enter ContextMenu mode"
+        );
+        assert!(
+            app.state.context_menu.is_some(),
+            "right-click should populate context_menu state"
+        );
+    }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2155,6 +2155,11 @@ impl AppState {
                         return None;
                     }
                 } else if let Some(info) = self.pane_at(mouse.column, mouse.row).cloned() {
+                    self.focus_pane(info.id);
+                    if self.mode != Mode::Terminal {
+                        self.mode = Mode::Terminal;
+                    }
+
                     if self.forward_pane_mouse_button(&info, mouse) {
                         self.selection = None;
                         return None;
@@ -2170,11 +2175,6 @@ impl AppState {
                         col,
                         self.pane_scroll_metrics(info.id),
                     ));
-
-                    self.focus_pane(info.id);
-                    if self.mode != Mode::Terminal {
-                        self.mode = Mode::Terminal;
-                    }
                 } else if let Some(info) = self.view.pane_infos.iter().find(|p| {
                     mouse.column >= p.rect.x
                         && mouse.column < p.rect.x + p.rect.width
@@ -4573,4 +4573,70 @@ mod tests {
 
         assert_eq!(wheel_routing(input_state), WheelRouting::HostScroll);
     }
+
+    #[tokio::test]
+    async fn clicking_unfocused_pane_with_mouse_reporting_focuses_it_via_left_button() {
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let first_pane = ws.tabs[0].root_pane;
+        let second_pane = ws.test_split(ratatui::layout::Direction::Vertical);
+
+        let terminal_area = Rect::new(26, 2, 80, 18);
+        let pane_infos = ws.tabs[0].layout.panes(terminal_area);
+        let first_info = pane_infos
+            .iter()
+            .find(|p| p.id == first_pane)
+            .expect("first pane info")
+            .clone();
+        let second_info = pane_infos
+            .iter()
+            .find(|p| p.id == second_pane)
+            .expect("second pane info")
+            .clone();
+
+        ws.tabs[0].runtimes.insert(
+            first_pane,
+            crate::pane::PaneRuntime::test_with_screen_bytes(
+                first_info.inner_rect.width.max(1),
+                first_info.inner_rect.height.max(1),
+                b"",
+            ),
+        );
+        ws.tabs[0].runtimes.insert(
+            second_pane,
+            crate::pane::PaneRuntime::test_with_screen_bytes(
+                second_info.inner_rect.width.max(1),
+                second_info.inner_rect.height.max(1),
+                b"\x1b[?1002h",
+            ),
+        );
+
+        ws.tabs[0].layout.focus_pane(first_pane);
+
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.view.pane_infos = pane_infos;
+
+        assert_eq!(
+            app.state.workspaces[0].tabs[0].layout.focused(),
+            first_pane,
+            "first pane should be focused before click"
+        );
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            second_info.inner_rect.x + 2,
+            second_info.inner_rect.y + 2,
+        ));
+
+        assert_eq!(
+            app.state.workspaces[0].tabs[0].layout.focused(),
+            second_pane,
+            "left-clicking a pane with mouse reporting should move focus to it"
+        );
+        assert_eq!(app.state.mode, Mode::Terminal);
+    }
+
 }


### PR DESCRIPTION
## Summary

Two related bugs in `AppState::handle_mouse` that broke mouse clicks on panes running a TUI with mouse reporting enabled. Claude Code reproduces both. Codex and plain shells do not, because they don't toggle any of the DECSET mouse modes (1000/1002/1003), so the code path that caused the bug never fires for them.

On a Claude Code pane:

- Left-click did nothing to focus. The pane border stayed on whatever was previously focused.
- Right-click (after the left-click fix) focused the pane but never opened the herdr context menu. Split, fullscreen, close were unreachable by mouse.

## Root cause

Both handlers called `forward_pane_mouse_button` first and early-returned when the forward succeeded. Forwarding succeeds whenever `mouse_protocol_mode != None`, i.e. whenever the inner TUI has enabled any DECSET mouse mode. So the rest of each handler, including the focus update and the context menu creation, never ran for Claude Code panes.

`handle_terminal_wheel` already did it the right way: focus first, forward second. That's why scrolling "accidentally" updated focus as a side-effect, and why the bug looked click-specific.

## The fix

Two commits, one per bug.

1. `fix: focus pane on left-click even when mouse reporting is active`
   Reorder `Down(MouseButton::Left)` so `focus_pane` and the mode transition run before the forward, matching the wheel handler. The forward still runs afterwards when the inner TUI wants the click.

2. `fix: always open pane context menu on right-click`
   Stop forwarding `Down(MouseButton::Right)` to the pane runtime entirely. Right-click on a pane belongs to herdr, not to the inner content, same as Ghostty / Alacritty / Kitty / iTerm2. Also dropped `Up(MouseButton::Right)` and `Drag(MouseButton::Right)` from the middle/right forward branch so the inner TUI never sees an up or drag without a matching down. Middle button stays because some protocols still use it for paste.

## Tests

One regression test per commit. Each builds a two-pane workspace and installs a `PaneRuntime` on the target pane with mouse reporting enabled. The bytes `\x1b[?1002h` are written to the runtime at construction, which goes through Ghostty's real VT parser, so `mouse_protocol_mode` ends up as an actual `ButtonMotion` rather than a mock. The test fires a `Down(Left)` or `Down(Right)` and asserts focus moved. The right-click test also asserts `Mode::ContextMenu` was entered and `context_menu` is populated.

I did the negative proof on both: revert the fix, run the test, confirm it fails, restore. Worth mentioning: the first version of the right-click test only checked focus and would have passed against broken code. That's how the context-menu half of the bug slipped past the original attempt in this PR. The tightened assertions catch it now.

`cargo build`, `cargo fmt --check`, `cargo test` all clean (453 unit + 22 integration).

## Manual verification

1. Run Claude Code in a pane.
2. `Ctrl+B` → `V` to split vertically.
3. Left-click on the Claude Code pane → focus moves correctly.
4. Right-click on the Claude Code pane → context menu opens with split/fullscreen/close entries.
5. Invoke a context menu action (e.g. split vertical) → it acts on the Claude Code pane, not on the previously-focused shell pane.
6. Repeated the same with Codex and a plain shell as controls → no behaviour change (they were already working).
7. Scroll wheel, drag-to-select text, scrollbar clicks, tab/sidebar clicks, and split-border drag resize all verified to still work.