### PR TITLE
feat: add jcode integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "sha2",
  "tokio",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = "1"
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 toml = "0.8"
+toml_edit = "0.22"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 unicode-width = "0.2"

--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -2120,7 +2120,8 @@
             "cursor",
             "mastracode",
             "antigravity_cli",
-            "grok"
+            "grok",
+            "jcode"
           ],
           "type": "string"
         },
@@ -7115,7 +7116,8 @@
             "cursor",
             "mastracode",
             "antigravity_cli",
-            "grok"
+            "grok",
+            "jcode"
           ],
           "type": "string"
         },

--- a/docs/next/website/src/content/docs/agents.mdx
+++ b/docs/next/website/src/content/docs/agents.mdx
@@ -32,6 +32,7 @@ Automatic detection works out of the box for common coding agents. The important
 | Antigravity CLI | screen manifest | session |
 | Kiro CLI | screen manifest | none |
 | Maki | screen manifest | none |
+| Jcode | screen manifest | session |
 
 Detected but less thoroughly tested: Gemini CLI and Cline. Unsupported agents still run normally as terminal processes. They just may not get rich state unless you add an integration or report state over the socket API.
 

--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -1,6 +1,6 @@
 ---
 title: Integrations
-description: Install Herdr integrations for Pi, OMP, Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, Qoder CLI, Cursor Agent CLI, MastraCode, Antigravity CLI, and Grok CLI.
+description: Install Herdr integrations for Pi, OMP, Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, Qoder CLI, Cursor Agent CLI, MastraCode, Antigravity CLI, Grok CLI, and Jcode.
 ---
 
 Herdr detects supported agents automatically. Official integrations can add native session identity for restore, lifecycle state reports, or both.
@@ -28,6 +28,7 @@ herdr integration install cursor
 herdr integration install mastracode
 herdr integration install antigravity-cli
 herdr integration install grok
+herdr integration install jcode
 ```
 
 ## Uninstall integrations
@@ -49,6 +50,7 @@ herdr integration uninstall cursor
 herdr integration uninstall mastracode
 herdr integration uninstall antigravity-cli
 herdr integration uninstall grok
+herdr integration uninstall jcode
 ```
 
 ## How Herdr uses integrations
@@ -58,13 +60,13 @@ Herdr uses integrations in two different ways:
 | Integration type | Agents | Effect |
 | --- | --- | --- |
 | Lifecycle authority | Pi, OMP, Kimi Code CLI, OpenCode, Kilo Code CLI, MastraCode | When installed and actively reporting for the pane, hook or plugin events author `idle`, `working`, and `blocked`. Herdr does not also use screen manifest fallback for that same lifecycle authority. |
-| Session identity | Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Cursor Agent CLI, Hermes Agent, Antigravity CLI, Grok CLI | The integration reports native session references for restore. State still comes from Herdr's screen manifest detection. |
+| Session identity | Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Cursor Agent CLI, Hermes Agent, Antigravity CLI, Grok CLI, Jcode | The integration reports native session references for restore. State still comes from Herdr's screen manifest detection. |
 
 Custom socket integrations can also report state when they define state that is not visible in the native terminal UI.
 
-Some integrations report native agent session references. Herdr uses official session references to resume Claude Code, Codex, Devin CLI, Droid, Kimi Code CLI, Qoder CLI, Cursor Agent CLI, Grok CLI, GitHub Copilot CLI, Pi, OMP, Hermes Agent, OpenCode, Kilo Code CLI, MastraCode, and Antigravity CLI panes after a Herdr server restart unless `[session] resume_agents_on_restore = false` disables it.
+Some integrations report native agent session references. Herdr uses official session references to resume Claude Code, Codex, Devin CLI, Droid, Kimi Code CLI, Qoder CLI, Cursor Agent CLI, Grok CLI, Jcode, GitHub Copilot CLI, Pi, OMP, Hermes Agent, OpenCode, Kilo Code CLI, MastraCode, and Antigravity CLI panes after a Herdr server restart unless `[session] resume_agents_on_restore = false` disables it.
 
-Native session restore requires current Herdr integrations: Pi integration version `2`, OMP version `3`, Claude Code version `6`, Codex version `5`, GitHub Copilot CLI version `2`, Devin CLI version `2`, Droid version `2`, Kimi Code CLI version `3`, Qoder CLI version `2`, Cursor Agent CLI version `1`, Grok CLI version `1`, OpenCode version `5`, Kilo Code CLI version `1`, Hermes Agent version `2`, MastraCode version `1`, or Antigravity CLI version `1`. Check installed versions with `herdr integration status`.
+Native session restore requires current Herdr integrations: Pi integration version `2`, OMP version `3`, Claude Code version `6`, Codex version `5`, GitHub Copilot CLI version `2`, Devin CLI version `2`, Droid version `2`, Kimi Code CLI version `3`, Qoder CLI version `2`, Cursor Agent CLI version `1`, Grok CLI version `1`, Jcode version `1`, OpenCode version `5`, Kilo Code CLI version `1`, Hermes Agent version `2`, MastraCode version `1`, or Antigravity CLI version `1`. Check installed versions with `herdr integration status`.
 
 ## Pi
 
@@ -287,6 +289,20 @@ The hook reports session identity through Grok's `SessionStart` hook while Grok 
 Herdr uses `~/.grok` by default, or `GROK_HOME` when set. The Grok config directory must already exist. Grok merges every `hooks/*.json` file in that directory, so install writes a self-contained `hooks/herdr.json` with the Herdr `SessionStart` entry next to the `hooks/herdr-agent-state.sh` script, and never edits other hook files. Uninstall removes exactly those two Herdr-owned files.
 
 After Grok emits a session start event, Herdr can use the reported session id to resume the pane with `grok --resume <id>`.
+
+## Jcode
+
+Install the Jcode hook:
+
+```bash
+herdr integration install jcode
+```
+
+The hook reports native session identity through Jcode's `session_start` observer while Jcode runs inside a Herdr pane. Jcode state remains screen-driven: the composer marker and processing status line provide working and idle evidence, while shell mode and user-opened overlays remain idle.
+
+Herdr uses `~/.jcode`. The Jcode config directory must already exist. Install writes `hooks/herdr-agent-state.sh` and registers it as `[hooks].session_start` in `config.toml`. Because Jcode currently has one command slot for that event, Herdr saves any existing `session_start` command and the adapter forwards each event to it. Uninstall restores the saved command. If you replace the configured command after installing, uninstall leaves your replacement untouched.
+
+After Jcode emits a session start event, Herdr can resume the pane with `jcode --resume <id>` after a server restart. The integration reports session identity only and never reports lifecycle state.
 
 ## Custom status labels
 

--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -300,7 +300,7 @@ herdr integration install jcode
 
 The hook reports native session identity through Jcode's `session_start` observer while Jcode runs inside a Herdr pane. Jcode state remains screen-driven: the composer marker and processing status line provide working and idle evidence, while shell mode and user-opened overlays remain idle.
 
-Herdr uses `~/.jcode`. The Jcode config directory must already exist. Install writes `hooks/herdr-agent-state.sh` and registers it as `[hooks].session_start` in `config.toml`. Because Jcode currently has one command slot for that event, Herdr saves any existing `session_start` command and the adapter forwards each event to it. Uninstall restores the saved command. If you replace the configured command after installing, uninstall leaves your replacement untouched.
+Herdr uses `~/.jcode`. The Jcode config directory must already exist. Install writes `hooks/herdr-agent-state.sh` and appends it to `[hooks].session_start` in `config.toml`. Jcode runs each command in that lifecycle hook array directly. Reinstalling does not duplicate the Herdr command, and uninstall removes only the Herdr command while preserving every other observer.
 
 After Jcode emits a session start event, Herdr can resume the pane with `jcode --resume <id>` after a server restart. The integration reports session identity only and never reports lifecycle state.
 

--- a/docs/next/website/src/content/docs/session-state.mdx
+++ b/docs/next/website/src/content/docs/session-state.mdx
@@ -73,6 +73,7 @@ Native session restore requires these Herdr integration versions or newer:
 | Codex | `5` | `codex resume <id>` |
 | Cursor Agent CLI | `1` | `cursor-agent --resume <id>` |
 | Grok CLI | `1` | `grok --resume <id>` |
+| Jcode | `1` | `jcode --resume <id>` |
 | GitHub Copilot CLI | `2` | `copilot --resume=<id>` |
 | Devin CLI | `2` | `devin --resume <id>` |
 | Droid | `2` | `droid --resume <id>` |

--- a/docs/next/website/src/data/config-reference.json
+++ b/docs/next/website/src/data/config-reference.json
@@ -1026,6 +1026,17 @@
             "on",
             "off"
           ]
+        },
+        {
+          "key": "ui.sound.agents.jcode",
+          "type": "enum",
+          "default": "\"default\"",
+          "description": "Sound override for detected Jcode agents.",
+          "values": [
+            "default",
+            "on",
+            "off"
+          ]
         }
       ]
     },

--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -89,6 +89,7 @@ pub fn is_reserved_native_state_source(source: &str, agent: &str) -> bool {
             | ("herdr:qodercli", "qodercli")
             | ("herdr:cursor", "cursor")
             | ("herdr:grok", "grok")
+            | ("herdr:jcode", "jcode")
     )
 }
 
@@ -197,6 +198,9 @@ pub fn plan(source: &str, agent: &str, session_ref: &AgentSessionRef) -> Option<
         ("herdr:grok", "grok", AgentSessionRefKind::Id) => {
             vec!["grok".into(), "--resume".into(), session_ref.value.clone()]
         }
+        ("herdr:jcode", "jcode", AgentSessionRefKind::Id) => {
+            vec!["jcode".into(), "--resume".into(), session_ref.value.clone()]
+        }
         _ => return None,
     };
 
@@ -233,6 +237,7 @@ pub(crate) fn is_official_agent_source(source: &str, agent: &str) -> bool {
             | ("herdr:cursor", "cursor")
             | ("herdr:antigravity_cli", "agy")
             | ("herdr:grok", "grok")
+            | ("herdr:jcode", "jcode")
     )
 }
 
@@ -264,6 +269,7 @@ mod tests {
         assert!(is_reserved_native_state_source("herdr:claude", "claude"));
         assert!(is_reserved_native_state_source("herdr:codex", "codex"));
         assert!(is_reserved_native_state_source("herdr:devin", "devin"));
+        assert!(is_reserved_native_state_source("herdr:jcode", "jcode"));
         assert!(!is_reserved_native_state_source("herdr:kimi", "kimi"));
         assert!(!is_reserved_native_state_source(
             "herdr:opencode",
@@ -434,6 +440,16 @@ mod tests {
             .unwrap()
             .argv,
             vec!["grok", "--resume", "grok-session"]
+        );
+        assert_eq!(
+            plan(
+                "herdr:jcode",
+                "jcode",
+                &AgentSessionRef::id("jcode-session").unwrap()
+            )
+            .unwrap()
+            .argv,
+            vec!["jcode", "--resume", "jcode-session"]
         );
     }
 

--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -635,6 +635,9 @@ mod tests {
 
         let devin_plan = plan("herdr:devin", "devin", &AgentSessionRef::id(id).unwrap()).unwrap();
         assert_eq!(devin_plan.argv, vec!["devin", "--resume", id]);
+
+        let jcode_plan = plan("herdr:jcode", "jcode", &AgentSessionRef::id(id).unwrap()).unwrap();
+        assert_eq!(jcode_plan.argv, vec!["jcode", "--resume", id]);
     }
 
     #[test]
@@ -644,6 +647,7 @@ mod tests {
         let kilo_session = absolute_test_path("kilo-session");
         let copilot_session = absolute_test_path("copilot-session");
         let devin_session = absolute_test_path("devin-session");
+        let jcode_session = absolute_test_path("jcode-session");
         assert!(plan(
             "herdr:hermes",
             "hermes",
@@ -672,6 +676,12 @@ mod tests {
             "herdr:devin",
             "devin",
             &AgentSessionRef::path(&devin_session).unwrap()
+        )
+        .is_none());
+        assert!(plan(
+            "herdr:jcode",
+            "jcode",
+            &AgentSessionRef::path(&jcode_session).unwrap()
         )
         .is_none());
         assert!(session_ref_from_snapshot(

--- a/src/api/schema/integrations.rs
+++ b/src/api/schema/integrations.rs
@@ -29,10 +29,11 @@ pub enum IntegrationTarget {
     Mastracode,
     AntigravityCli,
     Grok,
+    Jcode,
 }
 
 impl IntegrationTarget {
-    pub(crate) const ALL: [Self; 16] = [
+    pub(crate) const ALL: [Self; 17] = [
         Self::Pi,
         Self::Omp,
         Self::Claude,
@@ -49,6 +50,7 @@ impl IntegrationTarget {
         Self::Mastracode,
         Self::AntigravityCli,
         Self::Grok,
+        Self::Jcode,
     ];
 }
 

--- a/src/cli/integration.rs
+++ b/src/cli/integration.rs
@@ -103,13 +103,13 @@ fn parse_integration_target(
 ) -> std::io::Result<Option<IntegrationTarget>> {
     let Some(target) = args.first().map(|arg| arg.as_str()) else {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|grok>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|antigravity-cli|grok|jcode>"
         );
         return Ok(None);
     };
     if args.len() != 1 {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|grok>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|antigravity-cli|grok|jcode>"
         );
         return Ok(None);
     }
@@ -131,10 +131,11 @@ fn parse_integration_target(
         "mastracode" => IntegrationTarget::Mastracode,
         "antigravity-cli" | "antigravity_cli" => IntegrationTarget::AntigravityCli,
         "grok" => IntegrationTarget::Grok,
+        "jcode" => IntegrationTarget::Jcode,
         _ => {
             eprintln!("unknown integration target: {target}");
             eprintln!(
-                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor, mastracode, antigravity-cli, grok"
+                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor, mastracode, antigravity-cli, grok, jcode"
             );
             return Ok(None);
         }
@@ -161,6 +162,7 @@ fn print_integration_help() {
     eprintln!("  herdr integration install mastracode");
     eprintln!("  herdr integration install antigravity-cli");
     eprintln!("  herdr integration install grok");
+    eprintln!("  herdr integration install jcode");
     eprintln!("  herdr integration uninstall pi");
     eprintln!("  herdr integration uninstall omp");
     eprintln!("  herdr integration uninstall claude");
@@ -177,5 +179,6 @@ fn print_integration_help() {
     eprintln!("  herdr integration uninstall mastracode");
     eprintln!("  herdr integration uninstall antigravity-cli");
     eprintln!("  herdr integration uninstall grok");
+    eprintln!("  herdr integration uninstall jcode");
     eprintln!("  herdr integration status [--outdated-only]");
 }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -915,7 +915,7 @@ pub struct ExperimentalConfig {
     /// if the list contains no valid names, the reveal does not apply.
     /// Accepted names: pi, claude, codex, gemini, cursor, devin, cline,
     /// opencode, copilot, kimi, kiro, droid, amp, grok, hermes, kilo,
-    /// qodercli, qoder, maki.
+    /// qodercli, qoder, maki, jcode.
     /// Default: empty.
     pub cjk_ime_agents: Vec<String>,
     /// Cursor shape rendered for the IME anchor when

--- a/src/config/sidebar.rs
+++ b/src/config/sidebar.rs
@@ -622,6 +622,7 @@ rows = [[{ token = "git_status", fg = "#ff00aa" }], [{ token = "$jj", bold = tru
             Agent::Kilo,
             Agent::Qodercli,
             Agent::Maki,
+            Agent::Jcode,
         ];
         let entries = agents
             .iter()

--- a/src/config/sound.rs
+++ b/src/config/sound.rs
@@ -44,6 +44,7 @@ pub struct AgentSoundOverrides {
     pub kilo: AgentSoundSetting,
     pub qodercli: AgentSoundSetting,
     pub maki: AgentSoundSetting,
+    pub jcode: AgentSoundSetting,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
@@ -140,6 +141,7 @@ impl AgentSoundOverrides {
             Some(Agent::Kilo) => self.kilo,
             Some(Agent::Qodercli) => self.qodercli,
             Some(Agent::Maki) => self.maki,
+            Some(Agent::Jcode) => self.jcode,
             None => AgentSoundSetting::Default,
         }
     }
@@ -179,6 +181,7 @@ impl Default for AgentSoundOverrides {
             kilo: AgentSoundSetting::Default,
             qodercli: AgentSoundSetting::Default,
             maki: AgentSoundSetting::Default,
+            jcode: AgentSoundSetting::Default,
         }
     }
 }

--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -248,6 +248,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("gemini", include_str!("manifests/gemini.toml")),
     ("grok", include_str!("manifests/grok.toml")),
     ("hermes", include_str!("manifests/hermes.toml")),
+    ("jcode", include_str!("manifests/jcode.toml")),
     ("kilo", include_str!("manifests/kilo.toml")),
     ("kimi", include_str!("manifests/kimi.toml")),
     ("kiro", include_str!("manifests/kiro.toml")),

--- a/src/detect/manifests/jcode.toml
+++ b/src/detect/manifests/jcode.toml
@@ -1,0 +1,47 @@
+id = "jcode"
+version = "2026.08.03.1"
+min_engine_version = 1
+updated_at = "2026-08-03T00:00:00Z"
+aliases = ["j-code", "herdr:jcode"]
+
+# Jcode pins its composer to the bottom of the pane. The next message number is
+# followed by one marker: `>` for ready, `…` while a turn is in flight, `»` for
+# an armed skill, or `$` for shell mode. Only `…` means working.
+[[rules]]
+id = "composer_processing"
+state = "working"
+priority = 900
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+line_regex = ['^\s*\d+…']
+
+# A multi-line composer can move its marker outside the recent-line window.
+# Jcode's processing line then shows either a braille spinner or an animated
+# three-dot tool bar directly above the composer.
+[[rules]]
+id = "status_line_spinner_working"
+state = "working"
+priority = 890
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+line_regex = ['^[\x{2800}-\x{28FF}] \S']
+
+[[rules]]
+id = "status_line_tool_bar_working"
+state = "working"
+priority = 890
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+line_regex = ['^[·●]{3} \S+ [·●]{3}(\s|$)']
+
+[[rules]]
+id = "composer_ready"
+state = "idle"
+priority = 850
+region = "bottom_non_empty_lines(4)"
+visible_idle = true
+line_regex = ['^\s*\d+[>»$]']
+
+# Jcode emits no state-bearing OSC progress/title sequence. It also has no
+# in-session approval prompt, so there is deliberately no blocked rule. Shell
+# mode and user-opened overlays correctly remain idle.

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -62,10 +62,11 @@ pub enum Agent {
     Kilo,
     Qodercli,
     Maki,
+    Jcode,
 }
 
 impl Agent {
-    pub const ALL: [Self; 21] = [
+    pub const ALL: [Self; 22] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -87,9 +88,10 @@ impl Agent {
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
+        Self::Jcode,
     ];
 
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -109,6 +111,7 @@ impl Agent {
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
+        Self::Jcode,
     ];
 }
 
@@ -135,6 +138,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Jcode => "jcode",
     }
 }
 
@@ -161,6 +165,7 @@ pub fn interactive_agent_executable(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Jcode => "jcode",
     }
 }
 
@@ -197,6 +202,7 @@ fn lookup_agent(name: &str) -> Option<Agent> {
         "kilo" | "kilo-code" | "kilo code" => Some(Agent::Kilo),
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
         "maki" => Some(Agent::Maki),
+        "jcode" | "j-code" => Some(Agent::Jcode),
         _ => None,
     }
 }
@@ -295,7 +301,7 @@ pub(crate) fn full_lifecycle_hook_authority(source: &str, agent_label: &str) -> 
 pub(crate) fn session_identity_only_integration(source: &str, agent_label: &str) -> bool {
     matches!(
         (source, agent_label),
-        ("herdr:hermes", "hermes") | ("herdr:antigravity_cli", "agy")
+        ("herdr:hermes", "hermes") | ("herdr:antigravity_cli", "agy") | ("herdr:jcode", "jcode")
     )
 }
 
@@ -690,6 +696,7 @@ mod tests {
         assert_eq!(identify_agent("kilo"), Some(Agent::Kilo));
         assert_eq!(identify_agent("kilo-code"), Some(Agent::Kilo));
         assert_eq!(identify_agent("maki"), Some(Agent::Maki));
+        assert_eq!(identify_agent("jcode"), Some(Agent::Jcode));
     }
 
     #[test]
@@ -716,6 +723,7 @@ mod tests {
         assert_eq!(parse_agent_label("hermes-agent"), Some(Agent::Hermes));
         assert_eq!(parse_agent_label("maki"), Some(Agent::Maki));
         assert_eq!(parse_agent_label("kilo-code"), Some(Agent::Kilo));
+        assert_eq!(parse_agent_label("j-code"), Some(Agent::Jcode));
     }
 
     #[test]
@@ -751,6 +759,7 @@ mod tests {
             (Agent::Kilo, "kilo"),
             (Agent::Qodercli, "qodercli"),
             (Agent::Maki, "maki"),
+            (Agent::Jcode, "jcode"),
         ];
         assert_eq!(expected.len(), Agent::ALL.len());
         for (agent, executable) in expected {
@@ -780,10 +789,30 @@ mod tests {
         for (source, label, agent) in [
             ("herdr:hermes", "hermes", Agent::Hermes),
             ("herdr:antigravity_cli", "agy", Agent::Antigravity),
+            ("herdr:jcode", "jcode", Agent::Jcode),
         ] {
             assert!(!full_lifecycle_hook_authority(source, label));
             assert!(session_identity_only_integration(source, label));
             assert!(Agent::SCREEN_MANIFEST_AGENTS.contains(&agent));
+        }
+    }
+
+    #[test]
+    fn jcode_manifest_uses_composer_and_processing_status_evidence() {
+        for screen in [
+            "transcript\n2…",
+            "transcript\n⠼ waiting for response… 1s\nmultiline composer",
+            "transcript\n··● bash ●·· · run tests · 23s\nmultiline composer",
+        ] {
+            let detection = detect_agent(Some(Agent::Jcode), screen);
+            assert_eq!(detection.state, AgentState::Working, "screen: {screen}");
+            assert!(detection.visible_working);
+        }
+
+        for screen in ["1>", "6$", "6»"] {
+            let detection = detect_agent(Some(Agent::Jcode), screen);
+            assert_eq!(detection.state, AgentState::Idle, "screen: {screen}");
+            assert!(detection.visible_idle);
         }
     }
 

--- a/src/integration/actions.rs
+++ b/src/integration/actions.rs
@@ -3,12 +3,12 @@ use std::io;
 use super::registry::{integration_target_label, integration_target_supported};
 use super::targets::{
     install_antigravity_cli, install_claude, install_codex, install_copilot, install_cursor,
-    install_devin, install_droid, install_grok, install_hermes, install_kilo, install_kimi,
-    install_mastracode, install_omp, install_opencode, install_pi, install_qodercli,
+    install_devin, install_droid, install_grok, install_hermes, install_jcode, install_kilo,
+    install_kimi, install_mastracode, install_omp, install_opencode, install_pi, install_qodercli,
     uninstall_antigravity_cli, uninstall_claude, uninstall_codex, uninstall_copilot,
     uninstall_cursor, uninstall_devin, uninstall_droid, uninstall_grok, uninstall_hermes,
-    uninstall_kilo, uninstall_kimi, uninstall_mastracode, uninstall_omp, uninstall_opencode,
-    uninstall_pi, uninstall_qodercli,
+    uninstall_jcode, uninstall_kilo, uninstall_kimi, uninstall_mastracode, uninstall_omp,
+    uninstall_opencode, uninstall_pi, uninstall_qodercli,
 };
 use super::version::{agent_version_requirement, enforce_agent_version};
 use super::{KIMI_MIN_VERSION, PI_EXTENSION_INSTALL_NAME};
@@ -227,6 +227,19 @@ fn install_target_inner(target: crate::api::schema::IntegrationTarget) -> io::Re
                 ),
                 format!(
                     "registered grok hook config at {}",
+                    installed.config_path.display()
+                ),
+            ]
+        }
+        crate::api::schema::IntegrationTarget::Jcode => {
+            let installed = install_jcode()?;
+            vec![
+                format!(
+                    "installed jcode integration hook to {}",
+                    installed.hook_path.display()
+                ),
+                format!(
+                    "ensured jcode session_start hook at {}",
                     installed.config_path.display()
                 ),
             ]
@@ -634,6 +647,33 @@ pub(crate) fn uninstall_target(
             } else {
                 messages.push(format!(
                     "no grok hook config found at {}",
+                    result.config_path.display()
+                ));
+            }
+            messages
+        }
+        crate::api::schema::IntegrationTarget::Jcode => {
+            let result = uninstall_jcode()?;
+            let mut messages = Vec::new();
+            if result.removed_hook_file {
+                messages.push(format!(
+                    "removed jcode hook at {}",
+                    result.hook_path.display()
+                ));
+            } else {
+                messages.push(format!(
+                    "no jcode hook found at {}",
+                    result.hook_path.display()
+                ));
+            }
+            if result.updated_config {
+                messages.push(format!(
+                    "restored jcode session_start hook in {}",
+                    result.config_path.display()
+                ));
+            } else {
+                messages.push(format!(
+                    "no herdr jcode hook entry found in {}",
                     result.config_path.display()
                 ));
             }

--- a/src/integration/actions.rs
+++ b/src/integration/actions.rs
@@ -668,7 +668,7 @@ pub(crate) fn uninstall_target(
             }
             if result.updated_config {
                 messages.push(format!(
-                    "restored jcode session_start hook in {}",
+                    "updated jcode session_start hook in {}",
                     result.config_path.display()
                 ));
             } else {

--- a/src/integration/assets/jcode/herdr-agent-state.sh
+++ b/src/integration/assets/jcode/herdr-agent-state.sh
@@ -6,42 +6,24 @@
 # Jcode currently has one command slot per lifecycle event. Herdr saves any
 # pre-existing session_start command beside this script and forwards the event
 # to it, preserving the user's observer while adding session identity.
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || exit 0
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || exit 0
 previous_hook_file="$script_dir/herdr-session-start.previous"
 
+# Preserve the exact shell semantics of the observer Jcode previously ran.
+# This happens independently of Python so installing Herdr never disables it.
+if [ -s "$previous_hook_file" ]; then
+    previous_command=$(cat -- "$previous_hook_file" 2>/dev/null) || previous_command=
+    if [ -n "$previous_command" ]; then
+        (sh -c "$previous_command" </dev/null >/dev/null 2>&1 &)
+    fi
+fi
+
 command -v python3 >/dev/null 2>&1 || exit 0
-HERDR_JCODE_PREVIOUS_HOOK_FILE="$previous_hook_file" python3 - <<'PY'
+python3 - <<'PY'
 import json
 import os
-import shlex
 import socket
-import subprocess
 import time
-
-
-def forward_previous_hook():
-    path = os.environ.get("HERDR_JCODE_PREVIOUS_HOOK_FILE")
-    if not path:
-        return
-    try:
-        with open(path, encoding="utf-8") as handle:
-            command = handle.read().strip()
-        argv = shlex.split(command)
-        if not argv:
-            return
-        argv[0] = os.path.expanduser(argv[0])
-        subprocess.Popen(
-            argv,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
-    except Exception:
-        pass
-
-
-forward_previous_hook()
 
 if os.environ.get("HERDR_ENV") != "1":
     raise SystemExit(0)

--- a/src/integration/assets/jcode/herdr-agent-state.sh
+++ b/src/integration/assets/jcode/herdr-agent-state.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# managed by herdr; reinstalling the integration replaces this file.
+# HERDR_INTEGRATION_ID=jcode
+# HERDR_INTEGRATION_VERSION=1
+
+# Jcode currently has one command slot per lifecycle event. Herdr saves any
+# pre-existing session_start command beside this script and forwards the event
+# to it, preserving the user's observer while adding session identity.
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || exit 0
+previous_hook_file="$script_dir/herdr-session-start.previous"
+
+command -v python3 >/dev/null 2>&1 || exit 0
+HERDR_JCODE_PREVIOUS_HOOK_FILE="$previous_hook_file" python3 - <<'PY'
+import json
+import os
+import shlex
+import socket
+import subprocess
+import time
+
+
+def forward_previous_hook():
+    path = os.environ.get("HERDR_JCODE_PREVIOUS_HOOK_FILE")
+    if not path:
+        return
+    try:
+        with open(path, encoding="utf-8") as handle:
+            command = handle.read().strip()
+        argv = shlex.split(command)
+        if not argv:
+            return
+        argv[0] = os.path.expanduser(argv[0])
+        subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        pass
+
+
+forward_previous_hook()
+
+if os.environ.get("HERDR_ENV") != "1":
+    raise SystemExit(0)
+
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+session_id = os.environ.get("JCODE_HOOK_SESSION_ID")
+if not pane_id or not socket_path or not session_id:
+    raise SystemExit(0)
+
+hook_source = os.environ.get("JCODE_HOOK_SOURCE")
+if hook_source in ("create", "attach"):
+    session_start_source = "startup"
+elif hook_source == "resume":
+    session_start_source = "resume"
+else:
+    session_start_source = None
+
+seq = time.time_ns()
+params = {
+    "pane_id": pane_id,
+    "source": "herdr:jcode",
+    "agent": "jcode",
+    "seq": seq,
+    "agent_session_id": session_id,
+}
+if session_start_source is not None:
+    params["session_start_source"] = session_start_source
+
+request = json.dumps(
+    {
+        "id": f"herdr:jcode:{seq}",
+        "method": "pane.report_agent_session",
+        "params": params,
+    }
+)
+
+try:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(0.5)
+        client.connect(socket_path)
+        client.sendall((request + "\n").encode())
+        client.recv(4096)
+except Exception:
+    pass
+PY

--- a/src/integration/assets/jcode/herdr-agent-state.sh
+++ b/src/integration/assets/jcode/herdr-agent-state.sh
@@ -3,21 +3,6 @@
 # HERDR_INTEGRATION_ID=jcode
 # HERDR_INTEGRATION_VERSION=1
 
-# Jcode currently has one command slot per lifecycle event. Herdr saves any
-# pre-existing session_start command beside this script and forwards the event
-# to it, preserving the user's observer while adding session identity.
-script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || exit 0
-previous_hook_file="$script_dir/herdr-session-start.previous"
-
-# Preserve the exact shell semantics of the observer Jcode previously ran.
-# This happens independently of Python so installing Herdr never disables it.
-if [ -s "$previous_hook_file" ]; then
-    previous_command=$(cat -- "$previous_hook_file" 2>/dev/null) || previous_command=
-    if [ -n "$previous_command" ]; then
-        (sh -c "$previous_command" </dev/null >/dev/null 2>&1 &)
-    fi
-fi
-
 command -v python3 >/dev/null 2>&1 || exit 0
 python3 - <<'PY'
 import json

--- a/src/integration/config_edit.rs
+++ b/src/integration/config_edit.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::path::Path;
 
 use serde_json::{json, Map, Value};
+use toml_edit::{value, DocumentMut, Item, Table};
 
 use super::command::{hook_command, legacy_bash_hook_command};
 #[cfg(windows)]
@@ -808,6 +809,63 @@ pub(crate) fn remove_kimi_config_block(content: &str) -> String {
     } else {
         result
     }
+}
+
+pub(crate) fn jcode_session_start_command(
+    content: &str,
+    config_path: &Path,
+) -> io::Result<Option<String>> {
+    let document = parse_jcode_config(content, config_path)?;
+    Ok(document
+        .get("hooks")
+        .and_then(Item::as_table_like)
+        .and_then(|hooks| hooks.get("session_start"))
+        .and_then(Item::as_str)
+        .map(str::to_string))
+}
+
+pub(crate) fn set_jcode_session_start_command(
+    content: &str,
+    config_path: &Path,
+    command: Option<&str>,
+) -> io::Result<String> {
+    let mut document = parse_jcode_config(content, config_path)?;
+    match command {
+        Some(command) => {
+            if !document.contains_key("hooks") {
+                document.insert("hooks", Item::Table(Table::new()));
+            }
+            let hooks = document
+                .get_mut("hooks")
+                .and_then(Item::as_table_like_mut)
+                .ok_or_else(|| {
+                    io::Error::other(format!(
+                        "jcode hooks at {} must be a TOML table",
+                        config_path.display()
+                    ))
+                })?;
+            hooks.insert("session_start", value(command));
+        }
+        None => {
+            let remove_empty_hooks =
+                if let Some(hooks) = document.get_mut("hooks").and_then(Item::as_table_like_mut) {
+                    hooks.remove("session_start");
+                    hooks.is_empty()
+                } else {
+                    false
+                };
+            if remove_empty_hooks {
+                document.remove("hooks");
+            }
+        }
+    }
+    Ok(document.to_string())
+}
+
+fn parse_jcode_config(content: &str, config_path: &Path) -> io::Result<DocumentMut> {
+    content.parse::<DocumentMut>().map_err(|err| {
+        io::Error::other(format!("failed to parse {}: {err}", config_path.display()))
+    })
 }
 
 pub(crate) fn toml_basic_string(value: &str) -> String {

--- a/src/integration/config_edit.rs
+++ b/src/integration/config_edit.rs
@@ -816,12 +816,22 @@ pub(crate) fn jcode_session_start_command(
     config_path: &Path,
 ) -> io::Result<Option<String>> {
     let document = parse_jcode_config(content, config_path)?;
-    Ok(document
+    let Some(entry) = document
         .get("hooks")
         .and_then(Item::as_table_like)
         .and_then(|hooks| hooks.get("session_start"))
-        .and_then(Item::as_str)
-        .map(str::to_string))
+    else {
+        return Ok(None);
+    };
+    entry
+        .as_str()
+        .map(|value| Some(value.to_string()))
+        .ok_or_else(|| {
+            io::Error::other(format!(
+                "jcode hooks.session_start at {} must be a string",
+                config_path.display()
+            ))
+        })
 }
 
 pub(crate) fn set_jcode_session_start_command(

--- a/src/integration/config_edit.rs
+++ b/src/integration/config_edit.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::path::Path;
 
 use serde_json::{json, Map, Value};
-use toml_edit::{value, DocumentMut, Item, Table};
+use toml_edit::{value, Array, DocumentMut, Item, Table};
 
 use super::command::{hook_command, legacy_bash_hook_command};
 #[cfg(windows)]
@@ -811,65 +811,131 @@ pub(crate) fn remove_kimi_config_block(content: &str) -> String {
     }
 }
 
-pub(crate) fn jcode_session_start_command(
+pub(crate) fn jcode_session_start_commands(
     content: &str,
     config_path: &Path,
-) -> io::Result<Option<String>> {
+) -> io::Result<Vec<String>> {
     let document = parse_jcode_config(content, config_path)?;
     let Some(entry) = document
         .get("hooks")
         .and_then(Item::as_table_like)
         .and_then(|hooks| hooks.get("session_start"))
     else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
-    entry
-        .as_str()
-        .map(|value| Some(value.to_string()))
-        .ok_or_else(|| {
-            io::Error::other(format!(
-                "jcode hooks.session_start at {} must be a string",
-                config_path.display()
-            ))
+    if let Some(command) = entry.as_str() {
+        return Ok(vec![command.to_string()]);
+    }
+    let Some(commands) = entry.as_array() else {
+        return Err(invalid_jcode_session_start(config_path));
+    };
+    commands
+        .iter()
+        .map(|command| {
+            command
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| invalid_jcode_session_start(config_path))
         })
+        .collect()
 }
 
-pub(crate) fn set_jcode_session_start_command(
+pub(crate) fn append_jcode_session_start_command(
     content: &str,
     config_path: &Path,
-    command: Option<&str>,
+    command: &str,
 ) -> io::Result<String> {
+    let commands = jcode_session_start_commands(content, config_path)?;
+    if commands.iter().any(|existing| existing == command) {
+        return Ok(content.to_string());
+    }
+
     let mut document = parse_jcode_config(content, config_path)?;
-    match command {
-        Some(command) => {
-            if !document.contains_key("hooks") {
-                document.insert("hooks", Item::Table(Table::new()));
+    if !document.contains_key("hooks") {
+        document.insert("hooks", Item::Table(Table::new()));
+    }
+    let hooks = document
+        .get_mut("hooks")
+        .and_then(Item::as_table_like_mut)
+        .ok_or_else(|| {
+            io::Error::other(format!(
+                "jcode hooks at {} must be a TOML table",
+                config_path.display()
+            ))
+        })?;
+    match hooks.get_mut("session_start") {
+        Some(entry) if entry.is_str() => {
+            let mut updated = Array::new();
+            for existing in commands {
+                updated.push(existing);
             }
-            let hooks = document
-                .get_mut("hooks")
-                .and_then(Item::as_table_like_mut)
-                .ok_or_else(|| {
-                    io::Error::other(format!(
-                        "jcode hooks at {} must be a TOML table",
-                        config_path.display()
-                    ))
-                })?;
-            hooks.insert("session_start", value(command));
+            updated.push(command);
+            *entry = value(updated);
         }
+        Some(entry) => entry
+            .as_array_mut()
+            .ok_or_else(|| invalid_jcode_session_start(config_path))?
+            .push(command),
         None => {
-            let remove_empty_hooks =
-                if let Some(hooks) = document.get_mut("hooks").and_then(Item::as_table_like_mut) {
-                    hooks.remove("session_start");
-                    hooks.is_empty()
-                } else {
-                    false
-                };
-            if remove_empty_hooks {
-                document.remove("hooks");
-            }
+            let mut commands = Array::new();
+            commands.push(command);
+            hooks.insert("session_start", value(commands));
         }
     }
     Ok(document.to_string())
+}
+
+pub(crate) fn remove_jcode_session_start_command(
+    content: &str,
+    config_path: &Path,
+    command: &str,
+) -> io::Result<String> {
+    let commands = jcode_session_start_commands(content, config_path)?;
+    if !commands.iter().any(|existing| existing == command) {
+        return Ok(content.to_string());
+    }
+
+    let mut document = parse_jcode_config(content, config_path)?;
+    let remove_empty_hooks = {
+        let hooks = document
+            .get_mut("hooks")
+            .and_then(Item::as_table_like_mut)
+            .ok_or_else(|| {
+                io::Error::other(format!(
+                    "jcode hooks at {} must be a TOML table",
+                    config_path.display()
+                ))
+            })?;
+        let remove_session_start = {
+            let entry = hooks
+                .get_mut("session_start")
+                .ok_or_else(|| invalid_jcode_session_start(config_path))?;
+            if entry.is_str() {
+                true
+            } else {
+                let commands = entry
+                    .as_array_mut()
+                    .ok_or_else(|| invalid_jcode_session_start(config_path))?;
+                commands.retain(|existing| existing.as_str() != Some(command));
+                commands.is_empty()
+            }
+        };
+        if remove_session_start {
+            hooks.remove("session_start");
+        }
+        hooks.is_empty()
+    };
+    if remove_empty_hooks {
+        document.remove("hooks");
+    }
+    Ok(document.to_string())
+}
+
+fn invalid_jcode_session_start(config_path: &Path) -> io::Error {
+    io::Error::other(format!(
+        "jcode hooks.session_start at {} must be a string or array of strings",
+        config_path.display()
+    ))
 }
 
 fn parse_jcode_config(content: &str, config_path: &Path) -> io::Result<DocumentMut> {

--- a/src/integration/env.rs
+++ b/src/integration/env.rs
@@ -19,6 +19,7 @@ pub(crate) const QODERCLI_CONFIG_DIR_ENV_VAR: &str = "QODER_CONFIG_DIR";
 pub(crate) const CURSOR_CONFIG_DIR_ENV_VAR: &str = "CURSOR_CONFIG_DIR";
 pub(crate) const ANTIGRAVITY_CLI_CONFIG_DIR_ENV_VAR: &str = "ANTIGRAVITY_CLI_CONFIG_DIR";
 pub(crate) const GROK_CONFIG_DIR_ENV_VAR: &str = "GROK_CONFIG_DIR";
+pub(crate) const JCODE_HOME_ENV_VAR: &str = "JCODE_HOME";
 /// The grok CLI's own config-home override (documented alongside
 /// `$GROK_HOME/config.toml` and `$GROK_HOME/auth.json`).
 pub(crate) const GROK_HOME_ENV_VAR: &str = "GROK_HOME";
@@ -76,6 +77,10 @@ pub(crate) fn devin_dir() -> io::Result<PathBuf> {
 
 pub(crate) fn droid_dir() -> io::Result<PathBuf> {
     Ok(home_dir()?.join(".factory"))
+}
+
+pub(crate) fn jcode_dir() -> io::Result<PathBuf> {
+    config_dir_from_env_or_home(JCODE_HOME_ENV_VAR, &[".jcode"])
 }
 
 pub(crate) fn config_dir_from_env_or_home(

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -247,7 +247,6 @@ const GROK_HOOK_CONFIG_INSTALL_NAME: &str = "herdr.json";
 const GROK_HOOK_ASSET: &str = include_str!("assets/grok/herdr-agent-state.sh");
 const GROK_INTEGRATION_VERSION: u32 = 1;
 const JCODE_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
-const JCODE_PREVIOUS_HOOK_INSTALL_NAME: &str = "herdr-session-start.previous";
 const JCODE_HOOK_ASSET: &str = include_str!("assets/jcode/herdr-agent-state.sh");
 const JCODE_INTEGRATION_VERSION: u32 = 1;
 

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -246,6 +246,10 @@ const GROK_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
 const GROK_HOOK_CONFIG_INSTALL_NAME: &str = "herdr.json";
 const GROK_HOOK_ASSET: &str = include_str!("assets/grok/herdr-agent-state.sh");
 const GROK_INTEGRATION_VERSION: u32 = 1;
+const JCODE_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
+const JCODE_PREVIOUS_HOOK_INSTALL_NAME: &str = "herdr-session-start.previous";
+const JCODE_HOOK_ASSET: &str = include_str!("assets/jcode/herdr-agent-state.sh");
+const JCODE_INTEGRATION_VERSION: u32 = 1;
 
 pub(crate) const INSTALL_WARNING_PREFIX: &str = "warning:";
 

--- a/src/integration/registry.rs
+++ b/src/integration/registry.rs
@@ -418,10 +418,12 @@ fn jcode_hook_config_is_valid(hook_path: &Path) -> bool {
     fs::read_to_string(&config_path)
         .ok()
         .and_then(|content| {
-            super::config_edit::jcode_session_start_command(&content, &config_path).ok()
+            super::config_edit::jcode_session_start_commands(&content, &config_path).ok()
         })
-        .flatten()
-        .is_some_and(|command| command == super::targets::jcode_hook_command(hook_path))
+        .is_some_and(|commands| {
+            let hook_command = super::targets::jcode_hook_command(hook_path);
+            commands.iter().any(|command| command == &hook_command)
+        })
 }
 
 pub(crate) fn integration_status_at(
@@ -462,8 +464,8 @@ pub(crate) fn integration_status_at(
         && state == super::IntegrationStatusKind::Current
         && !jcode_hook_config_is_valid(&path)
     {
-        // Jcode only invokes the adapter while its single session_start slot
-        // points at the managed hook, so a broken config is nonfunctional.
+        // Jcode only invokes the adapter while session_start includes the
+        // managed hook, so a broken config is nonfunctional.
         state = super::IntegrationStatusKind::Outdated;
     }
 

--- a/src/integration/registry.rs
+++ b/src/integration/registry.rs
@@ -462,6 +462,8 @@ pub(crate) fn integration_status_at(
         && state == super::IntegrationStatusKind::Current
         && !jcode_hook_config_is_valid(&path)
     {
+        // Jcode only invokes the adapter while its single session_start slot
+        // points at the managed hook, so a broken config is nonfunctional.
         state = super::IntegrationStatusKind::Outdated;
     }
 

--- a/src/integration/registry.rs
+++ b/src/integration/registry.rs
@@ -24,6 +24,7 @@ pub(crate) fn integration_target_label(
         crate::api::schema::IntegrationTarget::Mastracode => "mastracode",
         crate::api::schema::IntegrationTarget::AntigravityCli => "antigravity-cli",
         crate::api::schema::IntegrationTarget::Grok => "grok",
+        crate::api::schema::IntegrationTarget::Jcode => "jcode",
     }
 }
 
@@ -53,6 +54,7 @@ pub(crate) fn integration_target_command_names(
         crate::api::schema::IntegrationTarget::Mastracode => &["mastracode"],
         crate::api::schema::IntegrationTarget::AntigravityCli => &["agy"],
         crate::api::schema::IntegrationTarget::Grok => &["grok"],
+        crate::api::schema::IntegrationTarget::Jcode => &["jcode"],
     }
 }
 
@@ -262,7 +264,7 @@ fn integration_specs() -> [(
     crate::api::schema::IntegrationTarget,
     io::Result<PathBuf>,
     u32,
-); 16] {
+); 17] {
     [
         (
             crate::api::schema::IntegrationTarget::Pi,
@@ -350,6 +352,11 @@ fn integration_specs() -> [(
             grok_dir().map(|dir| dir.join("hooks").join(super::GROK_HOOK_INSTALL_NAME)),
             super::GROK_INTEGRATION_VERSION,
         ),
+        (
+            crate::api::schema::IntegrationTarget::Jcode,
+            jcode_dir().map(|dir| dir.join("hooks").join(super::JCODE_HOOK_INSTALL_NAME)),
+            super::JCODE_INTEGRATION_VERSION,
+        ),
     ]
 }
 
@@ -403,6 +410,20 @@ fn grok_hook_config_is_valid(hook_path: &Path) -> bool {
         .is_some_and(|config| config == super::targets::grok_hook_config(hook_path))
 }
 
+fn jcode_hook_config_is_valid(hook_path: &Path) -> bool {
+    let Some(jcode_dir) = hook_path.parent().and_then(Path::parent) else {
+        return false;
+    };
+    let config_path = jcode_dir.join("config.toml");
+    fs::read_to_string(&config_path)
+        .ok()
+        .and_then(|content| {
+            super::config_edit::jcode_session_start_command(&content, &config_path).ok()
+        })
+        .flatten()
+        .is_some_and(|command| command == super::targets::jcode_hook_command(hook_path))
+}
+
 pub(crate) fn integration_status_at(
     target: crate::api::schema::IntegrationTarget,
     path: PathBuf,
@@ -434,6 +455,12 @@ pub(crate) fn integration_status_at(
     if target == crate::api::schema::IntegrationTarget::Grok
         && state == super::IntegrationStatusKind::Current
         && !grok_hook_config_is_valid(&path)
+    {
+        state = super::IntegrationStatusKind::Outdated;
+    }
+    if target == crate::api::schema::IntegrationTarget::Jcode
+        && state == super::IntegrationStatusKind::Current
+        && !jcode_hook_config_is_valid(&path)
     {
         state = super::IntegrationStatusKind::Outdated;
     }

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -90,7 +90,6 @@ pub(crate) fn install_jcode() -> io::Result<JcodeInstallPaths> {
     }
 
     let hooks_dir = dir.join("hooks");
-    fs::create_dir_all(&hooks_dir)?;
     let hook_path = hooks_dir.join(JCODE_HOOK_INSTALL_NAME);
     let config_path = dir.join("config.toml");
     let existing_config = if config_path.is_file() {
@@ -102,6 +101,8 @@ pub(crate) fn install_jcode() -> io::Result<JcodeInstallPaths> {
     let updated_config =
         append_jcode_session_start_command(&existing_config, &config_path, &command)?;
 
+    // Validate the user's config before creating any managed filesystem state.
+    fs::create_dir_all(&hooks_dir)?;
     fs::write(&hook_path, JCODE_HOOK_ASSET)?;
     make_executable(&hook_path)?;
     if updated_config != existing_config {

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -105,7 +105,7 @@ pub(crate) fn install_jcode() -> io::Result<JcodeInstallPaths> {
 
     if current.as_deref() != Some(command.as_str()) {
         match current.as_deref().filter(|value| !value.trim().is_empty()) {
-            Some(previous) => fs::write(&previous_hook_path, previous)?,
+            Some(previous) => write_jcode_previous_hook(&previous_hook_path, previous)?,
             None => {
                 remove_file_if_exists(&previous_hook_path)?;
             }
@@ -1387,7 +1387,7 @@ pub(crate) fn uninstall_jcode() -> io::Result<JcodeUninstallResult> {
             == Some(command.as_str())
         {
             let previous = match fs::read_to_string(&previous_hook_path) {
-                Ok(previous) if !previous.trim().is_empty() => Some(previous),
+                Ok(previous) if !previous.trim().is_empty() => Some(previous.trim().to_string()),
                 Ok(_) => None,
                 Err(err) if err.kind() == io::ErrorKind::NotFound => None,
                 Err(err) => return Err(err),
@@ -1412,4 +1412,14 @@ pub(crate) fn uninstall_jcode() -> io::Result<JcodeUninstallResult> {
         removed_hook_file,
         updated_config,
     })
+}
+
+fn write_jcode_previous_hook(path: &Path, command: &str) -> io::Result<()> {
+    fs::write(path, command)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
 }

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -12,13 +12,14 @@ use super::config_edit::{
     build_codex_config_with_hooks, build_kimi_config_with_hooks, ensure_command_hook,
     ensure_direct_command_hook, ensure_flat_command_hook, ensure_hermes_plugin_enabled,
     ensure_hooks_object, ensure_simple_command_hook, hooks_object_if_present,
-    remove_direct_hook_commands, remove_flat_command_hook, remove_hermes_plugin_enabled,
-    remove_hook_commands, remove_kimi_config_block, remove_simple_command_hook,
+    jcode_session_start_command, remove_direct_hook_commands, remove_flat_command_hook,
+    remove_hermes_plugin_enabled, remove_hook_commands, remove_kimi_config_block,
+    remove_simple_command_hook, set_jcode_session_start_command,
 };
 use super::env::{
     antigravity_cli_dir, claude_dir, codex_dir, copilot_dir, cursor_dir, devin_dir, droid_dir,
-    grok_dir, hermes_dir, hermes_plugin_dir, kilo_dir, kimi_dir, mastracode_dir, omp_extension_dir,
-    opencode_dir, pi_extension_dir, qodercli_dir,
+    grok_dir, hermes_dir, hermes_plugin_dir, jcode_dir, kilo_dir, kimi_dir, mastracode_dir,
+    omp_extension_dir, opencode_dir, pi_extension_dir, qodercli_dir,
 };
 use super::file_ops::{
     make_executable, remove_dir_all_if_exists, remove_file_if_exists, remove_legacy_bash_hook_file,
@@ -28,10 +29,11 @@ use super::types::{
     ClaudeUninstallResult, CodexInstallPaths, CodexUninstallResult, CopilotInstallPaths,
     CopilotUninstallResult, CursorInstallPaths, CursorUninstallResult, DevinInstallPaths,
     DevinUninstallResult, DroidInstallPaths, DroidUninstallResult, GrokInstallPaths,
-    GrokUninstallResult, HermesInstallPaths, HermesUninstallResult, KiloInstallPaths,
-    KiloUninstallResult, KimiInstallPaths, KimiUninstallResult, MastracodeInstallPaths,
-    MastracodeUninstallResult, OmpInstallPaths, OmpUninstallResult, OpenCodeInstallPaths,
-    OpenCodeUninstallResult, PiUninstallResult, QodercliInstallPaths, QodercliUninstallResult,
+    GrokUninstallResult, HermesInstallPaths, HermesUninstallResult, JcodeInstallPaths,
+    JcodeUninstallResult, KiloInstallPaths, KiloUninstallResult, KimiInstallPaths,
+    KimiUninstallResult, MastracodeInstallPaths, MastracodeUninstallResult, OmpInstallPaths,
+    OmpUninstallResult, OpenCodeInstallPaths, OpenCodeUninstallResult, PiUninstallResult,
+    QodercliInstallPaths, QodercliUninstallResult,
 };
 use super::{
     ANTIGRAVITY_CLI_HOOK_ASSET, ANTIGRAVITY_CLI_HOOK_BLOCK_NAME, ANTIGRAVITY_CLI_HOOK_EVENTS,
@@ -43,8 +45,9 @@ use super::{
     DROID_HOOK_EVENTS, DROID_HOOK_INSTALL_NAME, DROID_REMOVED_LIFECYCLE_HOOK_EVENTS,
     GROK_HOOK_ASSET, GROK_HOOK_CONFIG_INSTALL_NAME, GROK_HOOK_INSTALL_NAME,
     HERMES_PLUGIN_INIT_ASSET, HERMES_PLUGIN_INIT_INSTALL_NAME, HERMES_PLUGIN_MANIFEST_ASSET,
-    HERMES_PLUGIN_MANIFEST_INSTALL_NAME, KILO_PLUGIN_ASSET, KILO_PLUGIN_INSTALL_NAME,
-    KIMI_HOOK_ASSET, KIMI_HOOK_INSTALL_NAME, MASTRACODE_HOOK_ASSET, MASTRACODE_HOOK_EVENTS,
+    HERMES_PLUGIN_MANIFEST_INSTALL_NAME, JCODE_HOOK_ASSET, JCODE_HOOK_INSTALL_NAME,
+    JCODE_PREVIOUS_HOOK_INSTALL_NAME, KILO_PLUGIN_ASSET, KILO_PLUGIN_INSTALL_NAME, KIMI_HOOK_ASSET,
+    KIMI_HOOK_INSTALL_NAME, MASTRACODE_HOOK_ASSET, MASTRACODE_HOOK_EVENTS,
     MASTRACODE_HOOK_INSTALL_NAME, MASTRACODE_HOOK_TIMEOUT_MS, MASTRACODE_REMOVED_HOOK_EVENTS,
     OMP_EXTENSION_ASSET, OMP_EXTENSION_INSTALL_NAME, OPENCODE_PLUGIN_ASSET,
     OPENCODE_PLUGIN_INSTALL_NAME, PI_EXTENSION_ASSET, PI_EXTENSION_INSTALL_NAME,
@@ -72,6 +75,55 @@ pub(crate) fn install_pi() -> io::Result<PathBuf> {
     let path = dir.join(PI_EXTENSION_INSTALL_NAME);
     fs::write(&path, PI_EXTENSION_ASSET)?;
     Ok(path)
+}
+
+pub(crate) fn jcode_hook_command(hook_path: &Path) -> String {
+    hook_command(hook_path, None)
+}
+
+pub(crate) fn install_jcode() -> io::Result<JcodeInstallPaths> {
+    let dir = jcode_dir()?;
+    if !dir.is_dir() {
+        return Err(io::Error::other(format!(
+            "jcode config directory not found at {}. install jcode first",
+            dir.display()
+        )));
+    }
+
+    let hooks_dir = dir.join("hooks");
+    fs::create_dir_all(&hooks_dir)?;
+    let hook_path = hooks_dir.join(JCODE_HOOK_INSTALL_NAME);
+    let previous_hook_path = hooks_dir.join(JCODE_PREVIOUS_HOOK_INSTALL_NAME);
+    let config_path = dir.join("config.toml");
+    let existing_config = if config_path.is_file() {
+        fs::read_to_string(&config_path)?
+    } else {
+        String::new()
+    };
+    let command = jcode_hook_command(&hook_path);
+    let current = jcode_session_start_command(&existing_config, &config_path)?;
+
+    if current.as_deref() != Some(command.as_str()) {
+        match current.as_deref().filter(|value| !value.trim().is_empty()) {
+            Some(previous) => fs::write(&previous_hook_path, previous)?,
+            None => {
+                remove_file_if_exists(&previous_hook_path)?;
+            }
+        }
+    }
+
+    fs::write(&hook_path, JCODE_HOOK_ASSET)?;
+    make_executable(&hook_path)?;
+    let updated_config =
+        set_jcode_session_start_command(&existing_config, &config_path, Some(&command))?;
+    if updated_config != existing_config {
+        fs::write(&config_path, updated_config)?;
+    }
+
+    Ok(JcodeInstallPaths {
+        hook_path,
+        config_path,
+    })
 }
 
 pub(crate) fn install_omp() -> io::Result<OmpInstallPaths> {
@@ -1317,5 +1369,47 @@ pub(crate) fn uninstall_grok() -> io::Result<GrokUninstallResult> {
         config_path,
         removed_hook_file,
         removed_config_file,
+    })
+}
+
+pub(crate) fn uninstall_jcode() -> io::Result<JcodeUninstallResult> {
+    let dir = jcode_dir()?;
+    let hooks_dir = dir.join("hooks");
+    let hook_path = hooks_dir.join(JCODE_HOOK_INSTALL_NAME);
+    let previous_hook_path = hooks_dir.join(JCODE_PREVIOUS_HOOK_INSTALL_NAME);
+    let config_path = dir.join("config.toml");
+    let mut updated_config = false;
+
+    if config_path.is_file() {
+        let existing_config = fs::read_to_string(&config_path)?;
+        let command = jcode_hook_command(&hook_path);
+        if jcode_session_start_command(&existing_config, &config_path)?.as_deref()
+            == Some(command.as_str())
+        {
+            let previous = match fs::read_to_string(&previous_hook_path) {
+                Ok(previous) if !previous.trim().is_empty() => Some(previous),
+                Ok(_) => None,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => None,
+                Err(err) => return Err(err),
+            };
+            let new_config = set_jcode_session_start_command(
+                &existing_config,
+                &config_path,
+                previous.as_deref(),
+            )?;
+            if new_config != existing_config {
+                fs::write(&config_path, new_config)?;
+                updated_config = true;
+            }
+        }
+    }
+
+    remove_file_if_exists(&previous_hook_path)?;
+    let removed_hook_file = remove_file_if_exists(&hook_path)?;
+    Ok(JcodeUninstallResult {
+        hook_path,
+        config_path,
+        removed_hook_file,
+        updated_config,
     })
 }

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -9,12 +9,12 @@ use super::claude_settings::{
 };
 use super::command::{hook_command, shell_single_quote};
 use super::config_edit::{
-    build_codex_config_with_hooks, build_kimi_config_with_hooks, ensure_command_hook,
-    ensure_direct_command_hook, ensure_flat_command_hook, ensure_hermes_plugin_enabled,
-    ensure_hooks_object, ensure_simple_command_hook, hooks_object_if_present,
-    jcode_session_start_command, remove_direct_hook_commands, remove_flat_command_hook,
-    remove_hermes_plugin_enabled, remove_hook_commands, remove_kimi_config_block,
-    remove_simple_command_hook, set_jcode_session_start_command,
+    append_jcode_session_start_command, build_codex_config_with_hooks,
+    build_kimi_config_with_hooks, ensure_command_hook, ensure_direct_command_hook,
+    ensure_flat_command_hook, ensure_hermes_plugin_enabled, ensure_hooks_object,
+    ensure_simple_command_hook, hooks_object_if_present, remove_direct_hook_commands,
+    remove_flat_command_hook, remove_hermes_plugin_enabled, remove_hook_commands,
+    remove_jcode_session_start_command, remove_kimi_config_block, remove_simple_command_hook,
 };
 use super::env::{
     antigravity_cli_dir, claude_dir, codex_dir, copilot_dir, cursor_dir, devin_dir, droid_dir,
@@ -46,13 +46,12 @@ use super::{
     GROK_HOOK_ASSET, GROK_HOOK_CONFIG_INSTALL_NAME, GROK_HOOK_INSTALL_NAME,
     HERMES_PLUGIN_INIT_ASSET, HERMES_PLUGIN_INIT_INSTALL_NAME, HERMES_PLUGIN_MANIFEST_ASSET,
     HERMES_PLUGIN_MANIFEST_INSTALL_NAME, JCODE_HOOK_ASSET, JCODE_HOOK_INSTALL_NAME,
-    JCODE_PREVIOUS_HOOK_INSTALL_NAME, KILO_PLUGIN_ASSET, KILO_PLUGIN_INSTALL_NAME, KIMI_HOOK_ASSET,
-    KIMI_HOOK_INSTALL_NAME, MASTRACODE_HOOK_ASSET, MASTRACODE_HOOK_EVENTS,
-    MASTRACODE_HOOK_INSTALL_NAME, MASTRACODE_HOOK_TIMEOUT_MS, MASTRACODE_REMOVED_HOOK_EVENTS,
-    OMP_EXTENSION_ASSET, OMP_EXTENSION_INSTALL_NAME, OPENCODE_PLUGIN_ASSET,
-    OPENCODE_PLUGIN_INSTALL_NAME, PI_EXTENSION_ASSET, PI_EXTENSION_INSTALL_NAME,
-    QODERCLI_HOOK_ASSET, QODERCLI_HOOK_EVENTS, QODERCLI_HOOK_INSTALL_NAME,
-    QODERCLI_REMOVED_LIFECYCLE_HOOK_EVENTS,
+    KILO_PLUGIN_ASSET, KILO_PLUGIN_INSTALL_NAME, KIMI_HOOK_ASSET, KIMI_HOOK_INSTALL_NAME,
+    MASTRACODE_HOOK_ASSET, MASTRACODE_HOOK_EVENTS, MASTRACODE_HOOK_INSTALL_NAME,
+    MASTRACODE_HOOK_TIMEOUT_MS, MASTRACODE_REMOVED_HOOK_EVENTS, OMP_EXTENSION_ASSET,
+    OMP_EXTENSION_INSTALL_NAME, OPENCODE_PLUGIN_ASSET, OPENCODE_PLUGIN_INSTALL_NAME,
+    PI_EXTENSION_ASSET, PI_EXTENSION_INSTALL_NAME, QODERCLI_HOOK_ASSET, QODERCLI_HOOK_EVENTS,
+    QODERCLI_HOOK_INSTALL_NAME, QODERCLI_REMOVED_LIFECYCLE_HOOK_EVENTS,
 };
 
 fn ensure_extension_dir(dir: &Path, agent: &str) -> io::Result<()> {
@@ -93,7 +92,6 @@ pub(crate) fn install_jcode() -> io::Result<JcodeInstallPaths> {
     let hooks_dir = dir.join("hooks");
     fs::create_dir_all(&hooks_dir)?;
     let hook_path = hooks_dir.join(JCODE_HOOK_INSTALL_NAME);
-    let previous_hook_path = hooks_dir.join(JCODE_PREVIOUS_HOOK_INSTALL_NAME);
     let config_path = dir.join("config.toml");
     let existing_config = if config_path.is_file() {
         fs::read_to_string(&config_path)?
@@ -101,21 +99,11 @@ pub(crate) fn install_jcode() -> io::Result<JcodeInstallPaths> {
         String::new()
     };
     let command = jcode_hook_command(&hook_path);
-    let current = jcode_session_start_command(&existing_config, &config_path)?;
-
-    if current.as_deref() != Some(command.as_str()) {
-        match current.as_deref().filter(|value| !value.trim().is_empty()) {
-            Some(previous) => write_jcode_previous_hook(&previous_hook_path, previous)?,
-            None => {
-                remove_file_if_exists(&previous_hook_path)?;
-            }
-        }
-    }
+    let updated_config =
+        append_jcode_session_start_command(&existing_config, &config_path, &command)?;
 
     fs::write(&hook_path, JCODE_HOOK_ASSET)?;
     make_executable(&hook_path)?;
-    let updated_config =
-        set_jcode_session_start_command(&existing_config, &config_path, Some(&command))?;
     if updated_config != existing_config {
         fs::write(&config_path, updated_config)?;
     }
@@ -1376,35 +1364,20 @@ pub(crate) fn uninstall_jcode() -> io::Result<JcodeUninstallResult> {
     let dir = jcode_dir()?;
     let hooks_dir = dir.join("hooks");
     let hook_path = hooks_dir.join(JCODE_HOOK_INSTALL_NAME);
-    let previous_hook_path = hooks_dir.join(JCODE_PREVIOUS_HOOK_INSTALL_NAME);
     let config_path = dir.join("config.toml");
     let mut updated_config = false;
 
     if config_path.is_file() {
         let existing_config = fs::read_to_string(&config_path)?;
         let command = jcode_hook_command(&hook_path);
-        if jcode_session_start_command(&existing_config, &config_path)?.as_deref()
-            == Some(command.as_str())
-        {
-            let previous = match fs::read_to_string(&previous_hook_path) {
-                Ok(previous) if !previous.trim().is_empty() => Some(previous.trim().to_string()),
-                Ok(_) => None,
-                Err(err) if err.kind() == io::ErrorKind::NotFound => None,
-                Err(err) => return Err(err),
-            };
-            let new_config = set_jcode_session_start_command(
-                &existing_config,
-                &config_path,
-                previous.as_deref(),
-            )?;
-            if new_config != existing_config {
-                fs::write(&config_path, new_config)?;
-                updated_config = true;
-            }
+        let new_config =
+            remove_jcode_session_start_command(&existing_config, &config_path, &command)?;
+        if new_config != existing_config {
+            fs::write(&config_path, new_config)?;
+            updated_config = true;
         }
     }
 
-    remove_file_if_exists(&previous_hook_path)?;
     let removed_hook_file = remove_file_if_exists(&hook_path)?;
     Ok(JcodeUninstallResult {
         hook_path,
@@ -1412,14 +1385,4 @@ pub(crate) fn uninstall_jcode() -> io::Result<JcodeUninstallResult> {
         removed_hook_file,
         updated_config,
     })
-}
-
-fn write_jcode_previous_hook(path: &Path, command: &str) -> io::Result<()> {
-    fs::write(path, command)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-    }
-    Ok(())
 }

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -4146,7 +4146,7 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
         .status()
         .unwrap();
     assert!(status.success());
-    for _ in 0..100 {
+    for _ in 0..500 {
         if previous_output.is_file() {
             break;
         }
@@ -4161,8 +4161,22 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
     let socket_path = PathBuf::from(format!("/tmp/herdr-jcode-{}.sock", std::process::id()));
     let _ = fs::remove_file(&socket_path);
     let listener = UnixListener::bind(&socket_path).unwrap();
+    listener.set_nonblocking(true).unwrap();
     let server = std::thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut stream = loop {
+            match listener.accept() {
+                Ok((stream, _)) => break stream,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "jcode hook did not connect to the Herdr socket within 5 seconds"
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(error) => panic!("failed to accept Jcode hook connection: {error}"),
+            }
+        };
         let mut line = String::new();
         std::io::BufReader::new(stream.try_clone().unwrap())
             .read_line(&mut line)
@@ -4192,7 +4206,7 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
     assert_eq!(request["params"]["agent_session_id"], "jcode-session-123");
     assert_eq!(request["params"]["session_start_source"], "resume");
 
-    for _ in 0..100 {
+    for _ in 0..500 {
         if previous_output.is_file() {
             break;
         }

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -4154,7 +4154,9 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
         .unwrap();
     assert!(status.success());
     for _ in 0..500 {
-        if previous_output.is_file() {
+        if fs::read_to_string(&previous_output)
+            .is_ok_and(|content| content == "forwarded:without-python")
+        {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -4214,7 +4216,9 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
     assert_eq!(request["params"]["session_start_source"], "resume");
 
     for _ in 0..500 {
-        if previous_output.is_file() {
+        if fs::read_to_string(&previous_output)
+            .is_ok_and(|content| content == "forwarded:jcode-session-123")
+        {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(10));

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -2652,6 +2652,7 @@ fn bundled_integration_asset_versions_match_expected_versions() {
             MASTRACODE_HOOK_ASSET,
             MASTRACODE_INTEGRATION_VERSION,
         ),
+        ("jcode", JCODE_HOOK_ASSET, JCODE_INTEGRATION_VERSION),
     ] {
         assert_eq!(
             parse_integration_version(asset),
@@ -2781,6 +2782,12 @@ fn bundled_integration_assets_report_session_refs() {
     assert!(GROK_HOOK_ASSET.contains("herdr:grok"));
     assert!(!GROK_HOOK_ASSET.contains("\"state\":"));
     assert!(!GROK_HOOK_ASSET.contains("pane.release_agent"));
+    assert!(JCODE_HOOK_ASSET.contains("HERDR_INTEGRATION_ID=jcode"));
+    assert!(JCODE_HOOK_ASSET.contains("JCODE_HOOK_SESSION_ID"));
+    assert!(JCODE_HOOK_ASSET.contains("pane.report_agent_session"));
+    assert!(JCODE_HOOK_ASSET.contains("herdr:jcode"));
+    assert!(!JCODE_HOOK_ASSET.contains("pane.report_agent\""));
+    assert!(!JCODE_HOOK_ASSET.contains("pane.release_agent"));
 }
 
 #[test]
@@ -3968,5 +3975,184 @@ fn grok_dir_honors_grok_home_after_config_dir_seam() {
 
     std::env::remove_var(GROK_HOME_ENV_VAR);
     clear_integration_path_env();
+    let _ = fs::remove_dir_all(base);
+}
+
+#[cfg(unix)]
+#[test]
+fn install_and_uninstall_jcode_preserve_existing_session_hook() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let jcode = home.join(".jcode");
+    fs::create_dir_all(&jcode).unwrap();
+    let config_path = jcode.join("config.toml");
+    let previous = "~/bin/session-observer --label 'user hook'";
+    fs::write(
+        &config_path,
+        format!(
+            "# keep this comment\n[display]\nemoji = false\n\n[hooks]\nturn_end = \"notify\"\nsession_start = {}\n",
+            toml_basic_string(previous)
+        ),
+    )
+    .unwrap();
+    std::env::set_var("HOME", &home);
+
+    let installed = install_jcode().unwrap();
+    let installed_config = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(
+        jcode_session_start_command(&installed_config, &config_path)
+            .unwrap()
+            .as_deref(),
+        Some(jcode_hook_command(&installed.hook_path).as_str())
+    );
+    assert!(installed_config.contains("# keep this comment"));
+    assert!(installed_config.contains("turn_end = \"notify\""));
+    let previous_path = jcode.join("hooks").join(JCODE_PREVIOUS_HOOK_INSTALL_NAME);
+    assert_eq!(fs::read_to_string(&previous_path).unwrap(), previous);
+
+    // Reinstalling must not replace the saved user command with Herdr's own
+    // wrapper command.
+    install_jcode().unwrap();
+    assert_eq!(fs::read_to_string(&previous_path).unwrap(), previous);
+    assert_eq!(
+        integration_status_at(
+            crate::api::schema::IntegrationTarget::Jcode,
+            installed.hook_path.clone(),
+            JCODE_INTEGRATION_VERSION,
+        )
+        .state,
+        IntegrationStatusKind::Current
+    );
+
+    let result = uninstall_jcode().unwrap();
+    assert!(result.removed_hook_file);
+    assert!(result.updated_config);
+    assert!(!previous_path.exists());
+    let restored_config = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(
+        jcode_session_start_command(&restored_config, &config_path)
+            .unwrap()
+            .as_deref(),
+        Some(previous)
+    );
+    assert!(restored_config.contains("# keep this comment"));
+    assert!(restored_config.contains("turn_end = \"notify\""));
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[cfg(unix)]
+#[test]
+fn uninstall_jcode_does_not_clobber_a_user_replacement_hook() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let jcode = home.join(".jcode");
+    fs::create_dir_all(&jcode).unwrap();
+    let config_path = jcode.join("config.toml");
+    fs::write(&config_path, "[hooks]\nsession_start = \"first\"\n").unwrap();
+    std::env::set_var("HOME", &home);
+
+    install_jcode().unwrap();
+    let current = fs::read_to_string(&config_path).unwrap();
+    let replacement =
+        set_jcode_session_start_command(&current, &config_path, Some("second")).unwrap();
+    fs::write(&config_path, replacement).unwrap();
+
+    let result = uninstall_jcode().unwrap();
+    assert!(!result.updated_config);
+    let remaining = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(
+        jcode_session_start_command(&remaining, &config_path)
+            .unwrap()
+            .as_deref(),
+        Some("second")
+    );
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[cfg(unix)]
+#[test]
+fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
+    use std::io::{BufRead, Write};
+    use std::os::unix::net::UnixListener;
+
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let jcode = home.join(".jcode");
+    fs::create_dir_all(&jcode).unwrap();
+    let previous_script = base.join("previous.sh");
+    let previous_output = base.join("previous.out");
+    fs::write(
+        &previous_script,
+        "#!/bin/sh\nprintf '%s' \"$JCODE_HOOK_SESSION_ID\" >\"$1\"\n",
+    )
+    .unwrap();
+    let previous_command = format!(
+        "sh {} {}",
+        shell_single_quote(&previous_script.display().to_string()),
+        shell_single_quote(&previous_output.display().to_string())
+    );
+    fs::write(
+        jcode.join("config.toml"),
+        format!(
+            "[hooks]\nsession_start = {}\n",
+            toml_basic_string(&previous_command)
+        ),
+    )
+    .unwrap();
+    std::env::set_var("HOME", &home);
+    let installed = install_jcode().unwrap();
+
+    let socket_path = base.join("herdr.sock");
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut line = String::new();
+        std::io::BufReader::new(stream.try_clone().unwrap())
+            .read_line(&mut line)
+            .unwrap();
+        stream
+            .write_all(b"{\"id\":\"ok\",\"result\":{}}\n")
+            .unwrap();
+        serde_json::from_str::<Value>(&line).unwrap()
+    });
+
+    let status = std::process::Command::new("bash")
+        .arg(&installed.hook_path)
+        .env("HERDR_ENV", "1")
+        .env("HERDR_PANE_ID", "w1:p2")
+        .env("HERDR_SOCKET_PATH", &socket_path)
+        .env("JCODE_HOOK_SESSION_ID", "jcode-session-123")
+        .env("JCODE_HOOK_SOURCE", "resume")
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let request = server.join().unwrap();
+    assert_eq!(request["method"], "pane.report_agent_session");
+    assert_eq!(request["params"]["source"], "herdr:jcode");
+    assert_eq!(request["params"]["agent"], "jcode");
+    assert_eq!(request["params"]["pane_id"], "w1:p2");
+    assert_eq!(request["params"]["agent_session_id"], "jcode-session-123");
+    assert_eq!(request["params"]["session_start_source"], "resume");
+
+    for _ in 0..100 {
+        if previous_output.is_file() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert_eq!(
+        fs::read_to_string(&previous_output).unwrap(),
+        "jcode-session-123"
+    );
+
+    std::env::remove_var("HOME");
     let _ = fs::remove_dir_all(base);
 }

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -4010,6 +4010,14 @@ fn install_and_uninstall_jcode_preserve_existing_session_hook() {
     assert!(installed_config.contains("turn_end = \"notify\""));
     let previous_path = jcode.join("hooks").join(JCODE_PREVIOUS_HOOK_INSTALL_NAME);
     assert_eq!(fs::read_to_string(&previous_path).unwrap(), previous);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            fs::metadata(&previous_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
 
     // Reinstalling must not replace the saved user command with Herdr's own
     // wrapper command.
@@ -4075,6 +4083,28 @@ fn uninstall_jcode_does_not_clobber_a_user_replacement_hook() {
     let _ = fs::remove_dir_all(base);
 }
 
+#[test]
+fn install_jcode_rejects_non_string_session_hook_without_overwriting_it() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let jcode = home.join(".jcode");
+    fs::create_dir_all(&jcode).unwrap();
+    let config_path = jcode.join("config.toml");
+    fs::write(&config_path, "[hooks]\nsession_start = [\"first\"]\n").unwrap();
+    std::env::set_var("HOME", &home);
+
+    let error = install_jcode().unwrap_err();
+    assert!(error.to_string().contains("must be a string"));
+    assert_eq!(
+        fs::read_to_string(&config_path).unwrap(),
+        "[hooks]\nsession_start = [\"first\"]\n"
+    );
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
 #[cfg(unix)]
 #[test]
 fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
@@ -4086,16 +4116,9 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
     let home = base.join("home");
     let jcode = home.join(".jcode");
     fs::create_dir_all(&jcode).unwrap();
-    let previous_script = base.join("previous.sh");
     let previous_output = base.join("previous.out");
-    fs::write(
-        &previous_script,
-        "#!/bin/sh\nprintf '%s' \"$JCODE_HOOK_SESSION_ID\" >\"$1\"\n",
-    )
-    .unwrap();
     let previous_command = format!(
-        "sh {} {}",
-        shell_single_quote(&previous_script.display().to_string()),
+        "JCODE_FORWARD_PREFIX=forwarded; printf '%s:%s' \"$JCODE_FORWARD_PREFIX\" \"$JCODE_HOOK_SESSION_ID\" | /bin/cat > {}",
         shell_single_quote(&previous_output.display().to_string())
     );
     fs::write(
@@ -4109,7 +4132,34 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
     std::env::set_var("HOME", &home);
     let installed = install_jcode().unwrap();
 
-    let socket_path = base.join("herdr.sock");
+    // A missing Python runtime must disable only Herdr reporting, never the
+    // observer that occupied Jcode's session_start slot before installation.
+    let no_python_path = base.join("no-python-bin");
+    fs::create_dir_all(&no_python_path).unwrap();
+    std::os::unix::fs::symlink("/bin/sh", no_python_path.join("sh")).unwrap();
+    std::os::unix::fs::symlink("/bin/cat", no_python_path.join("cat")).unwrap();
+    std::os::unix::fs::symlink("/usr/bin/dirname", no_python_path.join("dirname")).unwrap();
+    let status = std::process::Command::new("/bin/sh")
+        .arg(&installed.hook_path)
+        .env("PATH", &no_python_path)
+        .env("JCODE_HOOK_SESSION_ID", "without-python")
+        .status()
+        .unwrap();
+    assert!(status.success());
+    for _ in 0..100 {
+        if previous_output.is_file() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert_eq!(
+        fs::read_to_string(&previous_output).unwrap(),
+        "forwarded:without-python"
+    );
+    fs::remove_file(&previous_output).unwrap();
+
+    let socket_path = PathBuf::from(format!("/tmp/herdr-jcode-{}.sock", std::process::id()));
+    let _ = fs::remove_file(&socket_path);
     let listener = UnixListener::bind(&socket_path).unwrap();
     let server = std::thread::spawn(move || {
         let (mut stream, _) = listener.accept().unwrap();
@@ -4150,9 +4200,10 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
     }
     assert_eq!(
         fs::read_to_string(&previous_output).unwrap(),
-        "jcode-session-123"
+        "forwarded:jcode-session-123"
     );
 
+    let _ = fs::remove_file(&socket_path);
     std::env::remove_var("HOME");
     let _ = fs::remove_dir_all(base);
 }

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -4136,10 +4136,17 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
     // observer that occupied Jcode's session_start slot before installation.
     let no_python_path = base.join("no-python-bin");
     fs::create_dir_all(&no_python_path).unwrap();
-    std::os::unix::fs::symlink("/bin/sh", no_python_path.join("sh")).unwrap();
-    std::os::unix::fs::symlink("/bin/cat", no_python_path.join("cat")).unwrap();
-    std::os::unix::fs::symlink("/usr/bin/dirname", no_python_path.join("dirname")).unwrap();
-    let status = std::process::Command::new("/bin/sh")
+    let find_on_path = |command: &str| {
+        std::env::split_paths(&std::env::var_os("PATH").expect("PATH should be set"))
+            .map(|directory| directory.join(command))
+            .find(|candidate| candidate.is_file())
+            .unwrap_or_else(|| panic!("{command} should be available on PATH"))
+    };
+    let shell = find_on_path("sh");
+    std::os::unix::fs::symlink(&shell, no_python_path.join("sh")).unwrap();
+    std::os::unix::fs::symlink(find_on_path("cat"), no_python_path.join("cat")).unwrap();
+    std::os::unix::fs::symlink(find_on_path("dirname"), no_python_path.join("dirname")).unwrap();
+    let status = std::process::Command::new(shell)
         .arg(&installed.hook_path)
         .env("PATH", &no_python_path)
         .env("JCODE_HOOK_SESSION_ID", "without-python")

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -4001,28 +4001,25 @@ fn install_and_uninstall_jcode_preserve_existing_session_hook() {
     let installed = install_jcode().unwrap();
     let installed_config = fs::read_to_string(&config_path).unwrap();
     assert_eq!(
-        jcode_session_start_command(&installed_config, &config_path)
-            .unwrap()
-            .as_deref(),
-        Some(jcode_hook_command(&installed.hook_path).as_str())
+        jcode_session_start_commands(&installed_config, &config_path).unwrap(),
+        vec![
+            previous.to_string(),
+            jcode_hook_command(&installed.hook_path)
+        ]
     );
     assert!(installed_config.contains("# keep this comment"));
     assert!(installed_config.contains("turn_end = \"notify\""));
-    let previous_path = jcode.join("hooks").join(JCODE_PREVIOUS_HOOK_INSTALL_NAME);
-    assert_eq!(fs::read_to_string(&previous_path).unwrap(), previous);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        assert_eq!(
-            fs::metadata(&previous_path).unwrap().permissions().mode() & 0o777,
-            0o600
-        );
-    }
 
-    // Reinstalling must not replace the saved user command with Herdr's own
-    // wrapper command.
+    // Reinstalling must not duplicate Herdr's command or disturb user commands.
     install_jcode().unwrap();
-    assert_eq!(fs::read_to_string(&previous_path).unwrap(), previous);
+    let reinstalled_config = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(
+        jcode_session_start_commands(&reinstalled_config, &config_path).unwrap(),
+        vec![
+            previous.to_string(),
+            jcode_hook_command(&installed.hook_path)
+        ]
+    );
     assert_eq!(
         integration_status_at(
             crate::api::schema::IntegrationTarget::Jcode,
@@ -4036,16 +4033,54 @@ fn install_and_uninstall_jcode_preserve_existing_session_hook() {
     let result = uninstall_jcode().unwrap();
     assert!(result.removed_hook_file);
     assert!(result.updated_config);
-    assert!(!previous_path.exists());
     let restored_config = fs::read_to_string(&config_path).unwrap();
     assert_eq!(
-        jcode_session_start_command(&restored_config, &config_path)
-            .unwrap()
-            .as_deref(),
-        Some(previous)
+        jcode_session_start_commands(&restored_config, &config_path).unwrap(),
+        vec![previous.to_string()]
     );
     assert!(restored_config.contains("# keep this comment"));
     assert!(restored_config.contains("turn_end = \"notify\""));
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[cfg(unix)]
+#[test]
+fn install_and_uninstall_jcode_preserve_existing_session_hook_array() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let jcode = home.join(".jcode");
+    fs::create_dir_all(&jcode).unwrap();
+    let config_path = jcode.join("config.toml");
+    fs::write(
+        &config_path,
+        "[hooks]\nsession_start = [\"first\", \"second\"]\nturn_end = \"notify\"\n",
+    )
+    .unwrap();
+    std::env::set_var("HOME", &home);
+
+    let installed = install_jcode().unwrap();
+    install_jcode().unwrap();
+    let installed_config = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(
+        jcode_session_start_commands(&installed_config, &config_path).unwrap(),
+        vec![
+            "first".to_string(),
+            "second".to_string(),
+            jcode_hook_command(&installed.hook_path),
+        ]
+    );
+
+    let result = uninstall_jcode().unwrap();
+    assert!(result.updated_config);
+    let remaining_config = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(
+        jcode_session_start_commands(&remaining_config, &config_path).unwrap(),
+        vec!["first".to_string(), "second".to_string()]
+    );
+    assert!(remaining_config.contains("turn_end = \"notify\""));
 
     std::env::remove_var("HOME");
     let _ = fs::remove_dir_all(base);
@@ -4064,19 +4099,18 @@ fn uninstall_jcode_does_not_clobber_a_user_replacement_hook() {
     std::env::set_var("HOME", &home);
 
     install_jcode().unwrap();
-    let current = fs::read_to_string(&config_path).unwrap();
-    let replacement =
-        set_jcode_session_start_command(&current, &config_path, Some("second")).unwrap();
-    fs::write(&config_path, replacement).unwrap();
+    fs::write(
+        &config_path,
+        "[hooks]\nsession_start = [\"first\", \"second\"]\n",
+    )
+    .unwrap();
 
     let result = uninstall_jcode().unwrap();
     assert!(!result.updated_config);
     let remaining = fs::read_to_string(&config_path).unwrap();
     assert_eq!(
-        jcode_session_start_command(&remaining, &config_path)
-            .unwrap()
-            .as_deref(),
-        Some("second")
+        jcode_session_start_commands(&remaining, &config_path).unwrap(),
+        vec!["first".to_string(), "second".to_string()]
     );
 
     std::env::remove_var("HOME");
@@ -4084,21 +4118,23 @@ fn uninstall_jcode_does_not_clobber_a_user_replacement_hook() {
 }
 
 #[test]
-fn install_jcode_rejects_non_string_session_hook_without_overwriting_it() {
+fn install_jcode_rejects_session_hook_arrays_with_non_string_values() {
     let _lock = integration_env_lock();
     let base = unique_base();
     let home = base.join("home");
     let jcode = home.join(".jcode");
     fs::create_dir_all(&jcode).unwrap();
     let config_path = jcode.join("config.toml");
-    fs::write(&config_path, "[hooks]\nsession_start = [\"first\"]\n").unwrap();
+    fs::write(&config_path, "[hooks]\nsession_start = [\"first\", 42]\n").unwrap();
     std::env::set_var("HOME", &home);
 
     let error = install_jcode().unwrap_err();
-    assert!(error.to_string().contains("must be a string"));
+    assert!(error
+        .to_string()
+        .contains("must be a string or array of strings"));
     assert_eq!(
         fs::read_to_string(&config_path).unwrap(),
-        "[hooks]\nsession_start = [\"first\"]\n"
+        "[hooks]\nsession_start = [\"first\", 42]\n"
     );
 
     std::env::remove_var("HOME");
@@ -4107,7 +4143,7 @@ fn install_jcode_rejects_non_string_session_hook_without_overwriting_it() {
 
 #[cfg(unix)]
 #[test]
-fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
+fn jcode_hook_reports_official_session() {
     use std::io::{BufRead, Write};
     use std::os::unix::net::UnixListener;
 
@@ -4116,56 +4152,14 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
     let home = base.join("home");
     let jcode = home.join(".jcode");
     fs::create_dir_all(&jcode).unwrap();
-    let previous_output = base.join("previous.out");
-    let previous_command = format!(
-        "JCODE_FORWARD_PREFIX=forwarded; printf '%s:%s' \"$JCODE_FORWARD_PREFIX\" \"$JCODE_HOOK_SESSION_ID\" | /bin/cat > {}",
-        shell_single_quote(&previous_output.display().to_string())
-    );
-    fs::write(
-        jcode.join("config.toml"),
-        format!(
-            "[hooks]\nsession_start = {}\n",
-            toml_basic_string(&previous_command)
-        ),
-    )
-    .unwrap();
     std::env::set_var("HOME", &home);
     let installed = install_jcode().unwrap();
-
-    // A missing Python runtime must disable only Herdr reporting, never the
-    // observer that occupied Jcode's session_start slot before installation.
-    let no_python_path = base.join("no-python-bin");
-    fs::create_dir_all(&no_python_path).unwrap();
-    let find_on_path = |command: &str| {
-        std::env::split_paths(&std::env::var_os("PATH").expect("PATH should be set"))
-            .map(|directory| directory.join(command))
-            .find(|candidate| candidate.is_file())
-            .unwrap_or_else(|| panic!("{command} should be available on PATH"))
-    };
-    let shell = find_on_path("sh");
-    std::os::unix::fs::symlink(&shell, no_python_path.join("sh")).unwrap();
-    std::os::unix::fs::symlink(find_on_path("cat"), no_python_path.join("cat")).unwrap();
-    std::os::unix::fs::symlink(find_on_path("dirname"), no_python_path.join("dirname")).unwrap();
-    let status = std::process::Command::new(shell)
-        .arg(&installed.hook_path)
-        .env("PATH", &no_python_path)
-        .env("JCODE_HOOK_SESSION_ID", "without-python")
-        .status()
-        .unwrap();
-    assert!(status.success());
-    for _ in 0..500 {
-        if fs::read_to_string(&previous_output)
-            .is_ok_and(|content| content == "forwarded:without-python")
-        {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
+    let config_path = jcode.join("config.toml");
     assert_eq!(
-        fs::read_to_string(&previous_output).unwrap(),
-        "forwarded:without-python"
+        jcode_session_start_commands(&fs::read_to_string(&config_path).unwrap(), &config_path)
+            .unwrap(),
+        vec![jcode_hook_command(&installed.hook_path)]
     );
-    fs::remove_file(&previous_output).unwrap();
 
     let socket_path = PathBuf::from(format!("/tmp/herdr-jcode-{}.sock", std::process::id()));
     let _ = fs::remove_file(&socket_path);
@@ -4173,59 +4167,60 @@ fn jcode_hook_forwards_existing_hook_and_reports_official_session() {
     listener.set_nonblocking(true).unwrap();
     let server = std::thread::spawn(move || {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        let mut stream = loop {
+        let mut requests = Vec::new();
+        while requests.len() < 2 {
             match listener.accept() {
-                Ok((stream, _)) => break stream,
+                Ok((mut stream, _)) => {
+                    let mut line = String::new();
+                    std::io::BufReader::new(stream.try_clone().unwrap())
+                        .read_line(&mut line)
+                        .unwrap();
+                    stream
+                        .write_all(b"{\"id\":\"ok\",\"result\":{}}\n")
+                        .unwrap();
+                    requests.push(serde_json::from_str::<Value>(&line).unwrap());
+                }
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                     assert!(
                         std::time::Instant::now() < deadline,
-                        "jcode hook did not connect to the Herdr socket within 5 seconds"
+                        "two jcode hooks did not connect to the Herdr socket within 5 seconds"
                     );
                     std::thread::sleep(std::time::Duration::from_millis(10));
                 }
                 Err(error) => panic!("failed to accept Jcode hook connection: {error}"),
             }
-        };
-        let mut line = String::new();
-        std::io::BufReader::new(stream.try_clone().unwrap())
-            .read_line(&mut line)
-            .unwrap();
-        stream
-            .write_all(b"{\"id\":\"ok\",\"result\":{}}\n")
-            .unwrap();
-        serde_json::from_str::<Value>(&line).unwrap()
+        }
+        requests
     });
 
-    let status = std::process::Command::new("bash")
-        .arg(&installed.hook_path)
-        .env("HERDR_ENV", "1")
-        .env("HERDR_PANE_ID", "w1:p2")
-        .env("HERDR_SOCKET_PATH", &socket_path)
-        .env("JCODE_HOOK_SESSION_ID", "jcode-session-123")
-        .env("JCODE_HOOK_SOURCE", "resume")
-        .status()
-        .unwrap();
-    assert!(status.success());
+    for (pane, session) in [
+        ("w1:p2", "jcode-session-123"),
+        ("w1:p3", "jcode-session-456"),
+    ] {
+        let status = std::process::Command::new("bash")
+            .arg(&installed.hook_path)
+            .env("HERDR_ENV", "1")
+            .env("HERDR_PANE_ID", pane)
+            .env("HERDR_SOCKET_PATH", &socket_path)
+            .env("JCODE_HOOK_SESSION_ID", session)
+            .env("JCODE_HOOK_SOURCE", "resume")
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
 
-    let request = server.join().unwrap();
+    let requests = server.join().unwrap();
+    let request = &requests[0];
     assert_eq!(request["method"], "pane.report_agent_session");
     assert_eq!(request["params"]["source"], "herdr:jcode");
     assert_eq!(request["params"]["agent"], "jcode");
     assert_eq!(request["params"]["pane_id"], "w1:p2");
     assert_eq!(request["params"]["agent_session_id"], "jcode-session-123");
     assert_eq!(request["params"]["session_start_source"], "resume");
-
-    for _ in 0..500 {
-        if fs::read_to_string(&previous_output)
-            .is_ok_and(|content| content == "forwarded:jcode-session-123")
-        {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
+    assert_eq!(requests[1]["params"]["pane_id"], "w1:p3");
     assert_eq!(
-        fs::read_to_string(&previous_output).unwrap(),
-        "forwarded:jcode-session-123"
+        requests[1]["params"]["agent_session_id"],
+        "jcode-session-456"
     );
 
     let _ = fs::remove_file(&socket_path);

--- a/src/integration/types.rs
+++ b/src/integration/types.rs
@@ -110,6 +110,20 @@ pub(crate) struct GrokUninstallResult {
 }
 
 #[derive(Debug)]
+pub(crate) struct JcodeInstallPaths {
+    pub hook_path: PathBuf,
+    pub config_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) struct JcodeUninstallResult {
+    pub hook_path: PathBuf,
+    pub config_path: PathBuf,
+    pub removed_hook_file: bool,
+    pub updated_config: bool,
+}
+
+#[derive(Debug)]
 pub(crate) struct QodercliUninstallResult {
     pub hook_path: PathBuf,
     pub settings_path: PathBuf,

--- a/tests/cli/hooks.rs
+++ b/tests/cli/hooks.rs
@@ -1,5 +1,110 @@
 use super::harness::*;
 
+// Shell integrations belong in `shell_hooks_conform_to_session_report_contract`.
+// The table exercises the asset against a real Unix socket and checks Herdr's
+// stable session-report contract. Keep adapter-specific edge cases as separate
+// tests below, and add a shared-socket case when an agent can have concurrent
+// panes (as Jcode does).
+#[derive(Clone, Copy)]
+struct ShellHookInvocation<'a> {
+    asset_path: &'a str,
+    args: &'a [&'a str],
+    hook_input: &'a str,
+    envs: &'a [(&'a str, &'a str)],
+    pane_id: &'a str,
+}
+
+struct FakeHookSocket {
+    base: PathBuf,
+    socket_path: PathBuf,
+    server: thread::JoinHandle<Vec<serde_json::Value>>,
+}
+
+impl FakeHookSocket {
+    fn start(expected_requests: usize) -> Self {
+        let base = unique_test_dir();
+        fs::create_dir_all(&base).unwrap();
+        let socket_path = base.join("herdr.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+
+        let server = thread::spawn(move || {
+            listener.set_nonblocking(true).unwrap();
+            let deadline = Instant::now() + Duration::from_millis(700);
+            let mut requests = Vec::with_capacity(expected_requests);
+            while requests.len() < expected_requests && Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut line = String::new();
+                        let mut reader = BufReader::new(stream.try_clone().unwrap());
+                        reader.read_line(&mut line).unwrap();
+                        let _ = stream.write_all(br#"{"id":"test","result":{"type":"ok"}}"#);
+                        let _ = stream.write_all(b"\n");
+                        let _ = stream.flush();
+                        requests.push(serde_json::from_str(&line).unwrap());
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(err) => panic!("accept failed: {err}"),
+                }
+            }
+            requests
+        });
+
+        Self {
+            base,
+            socket_path,
+            server,
+        }
+    }
+
+    fn finish(self) -> Vec<serde_json::Value> {
+        let requests = self.server.join().unwrap();
+        cleanup_test_base(&self.base);
+        requests
+    }
+}
+
+fn invoke_shell_hook(invocation: &ShellHookInvocation<'_>, socket_path: &Path) {
+    let hook_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(invocation.asset_path);
+    let mut command = Command::new("bash");
+    command
+        .arg(hook_path)
+        .args(invocation.args)
+        .env("HERDR_ENV", "1")
+        .env("HERDR_SOCKET_PATH", socket_path)
+        .env("HERDR_PANE_ID", invocation.pane_id)
+        .env_remove("CODEX_THREAD_ID")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (key, value) in invocation.envs {
+        command.env(key, value);
+    }
+    let mut child = command.spawn().unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    stdin.write_all(invocation.hook_input.as_bytes()).unwrap();
+    drop(stdin);
+
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "hook failed: asset={} status={:?} stderr={} stdout={}",
+        invocation.asset_path,
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+fn run_shell_hooks(invocations: &[ShellHookInvocation<'_>]) -> Vec<serde_json::Value> {
+    let socket = FakeHookSocket::start(invocations.len());
+    for invocation in invocations {
+        invoke_shell_hook(invocation, &socket.socket_path);
+    }
+    socket.finish()
+}
+
 fn run_claude_hook(action: &str, hook_input: &str) -> Option<serde_json::Value> {
     run_shell_hook(
         "src/integration/assets/claude/herdr-agent-state.sh",
@@ -47,66 +152,154 @@ fn run_shell_hook_with_env(
     hook_input: &str,
     envs: &[(&str, &str)],
 ) -> Option<serde_json::Value> {
-    let base = unique_test_dir();
-    fs::create_dir_all(&base).unwrap();
-    let socket_path = base.join("herdr.sock");
-    let listener = UnixListener::bind(&socket_path).unwrap();
-
-    let server = thread::spawn(move || {
-        listener.set_nonblocking(true).unwrap();
-        let deadline = Instant::now() + Duration::from_millis(700);
-        while Instant::now() < deadline {
-            match listener.accept() {
-                Ok((mut stream, _)) => {
-                    let mut line = String::new();
-                    let mut reader = BufReader::new(stream.try_clone().unwrap());
-                    reader.read_line(&mut line).unwrap();
-                    let _ = stream.write_all(br#"{"id":"test","result":{"type":"ok"}}"#);
-                    let _ = stream.write_all(b"\n");
-                    let _ = stream.flush();
-                    return Some(line);
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Err(err) => panic!("accept failed: {err}"),
-            }
-        }
-        None
-    });
-
-    let hook_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(asset_path);
-    let mut command = Command::new("bash");
-    command
-        .arg(hook_path)
-        .args(args)
-        .env("HERDR_ENV", "1")
-        .env("HERDR_SOCKET_PATH", &socket_path)
-        .env("HERDR_PANE_ID", "p_test")
-        .env_remove("CODEX_THREAD_ID")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    for (key, value) in envs {
-        command.env(key, value);
-    }
-    let mut child = command.spawn().unwrap();
-    let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all(hook_input.as_bytes()).unwrap();
-    drop(stdin);
-
-    let output = child.wait_with_output().unwrap();
-    assert!(
-        output.status.success(),
-        "hook failed: status={:?} stderr={} stdout={}",
-        output.status.code(),
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout)
+    let socket = FakeHookSocket::start(1);
+    invoke_shell_hook(
+        &ShellHookInvocation {
+            asset_path,
+            args,
+            hook_input,
+            envs,
+            pane_id: "p_test",
+        },
+        &socket.socket_path,
     );
+    socket.finish().into_iter().next()
+}
 
-    let request = server.join().unwrap();
-    cleanup_test_base(&base);
-    request.map(|line| serde_json::from_str(&line).unwrap())
+#[test]
+fn shell_hooks_conform_to_session_report_contract() {
+    struct Case<'a> {
+        name: &'a str,
+        invocation: ShellHookInvocation<'a>,
+        agent: &'a str,
+        session_id: &'a str,
+    }
+
+    let cases = [
+        Case {
+            name: "claude",
+            invocation: ShellHookInvocation {
+                asset_path: "src/integration/assets/claude/herdr-agent-state.sh",
+                args: &["session"],
+                hook_input: r#"{"hook_event_name":"SessionStart","session_id":"claude-session"}"#,
+                envs: &[],
+                pane_id: "p_claude",
+            },
+            agent: "claude",
+            session_id: "claude-session",
+        },
+        Case {
+            name: "codex",
+            invocation: ShellHookInvocation {
+                asset_path: "src/integration/assets/codex/herdr-agent-state.sh",
+                args: &["session"],
+                hook_input: r#"{"hook_event_name":"SessionStart","session_id":"codex-session","transcript_path":"/tmp/codex-session.jsonl"}"#,
+                envs: &[],
+                pane_id: "p_codex",
+            },
+            agent: "codex",
+            session_id: "codex-session",
+        },
+        Case {
+            name: "copilot",
+            invocation: ShellHookInvocation {
+                asset_path: "src/integration/assets/copilot/herdr-agent-state.sh",
+                args: &[],
+                hook_input: r#"{"hook_event_name":"SessionStart","session_id":"copilot-session"}"#,
+                envs: &[],
+                pane_id: "p_copilot",
+            },
+            agent: "copilot",
+            session_id: "copilot-session",
+        },
+        Case {
+            name: "devin",
+            invocation: ShellHookInvocation {
+                asset_path: "src/integration/assets/devin/herdr-agent-state.sh",
+                args: &["session"],
+                hook_input: r#"{"hook_event_name":"SessionStart","session_id":"devin-session"}"#,
+                envs: &[],
+                pane_id: "p_devin",
+            },
+            agent: "devin",
+            session_id: "devin-session",
+        },
+        Case {
+            name: "jcode",
+            invocation: ShellHookInvocation {
+                asset_path: "src/integration/assets/jcode/herdr-agent-state.sh",
+                args: &[],
+                hook_input: "",
+                envs: &[("JCODE_HOOK_SESSION_ID", "jcode-session")],
+                pane_id: "p_jcode",
+            },
+            agent: "jcode",
+            session_id: "jcode-session",
+        },
+    ];
+
+    for case in cases {
+        let mut requests = run_shell_hooks(&[case.invocation]);
+        let request = requests
+            .pop()
+            .unwrap_or_else(|| panic!("{} hook did not report a session", case.name));
+        assert_eq!(
+            request["method"], "pane.report_agent_session",
+            "{}",
+            case.name
+        );
+        assert_eq!(request["params"]["agent"], case.agent, "{}", case.name);
+        assert_eq!(
+            request["params"]["pane_id"], case.invocation.pane_id,
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            request["params"]["agent_session_id"], case.session_id,
+            "{}",
+            case.name
+        );
+        assert!(
+            request["params"].get("state").is_none(),
+            "{} session report included lifecycle state",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn jcode_hook_maps_two_panes_to_distinct_sessions_on_one_socket() {
+    let invocations = [
+        ShellHookInvocation {
+            asset_path: "src/integration/assets/jcode/herdr-agent-state.sh",
+            args: &[],
+            hook_input: "",
+            envs: &[("JCODE_HOOK_SESSION_ID", "jcode-session-one")],
+            pane_id: "p_jcode_one",
+        },
+        ShellHookInvocation {
+            asset_path: "src/integration/assets/jcode/herdr-agent-state.sh",
+            args: &[],
+            hook_input: "",
+            envs: &[("JCODE_HOOK_SESSION_ID", "jcode-session-two")],
+            pane_id: "p_jcode_two",
+        },
+    ];
+
+    let requests = run_shell_hooks(&invocations);
+    let mappings: std::collections::HashMap<_, _> = requests
+        .iter()
+        .map(|request| {
+            (
+                request["params"]["pane_id"].as_str().unwrap(),
+                request["params"]["agent_session_id"].as_str().unwrap(),
+            )
+        })
+        .collect();
+
+    assert_eq!(mappings.len(), 2);
+    assert_eq!(mappings.get("p_jcode_one"), Some(&"jcode-session-one"));
+    assert_eq!(mappings.get("p_jcode_two"), Some(&"jcode-session-two"));
 }
 
 #[test]

--- a/tests/cli/hooks.rs
+++ b/tests/cli/hooks.rs
@@ -14,14 +14,14 @@ struct ShellHookInvocation<'a> {
     pane_id: &'a str,
 }
 
-struct FakeHookSocket {
+pub(super) struct FakeHookSocket {
     base: PathBuf,
     socket_path: PathBuf,
     server: thread::JoinHandle<Vec<serde_json::Value>>,
 }
 
 impl FakeHookSocket {
-    fn start(expected_requests: usize) -> Self {
+    pub(super) fn start(expected_requests: usize) -> Self {
         let base = unique_test_dir();
         fs::create_dir_all(&base).unwrap();
         let socket_path = base.join("herdr.sock");
@@ -58,7 +58,11 @@ impl FakeHookSocket {
         }
     }
 
-    fn finish(self) -> Vec<serde_json::Value> {
+    pub(super) fn path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    pub(super) fn finish(self) -> Vec<serde_json::Value> {
         let requests = self.server.join().unwrap();
         cleanup_test_base(&self.base);
         requests

--- a/tests/cli/jcode_lifecycle.rs
+++ b/tests/cli/jcode_lifecycle.rs
@@ -1,0 +1,722 @@
+use super::harness::*;
+use super::hooks::FakeHookSocket;
+
+use std::os::unix::fs::PermissionsExt;
+
+const JCODE_HOOK_ASSET: &str =
+    include_str!("../../src/integration/assets/jcode/herdr-agent-state.sh");
+const USER_SCALAR: &str = "user-session-observer";
+const USER_FIRST: &str = "user-first";
+const USER_SECOND: &str = "user-second";
+const REPLACEMENT_FIRST: &str = "replacement-first";
+const REPLACEMENT_SECOND: &str = "replacement-second";
+const SCALAR_CONFIG: &str = "# keep user metadata\n[display]\nemoji = false\n\n[hooks]\nturn_end = \"notify\"\nsession_start = \"user-session-observer\"\n";
+const ARRAY_CONFIG: &str = "# keep user metadata\n[display]\nemoji = false\n\n[hooks]\nturn_end = \"notify\"\nsession_start = [\"user-first\", \"user-second\"]\n";
+const MALFORMED_CONFIG: &str = "[hooks]\nsession_start = [\"user-session-observer\", 42]\n";
+const REPLACEMENT_CONFIG: &str = "# user replaced the registered hook list\n[hooks]\nturn_end = \"notify\"\nsession_start = [\"replacement-first\", \"replacement-second\"]\n";
+
+/*
+The table below is the executable form of this graph. Every edge gets a fresh
+Jcode home, materializes and checks its source state, executes the real CLI or
+installed hook, then checks the target-state invariants.
+
+```mermaid
+stateDiagram-v2
+    AbsentConfig --> ManagedOnly: install
+    ScalarUserHook --> ManagedPlusScalar: install
+    ArrayUserHooks --> ManagedPlusArray: install
+    MalformedConfig --> MalformedConfig: rejected install
+    ManagedOnly --> ManagedOnly: idempotent reinstall / hook probes
+    ManagedPlusScalar --> ManagedPlusScalar: idempotent reinstall
+    ManagedPlusArray --> ManagedPlusArray: idempotent reinstall
+    ManagedPlusScalar --> UserReplacedManaged: user replaces registration
+    ManagedOnly --> UninstalledEmpty: uninstall
+    ManagedPlusScalar --> UninstalledScalar: uninstall
+    ManagedPlusArray --> UninstalledArray: uninstall
+    UserReplacedManaged --> UninstalledReplacement: uninstall
+    UninstalledEmpty --> ManagedOnly: reinstall
+    UninstalledScalar --> ManagedPlusScalar: reinstall
+    UninstalledArray --> ManagedPlusArray: reinstall
+```
+*/
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum State {
+    AbsentConfig,
+    ScalarUserHook,
+    ArrayUserHooks,
+    MalformedConfig,
+    ManagedOnly,
+    ManagedPlusScalar,
+    ManagedPlusArray,
+    UserReplacedManaged,
+    UninstalledEmpty,
+    UninstalledScalar,
+    UninstalledArray,
+    UninstalledReplacement,
+}
+
+impl State {
+    fn user_hooks(self) -> &'static [&'static str] {
+        match self {
+            Self::ScalarUserHook | Self::ManagedPlusScalar | Self::UninstalledScalar => {
+                &[USER_SCALAR]
+            }
+            Self::ArrayUserHooks | Self::ManagedPlusArray | Self::UninstalledArray => {
+                &[USER_FIRST, USER_SECOND]
+            }
+            Self::UserReplacedManaged | Self::UninstalledReplacement => {
+                &[REPLACEMENT_FIRST, REPLACEMENT_SECOND]
+            }
+            Self::AbsentConfig
+            | Self::MalformedConfig
+            | Self::ManagedOnly
+            | Self::UninstalledEmpty => &[],
+        }
+    }
+
+    fn has_config(self) -> bool {
+        self != Self::AbsentConfig
+    }
+
+    fn has_managed_hook_file(self) -> bool {
+        matches!(
+            self,
+            Self::ManagedOnly
+                | Self::ManagedPlusScalar
+                | Self::ManagedPlusArray
+                | Self::UserReplacedManaged
+        )
+    }
+
+    fn has_managed_registration(self) -> bool {
+        matches!(
+            self,
+            Self::ManagedOnly | Self::ManagedPlusScalar | Self::ManagedPlusArray
+        )
+    }
+
+    fn preserves_seed_metadata(self) -> bool {
+        matches!(
+            self,
+            Self::ScalarUserHook
+                | Self::ArrayUserHooks
+                | Self::ManagedPlusScalar
+                | Self::ManagedPlusArray
+                | Self::UninstalledScalar
+                | Self::UninstalledArray
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Action {
+    Install,
+    IdempotentReinstall,
+    RejectMalformedInstall,
+    ReplaceManagedRegistration,
+    Uninstall,
+    ReinstallAfterUninstall,
+    RunOutsideHerdr,
+    RunCreateAndResume,
+    RunTwoPanesOnOneSocket,
+    RunWithoutPython,
+    RunWithUnavailableSocket,
+}
+
+impl Action {
+    fn must_not_change_files(self) -> bool {
+        matches!(
+            self,
+            Self::IdempotentReinstall
+                | Self::RejectMalformedInstall
+                | Self::RunOutsideHerdr
+                | Self::RunCreateAndResume
+                | Self::RunTwoPanesOnOneSocket
+                | Self::RunWithoutPython
+                | Self::RunWithUnavailableSocket
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Edge {
+    name: &'static str,
+    from: State,
+    action: Action,
+    to: State,
+}
+
+const GRAPH: &[Edge] = &[
+    Edge {
+        name: "install with absent config",
+        from: State::AbsentConfig,
+        action: Action::Install,
+        to: State::ManagedOnly,
+    },
+    Edge {
+        name: "install with scalar user hook",
+        from: State::ScalarUserHook,
+        action: Action::Install,
+        to: State::ManagedPlusScalar,
+    },
+    Edge {
+        name: "install with user hook array",
+        from: State::ArrayUserHooks,
+        action: Action::Install,
+        to: State::ManagedPlusArray,
+    },
+    Edge {
+        name: "reject malformed hook array",
+        from: State::MalformedConfig,
+        action: Action::RejectMalformedInstall,
+        to: State::MalformedConfig,
+    },
+    Edge {
+        name: "idempotent reinstall without user hooks",
+        from: State::ManagedOnly,
+        action: Action::IdempotentReinstall,
+        to: State::ManagedOnly,
+    },
+    Edge {
+        name: "idempotent reinstall with scalar user hook",
+        from: State::ManagedPlusScalar,
+        action: Action::IdempotentReinstall,
+        to: State::ManagedPlusScalar,
+    },
+    Edge {
+        name: "idempotent reinstall with user hook array",
+        from: State::ManagedPlusArray,
+        action: Action::IdempotentReinstall,
+        to: State::ManagedPlusArray,
+    },
+    Edge {
+        name: "execution outside Herdr reports nothing",
+        from: State::ManagedOnly,
+        action: Action::RunOutsideHerdr,
+        to: State::ManagedOnly,
+    },
+    Edge {
+        name: "create and resume source mapping",
+        from: State::ManagedOnly,
+        action: Action::RunCreateAndResume,
+        to: State::ManagedOnly,
+    },
+    Edge {
+        name: "two panes share a socket without sharing session identity",
+        from: State::ManagedOnly,
+        action: Action::RunTwoPanesOnOneSocket,
+        to: State::ManagedOnly,
+    },
+    Edge {
+        name: "missing Python fails open",
+        from: State::ManagedOnly,
+        action: Action::RunWithoutPython,
+        to: State::ManagedOnly,
+    },
+    Edge {
+        name: "unavailable socket fails open",
+        from: State::ManagedOnly,
+        action: Action::RunWithUnavailableSocket,
+        to: State::ManagedOnly,
+    },
+    Edge {
+        name: "user replaces managed registration",
+        from: State::ManagedPlusScalar,
+        action: Action::ReplaceManagedRegistration,
+        to: State::UserReplacedManaged,
+    },
+    Edge {
+        name: "uninstall after user replacement preserves replacement",
+        from: State::UserReplacedManaged,
+        action: Action::Uninstall,
+        to: State::UninstalledReplacement,
+    },
+    Edge {
+        name: "uninstall removes only managed hook",
+        from: State::ManagedOnly,
+        action: Action::Uninstall,
+        to: State::UninstalledEmpty,
+    },
+    Edge {
+        name: "uninstall preserves scalar user hook",
+        from: State::ManagedPlusScalar,
+        action: Action::Uninstall,
+        to: State::UninstalledScalar,
+    },
+    Edge {
+        name: "uninstall preserves user hook array",
+        from: State::ManagedPlusArray,
+        action: Action::Uninstall,
+        to: State::UninstalledArray,
+    },
+    Edge {
+        name: "reinstall after empty uninstall",
+        from: State::UninstalledEmpty,
+        action: Action::ReinstallAfterUninstall,
+        to: State::ManagedOnly,
+    },
+    Edge {
+        name: "reinstall after scalar-hook uninstall",
+        from: State::UninstalledScalar,
+        action: Action::ReinstallAfterUninstall,
+        to: State::ManagedPlusScalar,
+    },
+    Edge {
+        name: "reinstall after array-hook uninstall",
+        from: State::UninstalledArray,
+        action: Action::ReinstallAfterUninstall,
+        to: State::ManagedPlusArray,
+    },
+];
+
+#[derive(Debug, Eq, PartialEq)]
+struct FileSnapshot {
+    config: Option<Vec<u8>>,
+    hook: Option<Vec<u8>>,
+}
+
+struct LifecycleHarness {
+    base: PathBuf,
+    jcode_dir: PathBuf,
+    config_path: PathBuf,
+    hooks_dir: PathBuf,
+    hook_path: PathBuf,
+}
+
+impl LifecycleHarness {
+    fn new(edge_index: usize) -> Self {
+        let base = unique_test_dir().join(format!("jcode-lifecycle-edge-{edge_index}"));
+        let jcode_dir = base.join("jcode-home");
+        fs::create_dir_all(&jcode_dir).unwrap();
+        let hooks_dir = jcode_dir.join("hooks");
+        Self {
+            config_path: jcode_dir.join("config.toml"),
+            hook_path: hooks_dir.join("herdr-agent-state.sh"),
+            base,
+            jcode_dir,
+            hooks_dir,
+        }
+    }
+
+    fn materialize(&self, state: State, edge: &Edge) {
+        match state {
+            State::AbsentConfig => {}
+            State::ScalarUserHook => self.write_config(SCALAR_CONFIG),
+            State::ArrayUserHooks => self.write_config(ARRAY_CONFIG),
+            State::MalformedConfig => self.write_config(MALFORMED_CONFIG),
+            State::ManagedOnly => self.install(edge),
+            State::ManagedPlusScalar => {
+                self.write_config(SCALAR_CONFIG);
+                self.install(edge);
+            }
+            State::ManagedPlusArray => {
+                self.write_config(ARRAY_CONFIG);
+                self.install(edge);
+            }
+            State::UserReplacedManaged => {
+                self.write_config(SCALAR_CONFIG);
+                self.install(edge);
+                self.write_config(REPLACEMENT_CONFIG);
+            }
+            State::UninstalledEmpty => {
+                self.install(edge);
+                self.uninstall(edge);
+            }
+            State::UninstalledScalar => {
+                self.write_config(SCALAR_CONFIG);
+                self.install(edge);
+                self.uninstall(edge);
+            }
+            State::UninstalledArray => {
+                self.write_config(ARRAY_CONFIG);
+                self.install(edge);
+                self.uninstall(edge);
+            }
+            State::UninstalledReplacement => {
+                self.write_config(SCALAR_CONFIG);
+                self.install(edge);
+                self.write_config(REPLACEMENT_CONFIG);
+                self.uninstall(edge);
+            }
+        }
+    }
+
+    fn apply(&self, edge: &Edge) {
+        let before = self.snapshot();
+        match edge.action {
+            Action::Install | Action::IdempotentReinstall | Action::ReinstallAfterUninstall => {
+                self.install(edge)
+            }
+            Action::RejectMalformedInstall => {
+                let output = self.integration("install");
+                assert!(
+                    !output.status.success(),
+                    "{}: malformed config was accepted",
+                    edge.name
+                );
+                assert!(
+                    String::from_utf8_lossy(&output.stderr)
+                        .contains("must be a string or array of strings"),
+                    "{}: unexpected rejection: {}",
+                    edge.name,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            Action::ReplaceManagedRegistration => self.write_config(REPLACEMENT_CONFIG),
+            Action::Uninstall => self.uninstall(edge),
+            Action::RunOutsideHerdr => self.run_outside_herdr(edge),
+            Action::RunCreateAndResume => self.run_create_and_resume(edge),
+            Action::RunTwoPanesOnOneSocket => self.run_two_panes(edge),
+            Action::RunWithoutPython => self.run_without_python(edge),
+            Action::RunWithUnavailableSocket => self.run_with_unavailable_socket(edge),
+        }
+        if edge.action.must_not_change_files() {
+            assert_eq!(
+                self.snapshot(),
+                before,
+                "{} changed managed files",
+                edge.name
+            );
+        }
+        if matches!(
+            (edge.from, edge.action),
+            (State::UserReplacedManaged, Action::Uninstall)
+        ) {
+            assert_eq!(
+                fs::read_to_string(&self.config_path).unwrap(),
+                REPLACEMENT_CONFIG,
+                "{} rewrote the user's replacement config",
+                edge.name
+            );
+        }
+    }
+
+    fn assert_state(&self, state: State, edge: &Edge, side: &str) {
+        assert_eq!(
+            self.config_path.is_file(),
+            state.has_config(),
+            "{} {side}: config existence does not match {state:?}",
+            edge.name
+        );
+        assert_eq!(
+            self.hook_path.is_file(),
+            state.has_managed_hook_file(),
+            "{} {side}: hook existence does not match {state:?}",
+            edge.name
+        );
+
+        if state == State::MalformedConfig {
+            assert_eq!(
+                fs::read_to_string(&self.config_path).unwrap(),
+                MALFORMED_CONFIG,
+                "{} {side}: malformed config was changed",
+                edge.name
+            );
+            assert!(
+                !self.hooks_dir.exists(),
+                "{} {side}: rejected config left managed filesystem state",
+                edge.name
+            );
+            return;
+        }
+
+        if state.has_config() {
+            let content = fs::read_to_string(&self.config_path).unwrap();
+            let mut expected: Vec<_> = state
+                .user_hooks()
+                .iter()
+                .map(|hook| (*hook).to_string())
+                .collect();
+            if state.has_managed_registration() {
+                expected.push(self.managed_command());
+            }
+            assert_eq!(
+                session_start_commands(&content),
+                expected,
+                "{} {side}: session_start commands do not match {state:?}",
+                edge.name
+            );
+            if state.preserves_seed_metadata() {
+                assert!(
+                    content.contains("# keep user metadata"),
+                    "{} {side}",
+                    edge.name
+                );
+                assert!(
+                    content.contains("turn_end = \"notify\""),
+                    "{} {side}",
+                    edge.name
+                );
+                assert!(content.contains("emoji = false"), "{} {side}", edge.name);
+            }
+        }
+
+        if state.has_managed_hook_file() {
+            assert_eq!(
+                fs::read_to_string(&self.hook_path).unwrap(),
+                JCODE_HOOK_ASSET,
+                "{} {side}: installed hook differs from the bundled asset",
+                edge.name
+            );
+            let mode = fs::metadata(&self.hook_path).unwrap().permissions().mode();
+            assert_ne!(
+                mode & 0o111,
+                0,
+                "{} {side}: hook is not executable",
+                edge.name
+            );
+        }
+    }
+
+    fn integration(&self, action: &str) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_herdr"))
+            .args(["integration", action, "jcode"])
+            .env("JCODE_HOME", &self.jcode_dir)
+            .env_remove("HERDR_ENV")
+            .env_remove("HERDR_SOCKET_PATH")
+            .env_remove("HERDR_CLIENT_SOCKET_PATH")
+            .output()
+            .unwrap()
+    }
+
+    fn install(&self, edge: &Edge) {
+        self.assert_cli_success(edge, "install", self.integration("install"));
+    }
+
+    fn uninstall(&self, edge: &Edge) {
+        self.assert_cli_success(edge, "uninstall", self.integration("uninstall"));
+    }
+
+    fn assert_cli_success(&self, edge: &Edge, action: &str, output: std::process::Output) {
+        assert!(
+            output.status.success(),
+            "{}: {action} failed: stdout={} stderr={}",
+            edge.name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn write_config(&self, content: &str) {
+        fs::write(&self.config_path, content).unwrap();
+    }
+
+    fn managed_command(&self) -> String {
+        format!("bash '{}'", self.hook_path.display())
+    }
+
+    fn snapshot(&self) -> FileSnapshot {
+        FileSnapshot {
+            config: fs::read(&self.config_path).ok(),
+            hook: fs::read(&self.hook_path).ok(),
+        }
+    }
+
+    fn invoke_hook(
+        &self,
+        socket_path: &Path,
+        pane_id: &str,
+        session_id: &str,
+        source: Option<&str>,
+        inside_herdr: bool,
+        path: Option<&Path>,
+    ) -> std::process::Output {
+        let mut command = Command::new(&self.hook_path);
+        command
+            .env_remove("HERDR_ENV")
+            .env_remove("HERDR_SOCKET_PATH")
+            .env_remove("HERDR_PANE_ID")
+            .env_remove("JCODE_HOOK_SESSION_ID")
+            .env_remove("JCODE_HOOK_SOURCE")
+            .env("HERDR_SOCKET_PATH", socket_path)
+            .env("HERDR_PANE_ID", pane_id)
+            .env("JCODE_HOOK_SESSION_ID", session_id);
+        if inside_herdr {
+            command.env("HERDR_ENV", "1");
+        }
+        if let Some(source) = source {
+            command.env("JCODE_HOOK_SOURCE", source);
+        }
+        if let Some(path) = path {
+            command.env("PATH", path);
+        }
+        command.output().unwrap()
+    }
+
+    fn assert_hook_success(&self, edge: &Edge, output: &std::process::Output) {
+        assert!(
+            output.status.success(),
+            "{}: hook failed open contract: stdout={} stderr={}",
+            edge.name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn run_outside_herdr(&self, edge: &Edge) {
+        let socket = FakeHookSocket::start(1);
+        let socket_path = socket.path().to_path_buf();
+        let output = self.invoke_hook(
+            &socket_path,
+            "p_outside",
+            "outside-session",
+            Some("create"),
+            false,
+            None,
+        );
+        self.assert_hook_success(edge, &output);
+        assert!(
+            socket.finish().is_empty(),
+            "{}: hook reported outside Herdr",
+            edge.name
+        );
+    }
+
+    fn run_create_and_resume(&self, edge: &Edge) {
+        let socket = FakeHookSocket::start(2);
+        let socket_path = socket.path().to_path_buf();
+        for (pane, session, source) in [
+            ("p_create", "create-session", "create"),
+            ("p_resume", "resume-session", "resume"),
+        ] {
+            let output = self.invoke_hook(&socket_path, pane, session, Some(source), true, None);
+            self.assert_hook_success(edge, &output);
+        }
+        let requests = socket.finish();
+        assert_eq!(requests.len(), 2, "{}: missing reports", edge.name);
+        assert_report(
+            edge,
+            &requests[0],
+            "p_create",
+            "create-session",
+            Some("startup"),
+        );
+        assert_report(
+            edge,
+            &requests[1],
+            "p_resume",
+            "resume-session",
+            Some("resume"),
+        );
+    }
+
+    fn run_two_panes(&self, edge: &Edge) {
+        let socket = FakeHookSocket::start(2);
+        let socket_path = socket.path().to_path_buf();
+        for (pane, session) in [
+            ("p_shared_one", "session-one"),
+            ("p_shared_two", "session-two"),
+        ] {
+            let output = self.invoke_hook(&socket_path, pane, session, None, true, None);
+            self.assert_hook_success(edge, &output);
+        }
+        let requests = socket.finish();
+        assert_eq!(requests.len(), 2, "{}: missing reports", edge.name);
+        assert_report(edge, &requests[0], "p_shared_one", "session-one", None);
+        assert_report(edge, &requests[1], "p_shared_two", "session-two", None);
+    }
+
+    fn run_without_python(&self, edge: &Edge) {
+        let empty_path = self.base.join("empty-path");
+        fs::create_dir_all(&empty_path).unwrap();
+        let socket = FakeHookSocket::start(1);
+        let socket_path = socket.path().to_path_buf();
+        let output = self.invoke_hook(
+            &socket_path,
+            "p_no_python",
+            "no-python-session",
+            Some("create"),
+            true,
+            Some(&empty_path),
+        );
+        self.assert_hook_success(edge, &output);
+        assert!(
+            socket.finish().is_empty(),
+            "{}: hook reported without Python",
+            edge.name
+        );
+    }
+
+    fn run_with_unavailable_socket(&self, edge: &Edge) {
+        let socket_path = self.base.join("unavailable.sock");
+        let output = self.invoke_hook(
+            &socket_path,
+            "p_no_socket",
+            "no-socket-session",
+            Some("resume"),
+            true,
+            None,
+        );
+        self.assert_hook_success(edge, &output);
+    }
+}
+
+impl Drop for LifecycleHarness {
+    fn drop(&mut self) {
+        cleanup_test_base(&self.base);
+    }
+}
+
+fn session_start_commands(content: &str) -> Vec<String> {
+    let document: toml::Value = toml::from_str(content).unwrap();
+    let Some(value) = document
+        .get("hooks")
+        .and_then(|hooks| hooks.get("session_start"))
+    else {
+        return Vec::new();
+    };
+    match value {
+        toml::Value::String(command) => vec![command.clone()],
+        toml::Value::Array(commands) => commands
+            .iter()
+            .map(|command| command.as_str().unwrap().to_string())
+            .collect(),
+        other => panic!("unexpected session_start value: {other:?}"),
+    }
+}
+
+fn assert_report(
+    edge: &Edge,
+    request: &serde_json::Value,
+    pane_id: &str,
+    session_id: &str,
+    start_source: Option<&str>,
+) {
+    assert_eq!(
+        request["method"], "pane.report_agent_session",
+        "{}",
+        edge.name
+    );
+    assert_eq!(request["params"]["source"], "herdr:jcode", "{}", edge.name);
+    assert_eq!(request["params"]["agent"], "jcode", "{}", edge.name);
+    assert_eq!(request["params"]["pane_id"], pane_id, "{}", edge.name);
+    assert_eq!(
+        request["params"]["agent_session_id"], session_id,
+        "{}",
+        edge.name
+    );
+    match start_source {
+        Some(source) => assert_eq!(
+            request["params"]["session_start_source"], source,
+            "{}",
+            edge.name
+        ),
+        None => assert!(
+            request["params"].get("session_start_source").is_none(),
+            "{}",
+            edge.name
+        ),
+    }
+    assert!(request["params"].get("state").is_none(), "{}", edge.name);
+}
+
+#[test]
+fn jcode_lifecycle_state_space_graph() {
+    for (edge_index, edge) in GRAPH.iter().enumerate() {
+        let harness = LifecycleHarness::new(edge_index);
+        harness.materialize(edge.from, edge);
+        harness.assert_state(edge.from, edge, "source");
+        harness.apply(edge);
+        harness.assert_state(edge.to, edge, "target");
+    }
+}

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -4,6 +4,7 @@ mod agent_wait;
 mod agents;
 mod harness;
 mod hooks;
+mod jcode_lifecycle;
 mod panes;
 mod plugins;
 mod protocol;

--- a/website/agent-detection/index.toml
+++ b/website/agent-detection/index.toml
@@ -41,6 +41,10 @@ id = "grok"
 path = "grok.toml"
 
 [[agents]]
+id = "jcode"
+path = "jcode.toml"
+
+[[agents]]
 id = "hermes"
 path = "hermes.toml"
 

--- a/website/agent-detection/jcode.toml
+++ b/website/agent-detection/jcode.toml
@@ -1,0 +1,47 @@
+id = "jcode"
+version = "2026.08.03.1"
+min_engine_version = 1
+updated_at = "2026-08-03T00:00:00Z"
+aliases = ["j-code", "herdr:jcode"]
+
+# Jcode pins its composer to the bottom of the pane. The next message number is
+# followed by one marker: `>` for ready, `…` while a turn is in flight, `»` for
+# an armed skill, or `$` for shell mode. Only `…` means working.
+[[rules]]
+id = "composer_processing"
+state = "working"
+priority = 900
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+line_regex = ['^\s*\d+…']
+
+# A multi-line composer can move its marker outside the recent-line window.
+# Jcode's processing line then shows either a braille spinner or an animated
+# three-dot tool bar directly above the composer.
+[[rules]]
+id = "status_line_spinner_working"
+state = "working"
+priority = 890
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+line_regex = ['^[\x{2800}-\x{28FF}] \S']
+
+[[rules]]
+id = "status_line_tool_bar_working"
+state = "working"
+priority = 890
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+line_regex = ['^[·●]{3} \S+ [·●]{3}(\s|$)']
+
+[[rules]]
+id = "composer_ready"
+state = "idle"
+priority = 850
+region = "bottom_non_empty_lines(4)"
+visible_idle = true
+line_regex = ['^\s*\d+[>»$]']
+
+# Jcode emits no state-bearing OSC progress/title sequence. It also has no
+# in-session approval prompt, so there is deliberately no blocked rule. Shell
+# mode and user-opened overlays correctly remain idle.

--- a/website/src/content/blog/ten-agents-three-clients-95-percent-less-cpu.md
+++ b/website/src/content/blog/ten-agents-three-clients-95-percent-less-cpu.md
@@ -1,30 +1,26 @@
 ---
 title: Ten agents, three clients, 95% less CPU
-description: Herdr's sidebar stopped animating, hidden panes stopped drawing, and mouse movement stopped counting as a change. The saving compounds with panes and clients, so the busiest sessions gained the most.
+description: Herdr stopped animating its sidebar, drawing hidden panes, and repainting unchanged frames during mouse movement. The busiest sessions gained the most.
 date: 2026-08-03
 ogImage: /assets/og-blog-frames-v1.png
 draft: false
 ---
 
-Herdr did not get faster.
+Across workloads dominated by unnecessary rendering, total CPU for the Herdr server and its attached clients fell by 89 to 95 percent. The renderer still runs at the same speed. Herdr now asks it to draw fewer frames.
 
-That distinction is worth keeping, because the honest version is more interesting. No renderer in Herdr became ten times quicker. Herdr stopped asking the renderer to draw things that nobody was going to look at. In the workloads where that work dominated, total CPU across the server and every attached client fell by 89 to 95 percent.
+The saving grows with the session. With one agent and one client, total CPU fell 91 percent. With ten agents producing background output and three clients, it fell 95 percent. Every frame the server skips is also one less frame to serialize, transmit, and apply in each client.
 
-The saving also compounds, which is the part worth knowing. One agent with one client attached improved 91 percent. Ten agents with background output and three clients attached improved 95, because a frame that is never produced is also never serialized, never transmitted, and never applied by any of them. The busier the session, the more there is to not do.
-
-Three changes got us there, and none of them were found in a profiler. The first started as a complaint, and the rule that came out of it was that motion should mean something changed.
+Three changes got us there, and none came from a profiler. The first started as a complaint and gave us a rule. Motion should mean something changed.
 
 ## The spinner was a complaint before it was a cost
 
 Herdr's job is to tell you which agent needs you. You run five, ten, twenty of them, and the sidebar is how you know where to look.
 
-So every working agent got a spinner. It seemed obvious at the time: motion means alive, and an agent that is thinking should look like it is thinking.
+So every working agent got a spinner. It seemed obvious at the time. Motion means alive, and an agent that is thinking should look like it is thinking.
 
-Run twenty agents and you find out what that actually builds. Twenty things moving at once, all saying the same thing, none of them saying it is the one that needs you. The workspace list already carried state as coloured dots, and the sidebar was the noisy half of the same information. People told us. We agreed.
+Run twenty agents and you get twenty things moving at once, all saying the same thing, none saying it is the one that needs you. The workspace list already carried state as coloured dots. The sidebar was the noisy half of the same information. People told us. We agreed.
 
-The first fix was a performance fix. Instead of rebuilding pane contents for a spinner tick, the server reused the client's retained frame, redrew only the status rectangle, patched it, and sent the smaller result. It worked. It made an animation that should not exist about as cheap as an animation can be.
-
-It was still twenty things moving. So we removed them.
+The first fix isolated spinner redraws to the status rectangle. Instead of rebuilding pane contents for every tick, the server reused the client's retained frame, patched the smaller result, and sent it. We had made the spinner about as cheap as possible. Then we removed it anyway. It was a design decision first; the CPU saving was a side effect.
 
 <figure class="pf">
   <div class="pf-2">
@@ -48,19 +44,17 @@ It was still twenty things moving. So we removed them.
   <figcaption class="pf-cap">Both panels carry the same information. Only one of them lets you find the blocked agent without reading. The left panel is animating in your browser right now, which is the entire argument.</figcaption>
 </figure>
 
-Working state is now a static coloured mark. Entering the state still renders immediately, so a change catches your eye the moment it happens. Staying in it costs nothing, and looks like nothing.
+Working state is now a static coloured mark. Entering the state still renders immediately, so a change catches your eye when it happens. Remaining in the state schedules no animation.
 
-The performance consequence was larger than the design one. Animating that sidebar meant waking on a timer, rendering the status surface, comparing the frame, preparing it, serializing it, sending it to every attached client, and having each client receive and apply it. Roughly eight times a second, for as long as any agent was working, whether or not one other thing on screen had changed.
+That design change saved more CPU than we expected. The spinner woke the server on a timer, rendered the status surface, compared and prepared the frame, serialized it, sent it to every attached client, and made each client apply it. This happened roughly eight times a second for as long as any agent was working, even when the rest of the screen stayed unchanged.
 
 Removing the spinner removed all of it: the timer, the animation deadlines, the scans asking whether any workspace contained a working pane, the animation-only render causes, the frame patching. Master produces zero scheduled animation frames. One agent working with nothing else on screen went from 1.467 percent CPU to 0.133 on Linux, and from 3.280 to 0.265 on macOS.
 
-We removed spinners because they were noise, not because they were inefficient. 
-
 ## The same rule, applied to output you cannot see
 
-Once motion means a change, the question becomes which things are actually changes.
+The same rule applies to output from panes nobody can see.
 
-When a pane produced output, the PTY reader set a shared flag meaning something happened. It coalesced wakeups efficiently and threw away the one fact that mattered, which was which pane. So when the server picked that flag up it could not tell whether the pane was even on screen. A background agent writing to a tab you were not looking at went into rendering anyway, and with several clients attached, produced frames for all of them.
+When a pane produced output, the PTY reader set a shared flag to say something had happened. That coalesced wakeups efficiently but discarded the source pane. By the time the server picked up the flag, it could not tell whether the pane was on screen. A background agent writing to a tab nobody was viewing still produced frames for every attached client.
 
 <figure class="pf">
   <div class="pf-2">
@@ -92,21 +86,21 @@ When a pane produced output, the PTY reader set a shared flag meaning something 
   <figcaption class="pf-cap">Render requests now carry their source. Writes from one pane coalesce into a single entry, while simultaneous writes from different panes each keep their identity.</figcaption>
 </figure>
 
-Skipping loses nothing. The bytes have already been parsed, so terminal state, scrollback, cursor, OSC metadata and agent detection all stay current. Switching to that tab renders from that state normally. Where the mapping is unknown, the pane is treated as visible rather than suppressed, because a wrong skip costs you a stale screen and a wrong render costs some CPU. Those are not the same kind of mistake.
+Skipping the render does not drop output. The bytes have already been parsed, so terminal state, scrollback, cursor, OSC metadata and agent detection all stay current. Switching to that tab renders from the current state. Where the mapping is unknown, Herdr treats the pane as visible, because a wrong skip leaves a stale screen while a wrong render only costs some CPU.
 
-## And to input that changes nothing
+## Mouse movement should not redraw an unchanged frame
 
 Every mouse event reported that the view had changed. Pointer movement over a pane is forwarded to the application inside it, but Herdr's own frame is usually identical before and after. At 60 motion events per second, that meant roughly 60 server renders and 60 client frames per second, to draw the same picture sixty times.
 
-Herdr now knows which of its own modes respond to hover, which is the global menu, context menus and the navigator. Outside those, movement alone repaints nothing, while the events themselves still route through to the pane exactly as before.
+Herdr now tracks which of its own modes respond to hover: the global menu, context menus and the navigator. Outside those modes, movement alone repaints nothing. The events still reach the pane exactly as before.
 
 The benchmark counted both ends. In every measured round, on both builds, 1,680 motion packets were sent and all 1,680 arrived in the pane. Version 0.7.5 emitted around 56 to 60 frames per second doing it. Master emitted none. Linux CPU fell from 9.450 percent to 0.667.
 
 ## Why three changes became ninety percent
 
-A render avoided at the server is not one saving. It is the frame preparation, the serialization, the transmission and the frame handling in every attached client, none of which happen.
+Skipping one server render also skips frame preparation, serialization, transmission, and frame handling in every attached client.
 
-That is why the numbers grow with clients rather than shrinking. Ten silent working panes with one client improved 78 percent. The same panes with three clients improved 91.
+More clients multiply the saving. Ten silent working panes with one client improved 78 percent. The same panes with three clients improved 91 percent.
 
 <figure class="pf">
   <div class="pf-panel">
@@ -139,7 +133,7 @@ That is why the numbers grow with clients rather than shrinking. Ten silent work
       </div>
     </div>
   </div>
-  <figcaption class="pf-cap">The last row is the one to look at. macOS followed the same shape, from 22.958 percent to 1.673 on the hidden output case and from 14.857 to 13.498 on the last one.</figcaption>
+  <figcaption class="pf-cap">macOS followed the same shape: 22.958 percent to 1.673 in the hidden-output case, and 14.857 to 13.498 with forty-nine hidden writers at 60Hz.</figcaption>
 </figure>
 
 On 0.7.5, adding hidden background output to a session cost 8.7 CPU points on Linux and 12.7 on macOS. On master the same activity costs 0.2 and 0.6, which is roughly the price of reading and parsing the bytes and nothing else.
@@ -148,16 +142,16 @@ On 0.7.5, adding hidden background output to a session cost 8.7 CPU points on Li
 
 Fifty panes, forty-nine of them writing at 60Hz, is about 2,940 terminal updates per second. Every one of them still has to be read from the PTY and parsed into terminal state, because that is what makes the pane correct when you switch to it. Suppressing frames cannot suppress terminal emulation.
 
-That case improved 23.6 percent on Linux and 9.1 on macOS. Visible output at 60Hz, a pane you are actually watching, improved 33.9 percent on Linux and 2.7 on macOS, which is to say it did not regress. Idle sat at the measurement floor on both builds and deserves no percentage claim at all.
+That case improved 23.6 percent on Linux and 9.1 on macOS. Visible output at 60Hz, in a pane you are watching, improved 33.9 percent on Linux and 2.7 on macOS. Idle sat at the measurement floor on both builds and deserves no percentage claim at all.
 
-None of those are the headline. All of them are the point. The gains are large exactly where the work was unnecessary and small exactly where it was not.
+The optimization targets unnecessary rendering. Output-heavy cases remain dominated by PTY reads and terminal parsing.
 
 ## How this was measured
 
-Official 0.7.5 release binaries against hashed master builds, on separate Linux and macOS machines, giving 54 isolated observations per operating system. Every run used a fresh named session, real attached clients in fixed 86 by 47 terminals, a five second warmup and twenty one second samples. The figures are total CPU for the Herdr server plus every attached client.
+We compared official 0.7.5 release binaries with hashed master builds on separate Linux and macOS machines, giving 54 isolated observations per operating system. Every run used a fresh named session, real attached clients in fixed 86 by 47 terminals, a five-second warmup and twenty-one-second samples. The figures show total CPU for the Herdr server plus every attached client.
 
-Every headline result also has a behavioural counter behind it rather than only a CPU total: scheduled frames per second for the sidebar, hidden source skips for background output, exact packet delivery counts for mouse motion. A CPU number on its own can be explained by a dozen things. A CPU number with a matching mechanism counter is harder to argue with.
+We paired every headline CPU result with a behavioural counter: scheduled frames per second for the sidebar, hidden-source skips for background output, and exact packet delivery counts for mouse motion. A CPU number on its own can be explained by a dozen things. A CPU number with a matching mechanism counter is harder to argue with.
 
-One limit worth stating plainly. This compares a shipped release against master, so intervening changes and build environments are part of what is being compared. The profiler evidence matches the mechanisms closely, but not every CPU point can be assigned to one commit.
+This compares a shipped release against master, so intervening changes and build environments are part of the comparison. The profiler evidence matches the mechanisms closely, but not every CPU point can be assigned to one commit.
 
-None of this started in a profiler. It started with people saying the sidebar was too busy, and with bug reports and performance reports from people running far stranger sessions than we test. Keep them coming. Thank you to everyone helping make Herdr better.
+The work started with people saying the sidebar was too busy, along with bug reports and performance reports from people running far stranger sessions than we test. Keep them coming, and thank you to everyone helping make Herdr better.


### PR DESCRIPTION
## Summary

Refreshes this integration onto current `master` (`3f2a6e74`) and resolves the registry conflicts requested in review.

- Recognize Jcode and support `herdr agent start --kind jcode`, `agent prompt --wait`, native session identity, and `jcode --resume <id>` restoration.
- Install the session hook as a native Jcode hook-array entry, preserving existing string/array hooks and unrelated TOML. Respect `JCODE_HOME` and reject malformed configuration before writing assets.
- Keep generation-1 endpoint enums, schemas, method-shape fixtures, and codecs unchanged. Jcode follows the existing **experimental CLI-only integration** route: `herdr integration install jcode`, `uninstall jcode`, and `status`. It is intentionally absent from the frozen Settings/API integration list.
- Provide Unix and native PowerShell adapters. Jcode-specific Windows quoting preserves backslashes, spaces, and apostrophes through Jcode's command parser.
- Preserve lifecycle source/sequence checks. A real-client test exposed early `--resume` reporting before process detection. The replacement now waits for verified process acquisition and is invalidated by newer reports, exit/respawn, or ownership changes.
- Retain the 18-transition lifecycle contract graph and shared shell-hook conformance checks, including source assertions and bounded collector I/O. Deterministic fake-client lifecycle checks now use a synthetic manifest, following current detection-test policy. Real screen compatibility was checked with actual Jcode clients.

Approved scope: https://github.com/herdrdev/herdr/discussions/1848#discussioncomment-17884398. Earlier screen evidence: https://github.com/herdrdev/herdr/discussions/2018.

Thanks to @przeqpiciel for the conflict-resolution and rebase work incorporated/adapted here.

## Jcode dependency

https://github.com/1jehuang/jcode/pull/758 is merged. The native composable-hook support is available from Jcode 0.68.0. Live checks below used Jcode 0.84.58-dev and the currently installed 0.84.62-dev.

## Validation on the refreshed branch

- `just ci`: **3,649 Rust tests passed, 6 skipped**, with formatting, Clippy, maintenance, architecture, and integration-asset checks passing.
- `just docs-contract-test`: 7 passed.
- Agent detection manifest/config-reference validators and `git diff --check` passed.
- Real Herdr CLI install/reinstall/status/uninstall checks preserved user string/array hooks and custom `JCODE_HOME`; invalid config failed without mutation.
- Real Jcode server started **outside Herdr**, with two actual Jcode clients connected through one isolated socket. Each pane acquired its own native ID and completed `agent prompt --wait` without cross-pane identity changes.
- Real `/clear` changed only the originating pane's ID. Native `--resume` restored the original ID and transcript. Stopping/restarting Herdr automatically restored three saved conversations with their names, native IDs, and live Jcode client titles.
- Prompt workflow checks used a local streaming model fixture, not a hosted provider. Herdr/Jcode processes, PTYs, hooks, sockets, persistence, and public CLI commands were real. All task-owned processes were cleaned up.

### Hosted validation on `68c3a4f7`

All current-head checks pass: Linux, macOS, Windows, Windows ConPTY packaging, Nix, distribution contracts and conventional commits. [CI run](https://github.com/herdrdev/herdr/actions/runs/35410828851).

Both CodeRabbit and Greptile completed review of this commit. Greptile reports 5/5 with no outstanding finding. CodeRabbit's valid malformed-config, private-file-permission and source-scoped resume findings are fixed and regression-tested. Its additional Windows module-gating comment is already covered by the enclosing `tests/cli.rs` crate-level Unix guard, with the explanation and passing native Windows job linked inline.

Native Windows tests now pass, including the PowerShell adapter tests. Full actual Jcode TUI acceptance was performed on Linux only. Local Windows cross-check was previously blocked by the absent SDK; hosted native Windows CI supplied the platform test evidence without local SDK license acceptance.

## Boundaries

- A newly cleared empty Jcode session has no durable transcript until a prompt saves it and cannot be cold-restored by native `--resume` before then. Saved conversations were verified across restart.
- The new detection manifest remains bundled with an exact unpublished-catalog exception because current stable clients cannot identify the new agent. Release maintainers must publish it and remove the exception before the first stable release containing Jcode.
- No release files, published documentation, frozen endpoint expectations, or unrelated branches are included.

