### PR TITLE
fix: recognize kitty CSI-u codepoints for F1 through F12

### DIFF
--- a/src/input/parse.rs
+++ b/src/input/parse.rs
@@ -262,6 +262,7 @@ fn kitty_codepoint_to_keycode(codepoint: u32) -> Option<KeyCode> {
         57361 => Some(KeyCode::PrintScreen),
         57362 => Some(KeyCode::Pause),
         57363 => Some(KeyCode::Menu),
+        57364..=57375 => Some(KeyCode::F((codepoint - 57364 + 1) as u8)),
         57376..=57398 => Some(KeyCode::F((codepoint - 57376 + 13) as u8)),
         57399 => Some(KeyCode::Char('0')),
         57400 => Some(KeyCode::Char('1')),
@@ -318,13 +319,8 @@ fn kitty_codepoint_to_keycode(codepoint: u32) -> Option<KeyCode> {
         57452 => Some(KeyCode::Modifier(ModifierKeyCode::RightMeta)),
         57453 => Some(KeyCode::Modifier(ModifierKeyCode::IsoLevel3Shift)),
         57454 => Some(KeyCode::Modifier(ModifierKeyCode::IsoLevel5Shift)),
-        value if is_kitty_functional_codepoint(value) => None,
         value => char::from_u32(value).map(KeyCode::Char),
     }
-}
-
-fn is_kitty_functional_codepoint(codepoint: u32) -> bool {
-    (57358..=57454).contains(&codepoint)
 }
 
 #[allow(dead_code)] // Reserved for the upcoming raw stdin parser.
@@ -851,8 +847,27 @@ mod tests {
     }
 
     #[test]
-    fn unknown_kitty_functional_key_remains_unsupported() {
-        assert!(parse_terminal_key_sequence("\x1b[57364;1u").is_none());
+    fn kitty_f1_through_f12_codepoints_are_recognized() {
+        let cases = [
+            ("\x1b[57364;1u", KeyCode::F(1)),
+            ("\x1b[57365;1u", KeyCode::F(2)),
+            ("\x1b[57366;1u", KeyCode::F(3)),
+            ("\x1b[57367;1u", KeyCode::F(4)),
+            ("\x1b[57368;1u", KeyCode::F(5)),
+            ("\x1b[57375;1u", KeyCode::F(12)),
+            ("\x1b[57376;1u", KeyCode::F(13)),
+        ];
+
+        for (sequence, code) in cases {
+            let parsed = parse_terminal_key_sequence(sequence).unwrap();
+            assert_terminal_key_eq(
+                parsed,
+                code,
+                KeyModifiers::empty(),
+                crossterm::event::KeyEventKind::Press,
+                None,
+            );
+        }
     }
 
     fn assert_fixture_corpus_parses(corpus: &str) {


### PR DESCRIPTION
## Summary

`kitty_codepoint_to_keycode` mapped codepoints for F13-F35 (57376-57398) but had no entries for F1-F12 (57364-57375), so those silently fell through to `None`. Terminals that send function keys as full kitty CSI-u sequences (e.g. Ghostty, which enables the kitty keyboard protocol by default) had F1-F12 dropped entirely.

## Reproduction

Confirmed live against a running herdr session: built the binary, started an isolated dev session with `previous_tab`/`next_tab` bound to F3/F4, and injected the raw byte sequences a kitty-protocol terminal sends for those keys (`\x1b[57366u` for F3, `\x1b[57367u` for F4) directly into the pane. Before the fix, both did nothing. After the fix, both correctly switched tabs.

I could not reproduce the exact asymmetry in #1809 (reporter says F2/F4 worked but F3 didn't) - in my testing the gap affects F1-F12 uniformly. This fix addresses the confirmed underlying gap either way.

## Tests

- `just lint`
- `just ci` (3066 tests, 0 failures)
- Added `kitty_f1_through_f12_codepoints_are_recognized`, replacing `unknown_kitty_functional_key_remains_unsupported` which had codified the gap as expected behavior

refs #1809