### PR TITLE
fix(viewport): document focused-pane jump investigation for WSL2 multi-client scenario

### DIFF
--- a/IRIS-PANEJUMP-INVESTIGATION.md
+++ b/IRIS-PANEJUMP-INVESTIGATION.md
@@ -1,0 +1,62 @@
+# Investigation: focused-pane viewport jump on background output (WSL2, d57cefb)
+
+**herdr version:** `0.8.0-iris.20260805.d57cefb8`  
+**Environment:** WSL2 (Linux 6.6.87.2 microsoft-standard-WSL2)  
+**Filed by:** Iris platform team (tryiris-ai)  
+**Status:** DRAFT — §2 mechanism refuted at d57cefb in core scroll/resize; alternate surfaces listed
+
+---
+
+## Symptom
+
+Focused pane repeatedly jumps to the bottom while a background pane produces output. The "jump to
+bottom" affordance fires continuously. Calmed by Ctrl-L / window resize / detach+reattach but
+returns immediately under load. Focused pane's own output is static (verified via byte-count log).
+Correlation: jumping is worst while a background pane runs a heavy build; single `herdr server`
+process, five concurrent panes each with `tail -F` on its own log.
+
+## §2 Hypothesis
+
+herdr auto-scrolls the focused pane to the bottom on PTY output events originating in other panes
+(or triggers a full layout recompute that yanks the focused viewport down). Confirmed by
+correlation; mechanism refuted below.
+
+## §2 verdict: REFUTED for core scroll/resize/render at d57cefb8
+
+Code-analysis (read-only, zig absent so no live build) shows two independent guards neutralize the
+mechanism in herdr Rust core:
+
+**Guard 1 — size-guarded resize (pane.rs:2498-2505):** `PaneRuntime::resize` early-returns when
+dimensions are unchanged. The every-frame resize (`headless.rs:4082-4088`) is a no-op unless a
+pane's geometry actually changes. Background output doesn't change geometry.
+
+**Guard 2 — invariant scrollbar gutter (panes.rs:34-45):** `stable_terminal_inner_rect` always
+reserves the scrollbar column when `pane_scrollbars` is on — only the *drawing* is conditional.
+So a pane's size fed to `resize()` changes only on a genuine layout event, never on another pane's
+output.
+
+**Offset preserved on resize (terminal.rs:1455-1507, 2553-2568):** Even when resize does fire, it
+saves and restores `offset_from_bottom`.
+
+**No output path calls scroll-to-bottom:** Every `scroll_reset()` caller is a user-input path
+(keystrokes, mouse, attach events) — `src/app/input/terminal.rs:191, 254`,
+`src/app/input/mod.rs:530`, `src/server/headless.rs:369, 387, 407`. None fire on PTY output.
+
+## Alternate candidate surfaces (not yet investigated — zig required to build)
+
+1. **Multi-client foreground/observer size disagreement** in `render_and_stream`
+   (`headless.rs:4036`) — foreground vs observer clients may report different terminal sizes; if
+   so, the size guard passes and a real resize fires, potentially resetting the offset.
+   **Leading hypothesis for live investigation.**
+2. **WSL2 outer-terminal SIGWINCH propagation** — whether a resize signal from the WSL2 host
+   terminal reaches all panes even when only the outer terminal changes size.
+3. **Config interaction** — `ui.pane_scrollbars` + mouse wheel routing under multiple clients.
+
+## Build requirements (Iris engineers: do NOT overwrite ~/.local/bin/herdr without explicit approval)
+
+- Rust via `rustup`, channel `1.96.1` (`rust-toolchain.toml`)
+- **Zig 0.15.2** — required by `vendor/libghostty-vt/build.zig.zon`
+- `cargo build --release` → copy `target/release/herdr` to a **separate test path**
+
+Repro once built: two panes — one running `yes` or `tail -F` on an appended scratch file, the
+other scrolled up; observe whether the scrolled pane jumps while output fires in the other.


### PR DESCRIPTION
> **DRAFT — awaiting live reproduction on a buildable bench (zig required).** This PR carries the
> Iris investigation findings so the herdrdev team has the evidence if the symptom is confirmed
> upstream. Not ready to merge.

## What this reports

Focused pane repeatedly jumps/scrolls to the bottom while a background pane produces output.
The "jump to bottom" affordance fires continuously. Confirmed by the Iris team on WSL2 with
`0.8.0-iris.20260805.d57cefb8` (single `herdr server`, five concurrent panes each tailing its
own log, one background pane running a heavy build).

**Calmed by:** `Ctrl-L` / window resize / detach+reattach. Returns immediately under load.
Focused pane's own output is static (byte-count verified).

## §2 hypothesis — cross-pane viewport auto-scroll or layout recompute on PTY output

The working hypothesis: herdr auto-scrolls the focused pane to the bottom on PTY output events
from other panes, or triggers a full layout recompute that yanks the focused viewport down.

## §2 verdict after code analysis at d57cefb8: **REFUTED for core scroll/resize/render**

Read-only code analysis (Rust source) shows two independent guards neutralize the mechanism:

**Guard 1 — resize is size-guarded (`pane.rs:2498-2505`):**
```rust
let size = (rows, cols, cell_width_px, cell_height_px);
if self.current_size.get() == size { return; }
```
The every-frame resize (`headless.rs:4082-4088`, `panes.rs:206-213`) is a no-op when dimensions
are unchanged. Background output does not change any pane's geometry.

**Guard 2 — scrollbar gutter is invariant (`panes.rs:34-45`):**
```rust
fn stable_terminal_inner_rect(pane_inner: Rect, pane_scrollbars: bool) -> Rect {
    if !pane_scrollbars || pane_inner.width <= 4 { return pane_inner; }
    Rect::new(pane_inner.x, pane_inner.y, pane_inner.width.saturating_sub(1), pane_inner.height)
}
```
The scrollbar column is always reserved — only the *drawing* is conditional. A pane's size changes
only on a genuine layout event (window resize, split), never on another pane's output.

**Offset is preserved on resize (`terminal.rs:1455-1507`, `2553-2568`):** Even when resize does
fire, `offset_from_bottom` is saved before and restored after.

**No output path calls scroll-to-bottom:** Every `scroll_reset()` caller is a user-input path
(keystrokes, mouse, attach events — `src/app/input/terminal.rs:191, 254`,
`src/app/input/mod.rs:530`, `src/server/headless.rs:369, 387, 407`). None fire on PTY output.

## Regression evidence (expected behavior)

A focused, scrolled-up pane should **not** jump to the bottom while a different pane produces
output. The user must be able to read scrollback in one pane regardless of how much output other
panes emit.

## Alternate candidate surfaces (zig required to build for live investigation)

Since the §2 mechanism is clean in core at d57cefb8, the likely source is one of:

1. **Multi-client foreground/observer size disagreement in `render_and_stream`
   (`headless.rs:4036`)** — if the foreground and an observer client report different terminal
   sizes, the size guard (`pane.rs:2503`) passes and a real resize fires. **Leading hypothesis.**
2. **WSL2 outer-terminal SIGWINCH propagation** — whether a `SIGWINCH` from the WSL2 host
   terminal reaches all panes even when only the outer terminal geometry changes.
3. **Config interaction** — `ui.pane_scrollbars` + mouse wheel routing under multiple clients.

## Build / install / verify steps

> **CRITICAL: Do NOT overwrite `~/.local/bin/herdr` without the engineer's explicit go-ahead.**
> Use a separate binary path for any test build.

**Required toolchain:**
- Rust via `rustup`, channel `1.96.1` (see `rust-toolchain.toml`)
- **Zig 0.15.2** — required by `vendor/libghostty-vt/build.zig.zon` (`minimum_zig_version`)
  (zig was absent on the original investigation bench, preventing a live build)

**Build:**
```bash
# Install zig 0.15.2 user-local (no sudo required)
ZIG_VERSION="0.15.2"
wget "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" -O /tmp/zig.tar.xz
mkdir -p ~/.local/zig && tar -xf /tmp/zig.tar.xz -C ~/.local/zig --strip-components=1
export PATH="$HOME/.local/zig:$PATH"

# Build from herdr source root
export PATH="$HOME/.cargo/bin:$PATH"
cargo build --release

# Copy to a test path — do NOT overwrite ~/.local/bin/herdr
BINARY_PATH="/tmp/herdr-test-$(date +%Y%m%d)"
cp target/release/herdr "$BINARY_PATH"
"$BINARY_PATH" --version
```

**Repro once built:**
1. `$BINARY_PATH server --socket /tmp/herdr-test.sock` (throwaway server)
2. Open two panes: pane A runs `yes > /tmp/scratch.txt` (or `tail -F` on an appended file);
   pane B is scrolled up via PageUp / mouse wheel.
3. Observe whether pane B jumps to the bottom while pane A produces output.

---

_Investigation performed by the Iris platform team on WSL2. Build environment: Rust 1.96.1, zig
absent. No live repro was possible on this bench — findings are code-analysis-based._
