### PR TITLE
fix(client): restore mouse capture after terminal resize

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1670,6 +1670,10 @@ async fn run_client_loop(
                 if let Err(e) = write_to_server(&mut write_stream, &msg) {
                     return Err(ClientError::ConnectionLost(e));
                 }
+                if state.mouse_capture_active {
+                    let sgr_pixels = host_sgr_pixels_active.load(Ordering::Acquire);
+                    set_mouse_capture(true, sgr_pixels).map_err(ClientError::ConnectionFailed)?;
+                }
             }
             ClientLoopEvent::ServerMessage(msg) => match msg {
                 ServerMessage::Frame(frame_data) => {


### PR DESCRIPTION
## Summary

- reapply active host mouse capture after the client terminal resizes
- preserve SGR pixel mouse reporting when restoring the mode

## Why

Some mobile terminals reset mouse reporting when the software keyboard changes the terminal size. Herdr continued to track mouse capture as enabled, so it did not emit the enable sequence again. Subsequent touch swipes could then arrive as arrow keys instead of mouse wheel events and move the agent input history.

Restoring the already-active mode after a resize keeps touch scrolling available without enabling mouse capture when it was disabled.

## Validation

- manually reproduced with Herdr v0.8.0 over SSH from Termius on iPhone
- verified that touch scrolling still works after hiding the software keyboard with the patched client
- `just check`

Refs #2815
