### PR TITLE
fix(input): apply Caps Lock when encoding pane keystrokes

### DIFF
--- a/src/input/encode.rs
+++ b/src/input/encode.rs
@@ -384,13 +384,36 @@ fn text_char_for_key(key: &TerminalKey) -> Option<char> {
         return None;
     };
 
-    if key.modifiers.is_empty() {
-        return Some(ch);
+    if !key.modifiers.is_empty() && key.modifiers != KeyModifiers::SHIFT {
+        return None;
     }
+
+    if let Some(letter) = apply_ascii_letter_case(ch, key) {
+        return Some(letter);
+    }
+
     if key.modifiers == KeyModifiers::SHIFT {
         return shifted_text_char(key, ch);
     }
-    None
+
+    Some(ch)
+}
+
+fn apply_ascii_letter_case(ch: char, key: &TerminalKey) -> Option<char> {
+    if !ch.is_ascii_alphabetic() {
+        return None;
+    }
+
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+    if !shift && !key.caps_lock {
+        return None;
+    }
+
+    Some(if shift ^ key.caps_lock {
+        ch.to_ascii_uppercase()
+    } else {
+        ch.to_ascii_lowercase()
+    })
 }
 
 fn shifted_text_char(key: &TerminalKey, ch: char) -> Option<char> {
@@ -494,7 +517,9 @@ fn encode_legacy_inner(key: TerminalKey) -> Vec<u8> {
                     _ => vec![ch as u8],
                 }
             } else {
-                let ch = if key.modifiers == KeyModifiers::SHIFT {
+                let ch = if let Some(letter) = apply_ascii_letter_case(ch, &key) {
+                    letter
+                } else if key.modifiers == KeyModifiers::SHIFT {
                     shifted_text_char(&key, ch).unwrap_or(ch)
                 } else {
                     ch
@@ -1181,5 +1206,40 @@ mod tests {
         let encoded = encode_terminal_key(key, KeyboardProtocol::Kitty { flags: 7 });
         assert!(!encoded.is_empty());
         assert_ne!(encoded, "测".as_bytes());
+    }
+
+    #[test]
+    fn caps_lock_uppercases_ascii_letter_in_legacy() {
+        let key = TerminalKey::new(KeyCode::Char('a'), KeyModifiers::empty()).with_caps_lock(true);
+        assert_eq!(encode_terminal_key(key, KeyboardProtocol::Legacy), b"A");
+    }
+
+    #[test]
+    fn caps_lock_uppercases_ascii_letter_in_kitty_disambiguate() {
+        let key = TerminalKey::new(KeyCode::Char('a'), KeyModifiers::empty()).with_caps_lock(true);
+        assert_eq!(
+            encode_terminal_key(key, KeyboardProtocol::Kitty { flags: 1 }),
+            b"A"
+        );
+    }
+
+    #[test]
+    fn caps_lock_xor_shift_lowercases_ascii_letter_in_legacy() {
+        let key = TerminalKey::new(KeyCode::Char('A'), KeyModifiers::SHIFT).with_caps_lock(true);
+        assert_eq!(encode_terminal_key(key, KeyboardProtocol::Legacy), b"a");
+    }
+
+    #[test]
+    fn caps_lock_does_not_shift_digits_in_legacy() {
+        let key = TerminalKey::new(KeyCode::Char('1'), KeyModifiers::empty()).with_caps_lock(true);
+        assert_eq!(encode_terminal_key(key, KeyboardProtocol::Legacy), b"1");
+    }
+
+    #[test]
+    fn parse_kitty_caps_lock_letter_encodes_uppercase() {
+        let key = parse_terminal_key_sequence("\x1b[97;65u").expect("caps lock CSI-u should parse");
+        assert_eq!(key.code, KeyCode::Char('a'));
+        assert!(key.caps_lock);
+        assert_eq!(encode_terminal_key(key, KeyboardProtocol::Legacy), b"A");
     }
 }

--- a/src/input/model.rs
+++ b/src/input/model.rs
@@ -1,6 +1,6 @@
 #[cfg(not(windows))]
 use crossterm::event::KeyboardEnhancementFlags;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventState, KeyModifiers};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,6 +73,7 @@ pub struct TerminalKey {
     pub repeat_count: u16,
     pub shifted_codepoint: Option<u32>,
     pub generated_text: Option<String>,
+    pub caps_lock: bool,
     source: KeySource,
 }
 
@@ -85,8 +86,14 @@ impl TerminalKey {
             repeat_count: 1,
             shifted_codepoint: None,
             generated_text: None,
+            caps_lock: false,
             source: KeySource::Synthesized,
         }
+    }
+
+    pub fn with_caps_lock(mut self, caps_lock: bool) -> Self {
+        self.caps_lock = caps_lock;
+        self
     }
 
     pub fn with_kind(mut self, kind: crossterm::event::KeyEventKind) -> Self {
@@ -203,13 +210,19 @@ impl TerminalKey {
     }
 
     pub fn as_key_event(&self) -> KeyEvent {
-        KeyEvent::new_with_kind(self.code, self.modifiers, self.kind)
+        let mut event = KeyEvent::new_with_kind(self.code, self.modifiers, self.kind);
+        if self.caps_lock {
+            event.state |= KeyEventState::CAPS_LOCK;
+        }
+        event
     }
 }
 
 impl From<KeyEvent> for TerminalKey {
     fn from(value: KeyEvent) -> Self {
-        Self::new(value.code, value.modifiers).with_kind(value.kind)
+        Self::new(value.code, value.modifiers)
+            .with_kind(value.kind)
+            .with_caps_lock(value.state.contains(KeyEventState::CAPS_LOCK))
     }
 }
 

--- a/src/input/parse.rs
+++ b/src/input/parse.rs
@@ -49,7 +49,8 @@ fn parse_kitty_key_sequence(data: &str) -> Option<TerminalKey> {
         modifiers |= KeyModifiers::SHIFT;
     }
 
-    let mut key = TerminalKey::new(code, modifiers).with_kind(kind);
+    let mut key =
+        apply_kitty_caps_lock(TerminalKey::new(code, modifiers).with_kind(kind), modifier);
     if let Some(shifted_codepoint) = shifted_codepoint {
         key = key.with_shifted_codepoint(shifted_codepoint);
     }
@@ -75,9 +76,12 @@ fn parse_modify_other_keys_sequence(data: &str) -> Option<TerminalKey> {
     let modifier = modifier_part.parse::<u8>().ok()?.checked_sub(1)?;
     let codepoint = codepoint_part.parse::<u32>().ok()?;
 
-    Some(TerminalKey::new(
-        kitty_codepoint_to_keycode(codepoint)?,
-        key_modifiers_from_u8(modifier),
+    Some(apply_kitty_caps_lock(
+        TerminalKey::new(
+            kitty_codepoint_to_keycode(codepoint)?,
+            key_modifiers_from_u8(modifier),
+        ),
+        modifier,
     ))
 }
 
@@ -218,10 +222,11 @@ fn parse_xterm_modified_special_sequence(data: &str) -> Option<TerminalKey> {
                 'S' => KeyCode::F(4),
                 _ => return None,
             };
-            return Some(
+            return Some(apply_kitty_caps_lock(
                 TerminalKey::new(code, key_modifiers_from_u8(mod_value))
                     .with_kind(parse_kitty_event_type(event_type)?),
-            );
+                mod_value,
+            ));
         }
     }
 
@@ -244,10 +249,11 @@ fn parse_xterm_modified_special_sequence(data: &str) -> Option<TerminalKey> {
         "24" => KeyCode::F(12),
         _ => return None,
     };
-    Some(
+    Some(apply_kitty_caps_lock(
         TerminalKey::new(code, key_modifiers_from_u8(mod_value))
             .with_kind(parse_kitty_event_type(event_type)?),
-    )
+        mod_value,
+    ))
 }
 
 fn split_modifier_and_event(input: &str) -> (&str, Option<&str>) {
@@ -367,6 +373,14 @@ fn key_modifiers_from_u8(modifier: u8) -> KeyModifiers {
         mods |= KeyModifiers::META;
     }
     mods
+}
+
+fn apply_kitty_caps_lock(key: TerminalKey, modifier: u8) -> TerminalKey {
+    if modifier & 0b0100_0000 != 0 {
+        key.with_caps_lock(true)
+    } else {
+        key
+    }
 }
 
 #[cfg(test)]
@@ -684,6 +698,15 @@ mod tests {
             None,
         );
         assert_eq!(key.generated_text.as_deref(), Some("😀"));
+    }
+
+    #[test]
+    fn parse_kitty_caps_lock_letter_sets_lock_flag() {
+        let key = parse_terminal_key_sequence("\x1b[97;65u").expect("caps lock CSI-u should parse");
+        assert_eq!(key.code, KeyCode::Char('a'));
+        assert_eq!(key.modifiers, KeyModifiers::empty());
+        assert!(key.caps_lock);
+        assert_eq!(encode_terminal_key(key, KeyboardProtocol::Legacy), b"A");
     }
 
     #[test]


### PR DESCRIPTION
## Bug

With Caps Lock on, letters typed in a pane stay lowercase. Shift still produces uppercase. Seen on Linux + Alacritty with Herdr 0.8.0 (stable).

Kitty reports Caps Lock as modifier bit 6 (`1 + 64 = 65` in CSI-u). Parse kept Shift/Alt/Ctrl/Super/Hyper/Meta and dropped that bit. Encode then treated `a` as unmodified text.

## Fix

- Store Caps Lock on `TerminalKey` instead of folding it into Shift.
- Preserve Kitty bit 6 and crossterm `KeyEventState::CAPS_LOCK`.
- When encoding ASCII letters, apply Caps XOR Shift. Digits and punctuation are unchanged (`1` stays `1`).

The Caps Lock key itself is still not forwarded into the pane; only later letters carry the lock. That matches how lock keys are handled today.

## Tests

`cargo test --locked --bin herdr caps_lock` — 6 passed.

Verified after installing the patched binary: Caps+`a` → `A`, Caps+Shift+`a` → `a`, Caps+`1` → `1`.

I do not think public docs need a change; this is existing Caps Lock behavior that was dropped on the way into the pane.