### PR TITLE
fix: retract withdrawn update notices

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Experimental pane graphics now support bounded named layers, acknowledged full-RGBA primary-layer direct file frames on audited local terminals, owned BGRA fallback, exact pixel mouse input, and placement-only resize replay.
 
 ### Fixed
+- Withdrawn releases no longer leave a permanent update badge; successful periodic checks now retract stale notices while preserving other release notes. (#2964)
 - High-rate output from many hidden panes no longer floods the server loop with redundant wakeups, and terminal input-mode synchronization no longer formats pane scrollback to read one keyboard flag.
 - Chinese IME commits now reach panes on macOS when the focused application requests printable key-release events. (#2924)
 - Windows now recognizes `Ctrl+1` through `Ctrl+9` keybindings instead of decoding those key records as control characters. (#2910)

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2743,6 +2743,16 @@ impl AppState {
                 }
                 Vec::new()
             }
+            AppEvent::UpdateUnavailable {
+                version,
+                release_notes_available,
+            } => {
+                if self.update_available.as_deref() == Some(version.as_str()) {
+                    self.update_available = None;
+                    self.latest_release_notes_available = release_notes_available;
+                }
+                Vec::new()
+            }
             AppEvent::AgentDetectionManifestsUpdated { updated, status } => {
                 self.agent_manifest_update_status = status;
                 self.refresh_agent_manifest_summaries();
@@ -5721,6 +5731,29 @@ mod tests {
         assert!(active_tab_suppresses_notifications(true, Some(true)));
         assert!(!active_tab_suppresses_notifications(true, Some(false)));
         assert!(!active_tab_suppresses_notifications(false, None));
+    }
+
+    #[test]
+    fn update_unavailable_clears_only_the_pending_update() {
+        let mut state = AppState::test_new();
+        state.update_available = Some("0.8.1".into());
+        state.latest_release_notes_available = true;
+
+        state.handle_app_event(AppEvent::UpdateUnavailable {
+            version: "0.8.1".into(),
+            release_notes_available: true,
+        });
+
+        assert_eq!(state.update_available, None);
+        assert!(state.latest_release_notes_available);
+
+        state.update_available = Some("0.8.2".into());
+        state.handle_app_event(AppEvent::UpdateUnavailable {
+            version: "0.8.1".into(),
+            release_notes_available: false,
+        });
+        assert_eq!(state.update_available.as_deref(), Some("0.8.2"));
+        assert!(state.latest_release_notes_available);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -722,7 +722,8 @@ impl App {
             background_update_check_enabled(no_session, config.update.manifest_check);
         if version_check_enabled {
             let update_tx = event_tx.clone();
-            std::thread::spawn(move || crate::update::auto_update(update_tx));
+            let announced_version = state.update_available.clone();
+            std::thread::spawn(move || crate::update::auto_update(update_tx, announced_version));
         }
         if manifest_check_enabled {
             let manifest_update_tx = event_tx.clone();
@@ -837,11 +838,7 @@ impl App {
         app.state.installed_plugins = load_plugin_registry(app.no_session);
         let now = Instant::now();
         if background_update_check_enabled(app.no_session, app.update_version_check_enabled) {
-            app.next_auto_update_check = app
-                .state
-                .update_available
-                .is_none()
-                .then_some(now + AUTO_UPDATE_CHECK_INTERVAL);
+            app.next_auto_update_check = Some(now + AUTO_UPDATE_CHECK_INTERVAL);
         }
         if background_update_check_enabled(app.no_session, app.update_manifest_check_enabled) {
             app.next_agent_manifest_update_check = Some(now + AUTO_UPDATE_CHECK_INTERVAL);
@@ -1572,7 +1569,6 @@ impl App {
                     self.no_session,
                     self.update_version_check_enabled,
                 )
-                && self.state.update_available.is_none()
             {
                 self.next_auto_update_check = Some(now);
             }

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -556,18 +556,11 @@ impl App {
             return;
         }
 
-        self.next_auto_update_check = self
-            .state
-            .update_available
-            .is_none()
-            .then_some(Instant::now() + AUTO_UPDATE_CHECK_INTERVAL);
-
-        if self.state.update_available.is_some() {
-            return;
-        }
+        self.next_auto_update_check = Some(Instant::now() + AUTO_UPDATE_CHECK_INTERVAL);
 
         let update_tx = self.event_tx.clone();
-        std::thread::spawn(move || crate::update::auto_update(update_tx));
+        let announced_version = self.state.update_available.clone();
+        std::thread::spawn(move || crate::update::auto_update(update_tx, announced_version));
     }
 
     pub(crate) fn run_agent_manifest_update_check(&mut self) {

--- a/src/events.rs
+++ b/src/events.rs
@@ -125,6 +125,11 @@ pub enum AppEvent {
         version: String,
         install_command: String,
     },
+    /// The previously announced version is no longer available.
+    UpdateUnavailable {
+        version: String,
+        release_notes_available: bool,
+    },
     /// Remote agent detection manifest update check finished.
     AgentDetectionManifestsUpdated {
         updated: Vec<crate::detect::manifest_update::ManifestUpdateCommit>,

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -107,6 +107,21 @@ pub fn mark_current_version_seen() -> std::io::Result<()> {
     mark_current_version_seen_at(&pending_path(), &crate::build_info::version())
 }
 
+pub fn clear_pending_version(version: &str) -> std::io::Result<bool> {
+    clear_pending_version_at(&pending_path(), version)
+}
+
+fn clear_pending_version_at(path: &Path, version: &str) -> std::io::Result<bool> {
+    let Some(stored) = load_stored_from_path(path) else {
+        return Ok(false);
+    };
+    if stored.version != version {
+        return Ok(true);
+    }
+    clear_pending_at(path)?;
+    Ok(false)
+}
+
 fn mark_current_version_seen_at(path: &Path, current_version: &str) -> std::io::Result<()> {
     let Some(mut stored) = load_stored_from_path(path) else {
         return Ok(());
@@ -225,6 +240,25 @@ mod tests {
         assert!(!notes.preview);
 
         clear_pending_at(&path).unwrap();
+    }
+
+    #[test]
+    fn clearing_pending_version_removes_only_matching_notes() {
+        let path = std::env::temp_dir().join(format!(
+            "herdr-release-notes-{}-{}",
+            std::process::id(),
+            "clear-version"
+        ));
+        let _ = clear_pending_at(&path);
+        save_pending_to_path(&path, "0.3.1", "### Changed\n- One").unwrap();
+
+        assert!(clear_pending_version_at(&path, "0.3.2").unwrap());
+        assert_eq!(
+            load_stored_from_path(&path).map(|notes| notes.version),
+            Some("0.3.1".to_string())
+        );
+        assert!(!clear_pending_version_at(&path, "0.3.1").unwrap());
+        assert!(!path.exists());
     }
 
     #[test]

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -35,19 +35,43 @@ pub fn save_pending(version: &str, body: &str) -> std::io::Result<()> {
 }
 
 fn save_pending_to_path(path: &Path, version: &str, body: &str) -> std::io::Result<()> {
-    let body = normalize_body(body);
-    if body.is_empty() {
-        return clear_pending_at(path);
-    }
+    with_pending_lock(path, || {
+        let body = normalize_body(body);
+        if body.is_empty() {
+            return clear_pending_at(path);
+        }
 
-    write_stored_to_path(
-        path,
-        &StoredReleaseNotes {
-            version: version.to_string(),
-            body,
-            show_on_startup: true,
-        },
-    )
+        write_stored_to_path(
+            path,
+            &StoredReleaseNotes {
+                version: version.to_string(),
+                body,
+                show_on_startup: true,
+            },
+        )
+    })
+}
+
+fn pending_lock_path(path: &Path) -> PathBuf {
+    path.with_extension("lock")
+}
+
+fn with_pending_lock<T>(
+    path: &Path,
+    operation: impl FnOnce() -> std::io::Result<T>,
+) -> std::io::Result<T> {
+    let lock_path = pending_lock_path(path);
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(lock_path)?;
+    lock.lock()?;
+    operation()
 }
 
 fn write_stored_to_path(path: &Path, stored: &StoredReleaseNotes) -> std::io::Result<()> {
@@ -112,25 +136,29 @@ pub fn clear_pending_version(version: &str) -> std::io::Result<bool> {
 }
 
 fn clear_pending_version_at(path: &Path, version: &str) -> std::io::Result<bool> {
-    let Some(stored) = load_stored_from_path(path) else {
-        return Ok(false);
-    };
-    if stored.version != version {
-        return Ok(true);
-    }
-    clear_pending_at(path)?;
-    Ok(false)
+    with_pending_lock(path, || {
+        let Some(stored) = load_stored_from_path(path) else {
+            return Ok(false);
+        };
+        if stored.version != version {
+            return Ok(true);
+        }
+        clear_pending_at(path)?;
+        Ok(false)
+    })
 }
 
 fn mark_current_version_seen_at(path: &Path, current_version: &str) -> std::io::Result<()> {
-    let Some(mut stored) = load_stored_from_path(path) else {
-        return Ok(());
-    };
-    if stored.version != current_version || !stored.show_on_startup {
-        return Ok(());
-    }
-    stored.show_on_startup = false;
-    write_stored_to_path(path, &stored)
+    with_pending_lock(path, || {
+        let Some(mut stored) = load_stored_from_path(path) else {
+            return Ok(());
+        };
+        if stored.version != current_version || !stored.show_on_startup {
+            return Ok(());
+        }
+        stored.show_on_startup = false;
+        write_stored_to_path(path, &stored)
+    })
 }
 
 fn clear_pending_at(path: &Path) -> std::io::Result<()> {
@@ -259,6 +287,50 @@ mod tests {
         );
         assert!(!clear_pending_version_at(&path, "0.3.1").unwrap());
         assert!(!path.exists());
+    }
+
+    #[test]
+    fn locked_clear_preserves_a_newer_replacement() {
+        let path = std::env::temp_dir().join(format!(
+            "herdr-release-notes-{}-{}",
+            std::process::id(),
+            "clear-race"
+        ));
+        let _ = clear_pending_at(&path);
+        save_pending_to_path(&path, "0.3.1", "### Changed\n- One").unwrap();
+
+        let lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(pending_lock_path(&path))
+            .unwrap();
+        lock.lock().unwrap();
+        let thread_path = path.clone();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let clear = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            clear_pending_version_at(&thread_path, "0.3.1")
+        });
+        started_rx.recv().unwrap();
+        write_stored_to_path(
+            &path,
+            &StoredReleaseNotes {
+                version: "0.3.2".to_string(),
+                body: "### Changed\n- Two".to_string(),
+                show_on_startup: true,
+            },
+        )
+        .unwrap();
+        drop(lock);
+
+        assert!(clear.join().unwrap().unwrap());
+        assert_eq!(
+            load_stored_from_path(&path).map(|notes| notes.version),
+            Some("0.3.2".to_string())
+        );
+
+        clear_pending_at(&path).unwrap();
+        fs::remove_file(pending_lock_path(&path)).unwrap();
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -2199,12 +2199,15 @@ fn print_outdated_integration_notice_with_updated_binary(updated_exe: &Path) {
 }
 
 /// Background update check: only surface availability and release notes.
-/// Runs in a background thread at startup.
-pub fn auto_update(events: tokio::sync::mpsc::Sender<crate::events::AppEvent>) {
+/// Runs in a background thread at startup and on the periodic update schedule.
+pub fn auto_update(
+    events: tokio::sync::mpsc::Sender<crate::events::AppEvent>,
+    announced_version: Option<String>,
+) {
     crate::logging::update_check_started();
     if let Ok(version) = env::var(FAKE_UPDATE_VERSION_ENV) {
         let version = version.trim();
-        if !version.is_empty() {
+        if !version.is_empty() && announced_version.as_deref() != Some(version) {
             tracing::info!(
                 env = FAKE_UPDATE_VERSION_ENV,
                 version,
@@ -2231,7 +2234,7 @@ pub fn auto_update(events: tokio::sync::mpsc::Sender<crate::events::AppEvent>) {
             );
             return;
         }
-        auto_update_homebrew(events);
+        auto_update_homebrew(events, announced_version.as_deref());
         return;
     }
 
@@ -2247,13 +2250,19 @@ pub fn auto_update(events: tokio::sync::mpsc::Sender<crate::events::AppEvent>) {
     }
 
     let release = match check_latest() {
-        Ok(Some(r)) => r,
-        Ok(None) => return,
+        Ok(Some(release)) => release,
+        Ok(None) => {
+            retract_announced_update(&events, announced_version.as_deref());
+            return;
+        }
         Err(err) => {
             crate::logging::update_check_failed(&err);
             return;
         }
     };
+    if announced_version.as_deref() == Some(release.label()) {
+        return;
+    }
 
     crate::logging::update_available(release.label());
     tracing::info!(
@@ -2271,26 +2280,35 @@ pub fn auto_update(events: tokio::sync::mpsc::Sender<crate::events::AppEvent>) {
         release.label()
     );
 
-    // Notify the TUI — blocking_send is safe from a std::thread
     let _ = events.blocking_send(crate::events::AppEvent::UpdateReady {
         version: release.label().to_string(),
         install_command: update_install_command().to_string(),
     });
 }
 
-fn auto_update_homebrew(events: tokio::sync::mpsc::Sender<crate::events::AppEvent>) {
+fn auto_update_homebrew(
+    events: tokio::sync::mpsc::Sender<crate::events::AppEvent>,
+    announced_version: Option<&str>,
+) {
     let version = match check_homebrew_latest() {
         Ok(Some(version)) => version,
-        Ok(None) => return,
+        Ok(None) => {
+            retract_announced_update(&events, announced_version);
+            return;
+        }
         Err(err) => {
             crate::logging::update_check_failed(&err);
             return;
         }
     };
+    let version_label = version.to_string();
+    if announced_version == Some(version_label.as_str()) {
+        return;
+    }
 
-    crate::logging::update_available(&version.to_string());
+    crate::logging::update_available(&version_label);
     let notes_body = homebrew_release_notes_body(&version);
-    if let Err(e) = crate::release_notes::save_pending(&version.to_string(), &notes_body) {
+    if let Err(e) = crate::release_notes::save_pending(&version_label, &notes_body) {
         tracing::warn!("failed to save pending release notes: {e}");
     }
 
@@ -2300,8 +2318,28 @@ fn auto_update_homebrew(events: tokio::sync::mpsc::Sender<crate::events::AppEven
     );
 
     let _ = events.blocking_send(crate::events::AppEvent::UpdateReady {
-        version: version.to_string(),
+        version: version_label,
         install_command: HOMEBREW_UPDATE_COMMAND.to_string(),
+    });
+}
+
+fn retract_announced_update(
+    events: &tokio::sync::mpsc::Sender<crate::events::AppEvent>,
+    announced_version: Option<&str>,
+) {
+    let Some(version) = announced_version else {
+        return;
+    };
+    let release_notes_available = match crate::release_notes::clear_pending_version(version) {
+        Ok(available) => available,
+        Err(err) => {
+            tracing::warn!(version, "failed to clear withdrawn update notes: {err}");
+            return;
+        }
+    };
+    let _ = events.blocking_send(crate::events::AppEvent::UpdateUnavailable {
+        version: version.to_string(),
+        release_notes_available,
     });
 }
 
@@ -2483,6 +2521,50 @@ mod tests {
         assert_eq!(Version::parse("1.2"), None);
         assert_eq!(Version::parse("abc"), None);
         assert_eq!(Version::parse(""), None);
+    }
+
+    #[test]
+    fn unchanged_fake_update_does_not_repeat_notification() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = std::env::var_os(FAKE_UPDATE_VERSION_ENV);
+        std::env::set_var(FAKE_UPDATE_VERSION_ENV, "9.9.9");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        auto_update(tx, Some("9.9.9".to_string()));
+
+        assert!(rx.try_recv().is_err());
+        if let Some(previous) = previous {
+            std::env::set_var(FAKE_UPDATE_VERSION_ENV, previous);
+        } else {
+            std::env::remove_var(FAKE_UPDATE_VERSION_ENV);
+        }
+    }
+
+    #[test]
+    fn retracted_update_clears_matching_notes_and_emits_unavailable() {
+        let _guard = env_lock().lock().unwrap();
+        let previous_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let config_home = set_test_config_home("retracted-update");
+        crate::release_notes::save_pending("9.9.9", "### Changed\n- Withdrawn").unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        retract_announced_update(&tx, Some("9.9.9"));
+
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(crate::events::AppEvent::UpdateUnavailable {
+                version,
+                release_notes_available: false
+            }) if version == "9.9.9"
+        ));
+        assert!(!crate::release_notes::pending_path().exists());
+
+        let _ = fs::remove_dir_all(config_home);
+        if let Some(previous) = previous_config_home {
+            std::env::set_var("XDG_CONFIG_HOME", previous);
+        } else {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## summary

- keep periodic update checks active after an update is announced
- retract only the matching badge and cached notes after a successful no-update result
- preserve historical notes, newer replacement notices, and state during failed checks
- suppress repeated notifications for an unchanged update

refs #2964

## validation

- `just check`
- release-build disposable session reproduction against the live stable manifest
- preflight contract and regression review