### PR TITLE
fix(attach): honour ui.mouse_capture in terminal attach

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -341,11 +341,13 @@ fn setup_terminal(mouse_capture: bool) -> io::Result<TerminalGuard> {
 
 /// Sets up a direct attach terminal.
 ///
-/// Direct attach forwards stdin to the attached PTY. It enables mouse capture
-/// so wheel events can drive the attached viewport or be forwarded to child
-/// programs that requested mouse input.
-fn setup_direct_attach_terminal() -> io::Result<TerminalGuard> {
-    setup_terminal_with_capabilities(false, true)
+/// Direct attach forwards stdin to the attached PTY. Mouse capture lets wheel
+/// events drive the attached viewport and reach child programs that asked for
+/// mouse input, but it also takes click-drag away from the host terminal's own
+/// selection. `ui.mouse_capture` is the existing knob for that trade-off, so
+/// honour it here instead of forcing capture on for every attach.
+fn setup_direct_attach_terminal(mouse_capture: bool) -> io::Result<TerminalGuard> {
+    setup_terminal_with_capabilities(false, mouse_capture)
 }
 
 fn setup_terminal_with_capabilities(
@@ -1192,7 +1194,7 @@ fn run_client_with_mode(
     // so we don't leave the terminal in raw mode if the server rejects us.
     let direct_attach = attach_escape.is_some();
     let terminal_guard = if direct_attach {
-        setup_direct_attach_terminal()
+        setup_direct_attach_terminal(mouse_capture)
     } else {
         setup_terminal(mouse_capture)
     }


### PR DESCRIPTION
## What

`herdr terminal attach` forces mouse capture on regardless of `ui.mouse_capture`.

`setup_direct_attach_terminal()` calls `setup_terminal_with_capabilities(false, true)` with the capture argument hardcoded, so the config option reaches every other client path but not this one.

## Why it matters

Capture is a straight either/or: once any mouse tracking mode is set, the terminal hands events to the application instead of selecting, so whoever holds the mouse owns both gestures. The attach client takes the mouse but implements only part of what it displaces — `AttachInputAction` is `Forward | Scroll | Detach | None`, with no selection anywhere.

The result is that in an attach window, click-drag does nothing at all: the host terminal has stopped selecting because capture is on, and nothing in the client has taken over the gesture. Setting `ui.mouse_capture = false` looks like the documented way to get host selection back, and it is silently ignored here.

## Repro

```
ui.mouse_capture = false
```

`herdr terminal attach <term>`, then click-drag over the pane. No selection appears. The same drag in any other herdr window selects normally.

## The change

Thread the existing config value through instead of hardcoding `true`. 8 insertions, 6 deletions, one file. Default behaviour is unchanged for anyone who has not set the option, since `mouse_capture` defaults to true.