### PR TITLE
fix(attach): stop the wheel typing cursor keys into the pane

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -378,6 +378,14 @@ fn setup_terminal_with_capabilities(
             set_mouse_capture(true)?;
         } else {
             set_mouse_capture(false)?;
+            // With no mouse mode set, ghostty and xterm translate the wheel
+            // into cursor keys on the alternate screen (DECSET 1007, on by
+            // default). Direct attach is always on the alternate screen, so
+            // every notch arrives as Up/Down and gets forwarded verbatim:
+            // scrolling types arrow keys at whatever is running in the pane.
+            // Nothing here consumes them, so turn the translation off.
+            io::stdout().write_all(b"\x1b[?1007l")?;
+            io::stdout().flush()?;
         }
     }
 
@@ -416,6 +424,7 @@ fn setup_terminal_with_capabilities(
     Ok(TerminalGuard {
         reset_modify_other_keys: modify_other_keys_mode.is_some(),
         reset_host_color_scheme_reports: host_color_scheme_reports,
+        reset_alternate_scroll: !enable_client_protocols && !mouse_capture,
         #[cfg(windows)]
         restore_windows_input_mode: windows_virtual_terminal_input.restore_mode,
     })
@@ -429,6 +438,7 @@ fn should_enable_host_color_scheme_reports(enable_client_protocols: bool) -> boo
 struct TerminalGuard {
     reset_modify_other_keys: bool,
     reset_host_color_scheme_reports: bool,
+    reset_alternate_scroll: bool,
     #[cfg(windows)]
     restore_windows_input_mode: Option<u32>,
 }
@@ -649,6 +659,11 @@ fn disable_windows_win32_input_mode(writer: &mut impl std::io::Write) -> io::Res
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
+        if self.reset_alternate_scroll {
+            let mut out = io::stdout();
+            let _ = out.write_all(b"\x1b[?1007h");
+            let _ = out.flush();
+        }
         restore_terminal_state(
             self.reset_modify_other_keys,
             self.reset_host_color_scheme_reports,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -341,11 +341,13 @@ fn setup_terminal(mouse_capture: bool) -> io::Result<TerminalGuard> {
 
 /// Sets up a direct attach terminal.
 ///
-/// Direct attach forwards stdin to the attached PTY. It enables mouse capture
-/// so wheel events can drive the attached viewport or be forwarded to child
-/// programs that requested mouse input.
-fn setup_direct_attach_terminal() -> io::Result<TerminalGuard> {
-    setup_terminal_with_capabilities(false, true)
+/// Direct attach forwards stdin to the attached PTY. Mouse capture lets wheel
+/// events drive the attached viewport and reach child programs that asked for
+/// mouse input, but it also takes click-drag away from the host terminal's own
+/// selection. `ui.mouse_capture` is the existing knob for that trade-off, so
+/// honour it here instead of forcing capture on for every attach.
+fn setup_direct_attach_terminal(mouse_capture: bool) -> io::Result<TerminalGuard> {
+    setup_terminal_with_capabilities(false, mouse_capture)
 }
 
 fn setup_terminal_with_capabilities(
@@ -1192,7 +1194,7 @@ fn run_client_with_mode(
     // so we don't leave the terminal in raw mode if the server rejects us.
     let direct_attach = attach_escape.is_some();
     let terminal_guard = if direct_attach {
-        setup_direct_attach_terminal()
+        setup_direct_attach_terminal(mouse_capture)
     } else {
         setup_terminal(mouse_capture)
     }


### PR DESCRIPTION
## What

With mouse capture off, scrolling the wheel in a `terminal attach` window types arrow keys into whatever is running in the pane.

## Why

With no mouse mode set, ghostty and xterm translate the wheel into cursor keys on the alternate screen — DECSET 1007, alternate scroll, on by default. Direct attach is always on the alternate screen, so every wheel notch arrives at the client as `Up`/`Down` and is forwarded verbatim. Nothing in the attach path consumes them.

So the wheel does not scroll; it presses arrow keys. In a shell that walks history, in vim it moves the cursor, and in an agent TUI it does whatever Up does there.

## Repro

Needs #2990 (or `ui.mouse_capture` left at its default and capture disabled another way), since capture masks the translation.

```
ui.mouse_capture = false
```

Attach to a pane running `cat -v`, scroll the wheel. Each notch prints `^[[A` / `^[[B`. Measured: twenty notches produce twenty literal escape sequences in the pane.

## The change

Turn alternate scroll off for the lifetime of the attach — `ESC[?1007l` at setup — and restore it in `TerminalGuard::drop`, which is where the other terminal-mode restores already live. The guard gains one bool tracking whether we actually changed it, so an attach that did not touch the mode does not restore something it never set.

Only applies when the client is not enabling its own protocols and capture is off, i.e. exactly the case where the translation would otherwise reach us.

15 insertions, one file.

## Verifying

Two assertions, both against a pane running `cat -v`. A bare `ESC[A` typed by the wheel must not reach the pane; a real arrow key press, which ghostty sends Kitty-encoded as `ESC[1;1:1A`, must still arrive as `ESC[A`. The second is what stops this from being a fix that also breaks the arrow keys.