### PR TITLE
fix: bind omp lifecycle reports to the pane's agent process

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Claude Code panes now use visible turn, background shell, and background agent activity as working-state fallbacks when OSC titles are unavailable or disabled. (#1630, #2241)
 - Tab bar status commands now remove ESC-prefixed terminal control sequences instead of displaying their sequence bodies as text. (#3001)
 - Unix plugin pane commands now default `PWD` to their resolved working directory, so direct popup tools open at explicit `--cwd` paths while preserving caller-provided `PWD` values. (#2984)
+- A nested Oh My Pi session started inside a pane can no longer take over that pane's agent lifecycle authority, so `herdr agent wait` stops returning a child session's idle while the pane's own agent is still working. (#2851)
+- Standalone `herdr agent wait` now reports the status it actually observed on the pane, instead of substituting a status seen in an earlier event that the pane had already left. (#2851)
+- The Oh My Pi hook no longer reports idle when a turn ends with an automatic continuation already scheduled. (#2851)
 
 ## [0.8.2] - 2026-08-19
 

--- a/src/api/schema/panes.rs
+++ b/src/api/schema/panes.rs
@@ -378,6 +378,10 @@ pub struct PaneReportAgentParams {
     pub agent_session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_session_path: Option<String>,
+    /// Filled in server-side from the accepted connection, never from payloads.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub reporter_process_id: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
@@ -393,6 +397,10 @@ pub struct PaneReportAgentSessionParams {
     pub agent_session_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_start_source: Option<String>,
+    /// Filled in server-side from the accepted connection, never from payloads.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub reporter_process_id: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -170,6 +170,11 @@ fn handle_connection_with_stop(
         debug!(err = %err, "api connection write timeout unavailable");
     }
 
+    // Read the peer identity while the connection is fresh. Darwin invalidates
+    // it once the peer closes, and lifecycle reporters use one short-lived
+    // connection per report.
+    let reporter_process_id = crate::ipc::local_stream_peer_process_id(&stream);
+
     let Some(line) = read_initial_request_line(&mut stream)? else {
         return Ok(());
     };
@@ -179,7 +184,7 @@ fn handle_connection_with_stop(
         return Ok(());
     }
 
-    let request = match serde_json::from_str::<Request>(line) {
+    let mut request = match serde_json::from_str::<Request>(line) {
         Ok(request) => request,
         Err(request_error) => {
             write_json_line_allow_disconnect(
@@ -195,6 +200,14 @@ fn handle_connection_with_stop(
             return Ok(());
         }
     };
+
+    // Lifecycle reports carry no trustworthy owner field, so the server stamps
+    // the accepted connection's process identity onto them. See issue #2851.
+    match &mut request.method {
+        Method::PaneReportAgent(params) => params.reporter_process_id = reporter_process_id,
+        Method::PaneReportAgentSession(params) => params.reporter_process_id = reporter_process_id,
+        _ => {}
+    }
 
     let request_id = request.id.clone();
     let method = api_method_name(&request.method);

--- a/src/api/wait.rs
+++ b/src/api/wait.rs
@@ -160,7 +160,6 @@ pub(super) fn wait_for_agent(
             initial,
             last_event_sequence,
             after_state_change_seq: None,
-            accept_transient_status: true,
             timeout_kind: AgentWaitTimeoutKind::Status,
         },
         stream,
@@ -255,7 +254,6 @@ pub(super) fn prompt_agent(
                 initial,
                 last_event_sequence,
                 after_state_change_seq,
-                accept_transient_status: false,
                 timeout_kind,
             },
             stream,
@@ -287,7 +285,6 @@ pub(super) fn prompt_agent(
             // the activity gate still terminate this settled-state wait.
             last_event_sequence,
             after_state_change_seq,
-            accept_transient_status: false,
             timeout_kind: AgentWaitTimeoutKind::Status,
         },
         stream,
@@ -330,7 +327,6 @@ struct ResolvedAgentWait {
     initial: crate::api::schema::AgentInfo,
     last_event_sequence: u64,
     after_state_change_seq: Option<u64>,
-    accept_transient_status: bool,
     timeout_kind: AgentWaitTimeoutKind,
 }
 
@@ -373,7 +369,6 @@ fn wait_for_resolved_agent(
         }
 
         let mut should_probe = false;
-        let mut matched_event_status = None;
         for (sequence, event) in event_hub.events_after(last_event_sequence) {
             last_event_sequence = sequence;
             match event.data {
@@ -385,9 +380,8 @@ fn wait_for_resolved_agent(
                     ..
                 } if event_pane == pane_id => {
                     if released {
-                        if let Some(status) = final_status
-                            .filter(|status| wait.until.contains(status))
-                            .or(matched_event_status)
+                        if let Some(status) =
+                            final_status.filter(|status| wait.until.contains(status))
                         {
                             let mut matched = wait.initial.clone();
                             matched.agent_status = status;
@@ -406,14 +400,8 @@ fn wait_for_resolved_agent(
                 }
                 EventData::PaneAgentStatusChanged {
                     pane_id: event_pane,
-                    agent_status,
                     ..
-                } if event_pane == pane_id => {
-                    if wait.accept_transient_status && wait.until.contains(&agent_status) {
-                        matched_event_status = Some(agent_status);
-                    }
-                    should_probe = true;
-                }
+                } if event_pane == pane_id => should_probe = true,
                 EventData::PaneUpdated { pane } if pane.pane_id == pane_id => should_probe = true,
                 EventData::PaneMoved {
                     previous_pane_id, ..
@@ -457,11 +445,8 @@ fn wait_for_resolved_agent(
                     .map(AgentWaitOutcome::Response)
                     .map(Some);
             }
-            if let Some(status) = matched_event_status {
-                let mut matched = current;
-                matched.agent_status = status;
-                return Ok(Some(AgentWaitOutcome::Matched(Box::new(matched))));
-            }
+            // An event status is only a wake-up signal: pasting it into a later
+            // snapshot reports a state that snapshot can contradict (#2851).
             if agent_wait_matches(&current, &wait.until, wait.after_state_change_seq) {
                 return Ok(Some(AgentWaitOutcome::Matched(Box::new(current))));
             }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2813,6 +2813,7 @@ impl AppState {
                 message,
                 seq,
                 session_ref,
+                reporter_process_id,
             } => {
                 if crate::agent_resume::is_reserved_native_state_source(&source, &agent_label) {
                     self.update_terminal_state(pane_id, |terminal| {
@@ -2822,13 +2823,14 @@ impl AppState {
                     .collect()
                 } else {
                     self.update_terminal_state(pane_id, |terminal| {
-                        terminal.set_hook_authority_with_session_ref(
+                        terminal.set_hook_authority_with_session_ref_from_reporter(
                             source,
                             agent_label,
                             state,
                             message,
                             session_ref,
                             seq,
+                            reporter_process_id,
                         )
                     })
                     .into_iter()
@@ -2842,14 +2844,16 @@ impl AppState {
                 seq,
                 session_ref,
                 session_start_source,
+                reporter_process_id,
             } => self
                 .update_terminal_state(pane_id, |terminal| {
-                    terminal.set_agent_session_ref_for_session_start(
+                    terminal.set_agent_session_ref_for_session_start_from_reporter(
                         source,
                         agent_label,
                         session_ref,
                         seq,
                         session_start_source,
+                        reporter_process_id,
                     )
                 })
                 .into_iter()
@@ -5293,6 +5297,7 @@ mod tests {
             message: None,
             seq: None,
             session_ref: None,
+            reporter_process_id: None,
         });
 
         let toast = state.toast.as_ref().unwrap();
@@ -5331,6 +5336,7 @@ mod tests {
             message: None,
             seq: Some(1),
             session_ref: None,
+            reporter_process_id: None,
         });
         state.handle_app_event(AppEvent::StateChanged {
             pane_id: bg_pane_id,
@@ -5379,6 +5385,7 @@ mod tests {
             message: None,
             seq: Some(1),
             session_ref: crate::agent_resume::AgentSessionRef::id("claude-session"),
+            reporter_process_id: None,
         });
         let terminal = state.terminals.get(&terminal_id).unwrap();
         assert_eq!(terminal.state, AgentState::Working);
@@ -5488,6 +5495,7 @@ mod tests {
             message: None,
             seq: Some(1),
             session_ref: crate::agent_resume::AgentSessionRef::id("devin-session"),
+            reporter_process_id: None,
         });
 
         let terminal = state.terminals.get(&terminal_id).unwrap();
@@ -5512,6 +5520,7 @@ mod tests {
             message: None,
             seq: Some(20),
             session_ref: crate::agent_resume::AgentSessionRef::path(first_session),
+            reporter_process_id: None,
         });
         assert_eq!(first_updates.len(), 1);
         state.session_dirty = false;
@@ -5524,6 +5533,7 @@ mod tests {
             message: None,
             seq: Some(21),
             session_ref: crate::agent_resume::AgentSessionRef::path(second_session),
+            reporter_process_id: None,
         });
 
         assert!(second_updates.is_empty());

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -1252,6 +1252,7 @@ impl App {
             state: detect_state_from_api(params.state),
             message: params.message,
             seq: params.seq,
+            reporter_process_id: params.reporter_process_id,
         });
 
         encode_success(id, ResponseResult::Ok {})
@@ -1282,6 +1283,7 @@ impl App {
             session_start_source: crate::agent_resume::normalize_session_start_source(
                 params.session_start_source,
             ),
+            reporter_process_id: params.reporter_process_id,
         });
 
         encode_success(id, ResponseResult::Ok {})

--- a/src/app/api/plugins/mod.rs
+++ b/src/app/api/plugins/mod.rs
@@ -2937,6 +2937,7 @@ action = "missing"
                 seq: None,
                 agent_session_id: None,
                 agent_session_path: None,
+                reporter_process_id: None,
             },
         );
 

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -1269,6 +1269,8 @@ fn pane_report_agent(args: &[String]) -> std::io::Result<i32> {
         seq,
         agent_session_id,
         agent_session_path,
+        // The server overwrites this with the accepted connection's identity.
+        reporter_process_id: None,
     }))
 }
 
@@ -1365,6 +1367,8 @@ fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
             agent_session_id,
             agent_session_path,
             session_start_source,
+            // The server overwrites this with the accepted connection's identity.
+            reporter_process_id: None,
         },
     ))
 }

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -304,6 +304,16 @@ pub(crate) fn full_lifecycle_hook_authority(source: &str, agent_label: &str) -> 
     )
 }
 
+/// Integrations whose reports all come from one long-lived agent process, so
+/// the pane's lifecycle authority can be leased to that process (issue #2851).
+///
+/// Shell assets report from a new process each time and `herdr:opencode` uses
+/// more than one, so they cannot hold a lease. `herdr:pi` has OMP's shape and
+/// is a follow-up.
+pub(crate) fn leased_lifecycle_reporter(source: &str, agent_label: &str) -> bool {
+    matches!((source, agent_label), ("herdr:omp", "omp"))
+}
+
 pub(crate) fn session_identity_only_integration(source: &str, agent_label: &str) -> bool {
     matches!(
         (source, agent_label),

--- a/src/events.rs
+++ b/src/events.rs
@@ -81,6 +81,8 @@ pub enum AppEvent {
         message: Option<String>,
         seq: Option<u64>,
         session_ref: Option<crate::agent_resume::AgentSessionRef>,
+        /// Trusted peer process id of the reporter. `None` means unknown.
+        reporter_process_id: Option<u32>,
     },
     /// Agent session identity was reported without state authority.
     AgentSessionReported {
@@ -90,6 +92,8 @@ pub enum AppEvent {
         seq: Option<u64>,
         session_ref: Option<crate::agent_resume::AgentSessionRef>,
         session_start_source: Option<String>,
+        /// Trusted peer process id of the reporter. `None` means unknown.
+        reporter_process_id: Option<u32>,
     },
     /// Display-only agent metadata was reported for a pane.
     HookMetadataReported {

--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -498,6 +498,45 @@ test("Oh My Pi retries working before a queued idle state", async () => {
   expect(requestState(attemptedRequests[2])).toBe("idle");
 });
 
+test("Oh My Pi keeps working when a turn ends with a scheduled continuation", async () => {
+  const requests = await startRecordingServer("omp-will-continue");
+  process.env.HERDR_OMP_IDLE_DEBOUNCE_MS = "0";
+  const { handlers, pi } = createExtensionHarness();
+
+  const { default: install } = await importFresh("./omp/herdr-agent-state.ts");
+  install(pi);
+
+  let idle = true;
+  const context = {
+    hasUI: true,
+    isIdle: () => idle,
+    sessionManager: {
+      getSessionFile: () => undefined,
+      getSessionId: () => undefined,
+    },
+  };
+
+  handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+
+  idle = false;
+  handlers.get("agent_start")?.({}, context);
+  await waitFor(() => requestStates(requests).length === 2);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  // OMP already scheduled an automatic continuation, so this loop end is not a
+  // user-visible settle and must not publish idle. See issue #2851.
+  handlers.get("agent_end")?.({ messages: [], willContinue: true }, context);
+  await Bun.sleep(50);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  // The real terminal end still settles the pane.
+  idle = true;
+  handlers.get("agent_end")?.({ messages: [] }, context);
+  await waitFor(() => requestStates(requests).length === 3);
+  expect(requestStates(requests)).toEqual(["idle", "working", "idle"]);
+});
+
 test("Pi retries working state after an unanswered socket attempt", async () => {
   const { attemptedRequests, deliveredRequests, connectionCount } =
     await startDroppedFirstResponseServer("pi-retry");

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -2,7 +2,7 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=omp
-// HERDR_INTEGRATION_VERSION=8
+// HERDR_INTEGRATION_VERSION=9
 // @ts-nocheck
 
 import net from "node:net";
@@ -440,6 +440,11 @@ export default function (pi) {
       // OMP can emit duplicate/late end events while auto-retry is already
       // holding the pane in Working. Do not let an unqualified duplicate end
       // cancel the retry hold and publish a false Idle.
+      return;
+    }
+    if (event?.willContinue === true) {
+      // A continuation is already scheduled, so this end is not a settle.
+      // Older builds omit the field and fall through as before.
       return;
     }
 

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -27,7 +27,7 @@ const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
 const PI_INTEGRATION_VERSION: u32 = 8;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
-const OMP_INTEGRATION_VERSION: u32 = 8;
+const OMP_INTEGRATION_VERSION: u32 = 9;
 const CLAUDE_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
     "herdr-agent-state.ps1"
 } else {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -138,6 +138,91 @@ pub(crate) fn shutdown_local_stream_write(stream: &LocalStream) -> io::Result<()
     }
 }
 
+/// Trusted process identity of the connected peer, read from the kernel.
+///
+/// Call this immediately after `accept`: Darwin's `LOCAL_PEERPID` reads the live
+/// socket and fails once the peer closes, unlike Linux `SO_PEERCRED`, which
+/// snapshots at connect time. `None` means unknown, never denied.
+#[cfg(unix)]
+pub(crate) fn local_stream_peer_process_id(stream: &LocalStream) -> Option<u32> {
+    use std::os::fd::AsRawFd;
+
+    let LocalStream::UdSocket(stream) = stream;
+    let fd = stream.inner().as_raw_fd();
+
+    #[cfg(target_os = "macos")]
+    let pid = {
+        let mut pid: libc::pid_t = 0;
+        let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
+        // SAFETY: `fd` is a live socket owned by `stream`, and the out pointer
+        // and length describe a `pid_t` this frame owns.
+        let rc = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_LOCAL,
+                libc::LOCAL_PEERPID,
+                std::ptr::addr_of_mut!(pid).cast(),
+                &mut len,
+            )
+        };
+        if rc != 0 {
+            return None;
+        }
+        pid
+    };
+
+    #[cfg(target_os = "linux")]
+    let pid = {
+        let mut cred = libc::ucred {
+            pid: 0,
+            uid: 0,
+            gid: 0,
+        };
+        let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+        // SAFETY: `fd` is a live socket owned by `stream`, and the out pointer
+        // and length describe a `ucred` this frame owns.
+        let rc = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_PEERCRED,
+                std::ptr::addr_of_mut!(cred).cast(),
+                &mut len,
+            )
+        };
+        if rc != 0 {
+            return None;
+        }
+        cred.pid
+    };
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    let pid = {
+        let _ = fd;
+        0
+    };
+
+    u32::try_from(pid).ok().filter(|pid| *pid != 0)
+}
+
+/// Trusted process identity of the connected named-pipe client.
+#[cfg(windows)]
+pub(crate) fn local_stream_peer_process_id(stream: &LocalStream) -> Option<u32> {
+    use std::os::windows::io::{AsHandle, AsRawHandle};
+
+    let LocalStream::NamedPipe(pipe) = stream;
+    let mut process_id: u32 = 0;
+    // SAFETY: the handle is owned by `pipe` and the out pointer describes a
+    // `u32` this frame owns.
+    let ok = unsafe {
+        windows_sys::Win32::System::Pipes::GetNamedPipeClientProcessId(
+            pipe.as_handle().as_raw_handle(),
+            &mut process_id,
+        )
+    };
+    (ok != 0 && process_id != 0).then_some(process_id)
+}
+
 /// Binds a listener for private terminal traffic. Unix callers restrict the
 /// socket file after binding; Windows must set the named-pipe DACL at creation.
 pub(crate) fn bind_private_local_listener(path: &Path) -> io::Result<LocalListener> {

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -7386,6 +7386,7 @@ next_tab = ""
                 message: None,
                 seq: None,
                 session_ref: None,
+                reporter_process_id: None,
             })
         );
         assert!(
@@ -11648,6 +11649,7 @@ next_tab = ""
                     seq: Some(19),
                     agent_session_id: None,
                     agent_session_path: None,
+                    reporter_process_id: None,
                 }),
             },
             respond_to,

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -22,6 +22,8 @@ pub struct HookAuthority {
     pub message: Option<String>,
     pub reported_at: Instant,
     pub session_ref: Option<crate::agent_resume::AgentSessionRef>,
+    /// Trusted peer process that claimed this authority, for leased sources.
+    pub reporter_process_id: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -610,6 +612,7 @@ impl TerminalState {
         .and_then(|mutation| mutation.effective_state_change)
     }
 
+    #[cfg(test)]
     pub fn set_hook_authority_with_session_ref(
         &mut self,
         source: String,
@@ -630,6 +633,29 @@ impl TerminalState {
         )
     }
 
+    pub fn set_hook_authority_with_session_ref_from_reporter(
+        &mut self,
+        source: String,
+        agent_label: String,
+        state: AgentState,
+        message: Option<String>,
+        session_ref: Option<crate::agent_resume::AgentSessionRef>,
+        seq: Option<u64>,
+        reporter_process_id: Option<u32>,
+    ) -> Option<TerminalStateMutation> {
+        self.set_hook_authority_at_from_reporter(
+            source,
+            agent_label,
+            state,
+            message,
+            session_ref,
+            seq,
+            Instant::now(),
+            reporter_process_id,
+        )
+    }
+
+    #[cfg(test)]
     pub fn set_hook_authority_at(
         &mut self,
         source: String,
@@ -640,6 +666,34 @@ impl TerminalState {
         seq: Option<u64>,
         now: Instant,
     ) -> Option<TerminalStateMutation> {
+        self.set_hook_authority_at_from_reporter(
+            source,
+            agent_label,
+            state,
+            message,
+            session_ref,
+            seq,
+            now,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    // One flat report; a struct would only rename the same fields.
+    fn set_hook_authority_at_from_reporter(
+        &mut self,
+        source: String,
+        agent_label: String,
+        state: AgentState,
+        message: Option<String>,
+        session_ref: Option<crate::agent_resume::AgentSessionRef>,
+        seq: Option<u64>,
+        now: Instant,
+        reporter_process_id: Option<u32>,
+    ) -> Option<TerminalStateMutation> {
+        if self.reporter_lease_blocks_replacement(&source, &agent_label, reporter_process_id) {
+            return None;
+        }
         if crate::detect::session_identity_only_integration(&source, &agent_label) {
             return None;
         }
@@ -658,6 +712,7 @@ impl TerminalState {
             &session_ref,
             seq,
             now,
+            reporter_process_id,
         ) {
             FullLifecycleHookReportRoute::Accept { reanchor_sequence } => reanchor_sequence,
             FullLifecycleHookReportRoute::Ignore => return None,
@@ -731,6 +786,7 @@ impl TerminalState {
             message,
             reported_at: now,
             session_ref,
+            reporter_process_id,
         });
         let current_session = self.current_session_identity_for_persistence();
         Some(TerminalStateMutation {
@@ -865,6 +921,7 @@ impl TerminalState {
         session_ref: &Option<crate::agent_resume::AgentSessionRef>,
         seq: Option<u64>,
         reported_at: Instant,
+        reporter_process_id: Option<u32>,
     ) -> FullLifecycleHookReportRoute {
         if !crate::detect::full_lifecycle_hook_authority(source, agent_label) {
             return FullLifecycleHookReportRoute::Accept {
@@ -981,6 +1038,7 @@ impl TerminalState {
                     message: message.map(str::to_string),
                     reported_at,
                     session_ref: Some(session_ref),
+                    reporter_process_id,
                 },
                 seq,
             });
@@ -1072,6 +1130,32 @@ impl TerminalState {
             .as_ref()
             .filter(|current| *current != session_ref)
             .cloned()
+    }
+
+    /// Identity alone decides. The session ref is deliberately not consulted:
+    /// the pane publishes it, so a nested reporter can replay it, and exempting
+    /// reports that carry the anchored ref would hand over the lease. Guards
+    /// against unrelated processes, not against an attacker already running as
+    /// the user. See issue #2851.
+    fn reporter_lease_blocks_replacement(
+        &self,
+        source: &str,
+        agent_label: &str,
+        reporter_process_id: Option<u32>,
+    ) -> bool {
+        if !crate::detect::leased_lifecycle_reporter(source, agent_label) {
+            return false;
+        }
+        let Some(authority) = self.hook_authority.as_ref() else {
+            return false;
+        };
+        if authority.source != source || authority.agent_label != agent_label {
+            return false;
+        }
+        let Some(leased_to) = authority.reporter_process_id else {
+            return false;
+        };
+        reporter_process_id != Some(leased_to)
     }
 
     fn clear_full_lifecycle_hook_suppression_for_detected_agent(
@@ -1330,6 +1414,8 @@ impl TerminalState {
                 | ("herdr:opencode", "opencode", Some("select"))
                 | ("herdr:pi", "pi", Some("new" | "resume" | "fork"))
                 | (
+                    // OMP re-asserts `startup` every `agent_start`; a foreign
+                    // one is denied by the reporter lease, not by this list.
                     "herdr:omp",
                     "omp",
                     Some("startup" | "new" | "resume" | "fork")
@@ -1385,6 +1471,28 @@ impl TerminalState {
         seq: Option<u64>,
         session_start_source: Option<String>,
     ) -> Option<TerminalStateMutation> {
+        self.set_agent_session_ref_for_session_start_from_reporter(
+            source,
+            agent_label,
+            session_ref,
+            seq,
+            session_start_source,
+            None,
+        )
+    }
+
+    pub fn set_agent_session_ref_for_session_start_from_reporter(
+        &mut self,
+        source: String,
+        agent_label: String,
+        session_ref: Option<crate::agent_resume::AgentSessionRef>,
+        seq: Option<u64>,
+        session_start_source: Option<String>,
+        reporter_process_id: Option<u32>,
+    ) -> Option<TerminalStateMutation> {
+        if self.reporter_lease_blocks_replacement(&source, &agent_label, reporter_process_id) {
+            return None;
+        }
         let session_ref = session_ref?;
         let known_agent = crate::detect::parse_agent_label(&agent_label);
         let process_present = known_agent.is_some()
@@ -2824,6 +2932,330 @@ mod tests {
 
         assert!(stale.is_none());
         assert_eq!(terminal.state, AgentState::Blocked);
+    }
+
+    fn omp_pane_with_live_authority(parent_session: &str, reporter: Option<u32>) -> TerminalState {
+        let mut terminal = test_terminal();
+        terminal.set_detected_state(Some(Agent::Omp), AgentState::Idle);
+        assert!(terminal
+            .set_agent_session_ref_for_session_start_from_reporter(
+                "herdr:omp".into(),
+                "omp".into(),
+                crate::agent_resume::AgentSessionRef::path(parent_session.to_string()),
+                Some(1000),
+                Some("startup".into()),
+                reporter,
+            )
+            .is_some());
+        assert!(terminal
+            .set_hook_authority_with_session_ref_from_reporter(
+                "herdr:omp".into(),
+                "omp".into(),
+                AgentState::Working,
+                None,
+                crate::agent_resume::AgentSessionRef::path(parent_session.to_string()),
+                Some(1001),
+                reporter,
+            )
+            .is_some());
+        assert_eq!(terminal.state, AgentState::Working);
+        terminal
+    }
+
+    #[test]
+    fn omp_session_start_reports_from_a_foreign_reporter_never_replace_live_authority() {
+        for session_start_source in [
+            Some("startup"),
+            Some("new"),
+            Some("resume"),
+            Some("fork"),
+            Some("handoff"),
+            Some("select"),
+            None,
+        ] {
+            for child_reporter in [Some(4002), None] {
+                let parent_session = test_session_path("omp-parent.jsonl");
+                let child_session = test_session_path("omp-child.jsonl");
+                let mut terminal = omp_pane_with_live_authority(&parent_session, Some(4001));
+
+                let child_session_report = terminal
+                    .set_agent_session_ref_for_session_start_from_reporter(
+                        "herdr:omp".into(),
+                        "omp".into(),
+                        crate::agent_resume::AgentSessionRef::path(child_session.clone()),
+                        Some(2000),
+                        session_start_source.map(str::to_string),
+                        child_reporter,
+                    );
+                let child_idle = terminal.set_hook_authority_with_session_ref_from_reporter(
+                    "herdr:omp".into(),
+                    "omp".into(),
+                    AgentState::Idle,
+                    None,
+                    crate::agent_resume::AgentSessionRef::path(child_session),
+                    Some(2001),
+                    child_reporter,
+                );
+
+                assert!(
+                    child_session_report.is_none(),
+                    "{session_start_source:?} from {child_reporter:?} replaced the live session"
+                );
+                assert!(child_idle.is_none());
+                assert_eq!(terminal.state, AgentState::Working);
+                assert_eq!(
+                    terminal.hook_authority.as_ref().unwrap().session_ref,
+                    crate::agent_resume::AgentSessionRef::path(parent_session)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn omp_state_report_from_a_foreign_reporter_cannot_park_a_replacement() {
+        let parent_session = test_session_path("omp-parent.jsonl");
+        let child_session = test_session_path("omp-child.jsonl");
+        let mut terminal = omp_pane_with_live_authority(&parent_session, Some(4001));
+
+        let child_idle = terminal.set_hook_authority_with_session_ref_from_reporter(
+            "herdr:omp".into(),
+            "omp".into(),
+            AgentState::Idle,
+            None,
+            crate::agent_resume::AgentSessionRef::path(child_session.clone()),
+            Some(2000),
+            Some(4002),
+        );
+        let child_session_report = terminal.set_agent_session_ref_for_session_start_from_reporter(
+            "herdr:omp".into(),
+            "omp".into(),
+            crate::agent_resume::AgentSessionRef::path(child_session),
+            Some(2001),
+            Some("resume".into()),
+            Some(4002),
+        );
+
+        assert!(child_idle.is_none());
+        assert!(child_session_report.is_none());
+        assert_eq!(terminal.state, AgentState::Working);
+        assert_eq!(
+            terminal.hook_authority.as_ref().unwrap().session_ref,
+            crate::agent_resume::AgentSessionRef::path(parent_session)
+        );
+    }
+
+    #[test]
+    fn omp_session_start_report_from_the_leased_reporter_still_reanchors() {
+        for session_start_source in ["startup", "new", "resume", "fork"] {
+            let parent_session = test_session_path("omp-parent.jsonl");
+            let next_session = test_session_path("omp-next.jsonl");
+            let mut terminal = omp_pane_with_live_authority(&parent_session, Some(4001));
+
+            let reanchored = terminal.set_agent_session_ref_for_session_start_from_reporter(
+                "herdr:omp".into(),
+                "omp".into(),
+                crate::agent_resume::AgentSessionRef::path(next_session.clone()),
+                Some(2000),
+                Some(session_start_source.into()),
+                Some(4001),
+            );
+            assert!(reanchored.is_some(), "{session_start_source} was denied");
+
+            let working_again = terminal.set_hook_authority_with_session_ref_from_reporter(
+                "herdr:omp".into(),
+                "omp".into(),
+                AgentState::Working,
+                None,
+                crate::agent_resume::AgentSessionRef::path(next_session.clone()),
+                Some(2001),
+                Some(4001),
+            );
+            assert!(working_again.is_some());
+            assert_eq!(
+                terminal.hook_authority.as_ref().unwrap().session_ref,
+                crate::agent_resume::AgentSessionRef::path(next_session)
+            );
+        }
+    }
+
+    #[test]
+    fn omp_reporter_lease_denies_a_foreign_report_that_replays_the_anchored_session() {
+        // The pane publishes its session ref, so a nested process can replay it.
+        let parent_session = test_session_path("omp-parent.jsonl");
+        let child_session = test_session_path("omp-child.jsonl");
+        let mut terminal = omp_pane_with_live_authority(&parent_session, Some(4001));
+
+        let replayed_idle = terminal.set_hook_authority_with_session_ref_from_reporter(
+            "herdr:omp".into(),
+            "omp".into(),
+            AgentState::Idle,
+            None,
+            crate::agent_resume::AgentSessionRef::path(parent_session.clone()),
+            Some(1002),
+            Some(4002),
+        );
+        assert!(replayed_idle.is_none());
+        assert_eq!(terminal.state, AgentState::Working);
+
+        let stolen = terminal.set_agent_session_ref_for_session_start_from_reporter(
+            "herdr:omp".into(),
+            "omp".into(),
+            crate::agent_resume::AgentSessionRef::path(child_session),
+            Some(2000),
+            Some("resume".into()),
+            Some(4002),
+        );
+        assert!(stolen.is_none());
+        assert_eq!(
+            terminal.hook_authority.as_ref().unwrap().session_ref,
+            crate::agent_resume::AgentSessionRef::path(parent_session)
+        );
+
+        let own_idle = terminal.set_hook_authority_with_session_ref_from_reporter(
+            "herdr:omp".into(),
+            "omp".into(),
+            AgentState::Idle,
+            None,
+            crate::agent_resume::AgentSessionRef::path(test_session_path("omp-parent.jsonl")),
+            Some(1003),
+            Some(4001),
+        );
+        assert!(own_idle.is_some());
+        assert_eq!(terminal.state, AgentState::Idle);
+    }
+
+    #[test]
+    fn omp_reporter_lease_does_not_outlive_the_authority_it_was_taken_for() {
+        let parent_session = test_session_path("omp-parent.jsonl");
+        let next_session = test_session_path("omp-next.jsonl");
+        let mut terminal = omp_pane_with_live_authority(&parent_session, Some(4001));
+
+        terminal.clear_hook_authority(Some("herdr:omp"), Some(1002));
+        assert!(terminal.hook_authority.is_none());
+
+        let restarted = terminal.set_hook_authority_with_session_ref_from_reporter(
+            "herdr:omp".into(),
+            "omp".into(),
+            AgentState::Working,
+            None,
+            crate::agent_resume::AgentSessionRef::path(next_session.clone()),
+            Some(2000),
+            Some(4002),
+        );
+        assert!(restarted.is_some());
+        assert_eq!(
+            terminal.hook_authority.as_ref().unwrap().session_ref,
+            crate::agent_resume::AgentSessionRef::path(next_session)
+        );
+    }
+
+    #[test]
+    fn omp_reporter_lease_is_released_on_every_authority_teardown() {
+        // A dead process id must not keep gating whoever claims the pane next.
+        for teardown in [
+            "clear_hook_authority",
+            "release_agent",
+            "respawn",
+            "agent_process_exit",
+        ] {
+            let parent_session = test_session_path("omp-parent.jsonl");
+            let mut terminal = omp_pane_with_live_authority(&parent_session, Some(4001));
+            assert!(terminal.reporter_lease_blocks_replacement("herdr:omp", "omp", Some(4002)));
+
+            match teardown {
+                "clear_hook_authority" => {
+                    terminal.clear_hook_authority(Some("herdr:omp"), Some(1002));
+                }
+                "release_agent" => {
+                    terminal.release_agent_with_mutation("herdr:omp", "omp", Some(1002));
+                }
+                "respawn" => terminal.clear_agent_runtime_identity_after_respawn(),
+                _ => {
+                    terminal.set_detected_state_with_visible_blocker(
+                        Some(Agent::Omp),
+                        AgentState::Unknown,
+                        false,
+                        false,
+                        true,
+                    );
+                }
+            }
+
+            assert!(
+                !terminal.reporter_lease_blocks_replacement("herdr:omp", "omp", Some(4002)),
+                "{teardown} still denies a new reporter"
+            );
+        }
+    }
+
+    #[test]
+    fn omp_reporter_lease_is_released_when_the_pane_agent_changes() {
+        let parent_session = test_session_path("omp-parent.jsonl");
+        let mut terminal = omp_pane_with_live_authority(&parent_session, Some(4001));
+
+        terminal.set_detected_state(Some(Agent::Pi), AgentState::Idle);
+
+        assert!(terminal.hook_authority.is_none());
+        assert!(!terminal.reporter_lease_blocks_replacement("herdr:omp", "omp", Some(4002)));
+    }
+
+    #[test]
+    fn omp_bare_state_report_from_a_foreign_reporter_is_denied() {
+        // The asset omits the session ref before it has a session file.
+        let parent_session = test_session_path("omp-parent.jsonl");
+        let mut terminal = omp_pane_with_live_authority(&parent_session, Some(4001));
+
+        for foreign_reporter in [Some(4002), None] {
+            let bare_idle = terminal.set_hook_authority_with_session_ref_from_reporter(
+                "herdr:omp".into(),
+                "omp".into(),
+                AgentState::Idle,
+                None,
+                None,
+                Some(2000),
+                foreign_reporter,
+            );
+            assert!(bare_idle.is_none(), "{foreign_reporter:?}");
+            assert_eq!(terminal.state, AgentState::Working);
+            assert_eq!(
+                terminal.hook_authority.as_ref().unwrap().session_ref,
+                crate::agent_resume::AgentSessionRef::path(parent_session.clone())
+            );
+        }
+    }
+
+    #[test]
+    fn non_leased_full_lifecycle_sources_keep_first_writer_replacement() {
+        // A shell asset reports from a new process each time.
+        let mut terminal = test_terminal();
+        anchor_full_lifecycle_session(
+            &mut terminal,
+            Agent::Mastracode,
+            "herdr:mastracode",
+            "mastracode",
+            crate::agent_resume::AgentSessionRef::id("mastracode-first").unwrap(),
+        );
+        assert!(terminal
+            .set_hook_authority_with_session_ref_from_reporter(
+                "herdr:mastracode".into(),
+                "mastracode".into(),
+                AgentState::Working,
+                None,
+                crate::agent_resume::AgentSessionRef::id("mastracode-first"),
+                Some(1),
+                Some(5001),
+            )
+            .is_some());
+
+        let replaced = terminal.set_agent_session_ref_for_session_start_from_reporter(
+            "herdr:mastracode".into(),
+            "mastracode".into(),
+            crate::agent_resume::AgentSessionRef::id("mastracode-second"),
+            Some(2),
+            Some("startup".into()),
+            Some(5002),
+        );
+        assert!(replaced.is_some());
     }
 
     #[test]

--- a/tests/cli/agent_wait.rs
+++ b/tests/cli/agent_wait.rs
@@ -198,3 +198,101 @@ fn agent_wait_exits_when_done_status_matches() {
 
     cleanup_spawned_herdr(herdr, base);
 }
+
+fn report_agent_frame(id: &str, pane_id: &str, state: &str, seq: u64) -> String {
+    format!(
+        r#"{{"id":"{id}","method":"pane.report_agent","params":{{"pane_id":"{pane_id}","source":"custom:test","agent":"pi","state":"{state}","seq":{seq}}}}}"#
+    )
+}
+
+/// A short idle blip that the pane immediately leaves must not complete a
+/// standalone wait: the wait must re-probe and report only settled state.
+/// See issue #2851.
+#[test]
+fn agent_wait_does_not_return_a_transient_status() {
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let socket_path = runtime_dir.join("herdr.sock");
+
+    let herdr = spawn_herdr(&config_home, &runtime_dir, &socket_path);
+    wait_for_socket(&socket_path, Duration::from_secs(5));
+
+    let created = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"req_cli_transient_1","method":"workspace.create","params":{{"cwd":"{}","focus":true}}}}"#,
+            base.display()
+        ),
+    );
+    let pane_id = created["result"]["root_pane"]["pane_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let reported = send_request(
+        &socket_path,
+        &report_agent_frame("req_cli_transient_2", &pane_id, "working", 1),
+    );
+    assert_eq!(reported["result"]["type"], "ok");
+
+    let wait_socket = socket_path.clone();
+    let wait_pane = pane_id.clone();
+    let waiter = thread::spawn(move || {
+        run_cli(
+            &wait_socket,
+            &[
+                "agent",
+                "wait",
+                &wait_pane,
+                "--until",
+                "idle",
+                "--timeout",
+                "2000",
+            ],
+        )
+    });
+
+    // Let the wait record its event cursor and enter its poll loop.
+    thread::sleep(Duration::from_millis(300));
+
+    // Blip idle and restore working. Both frames are written before either
+    // response is read, so the server applies them back to back and the pane is
+    // working again by the time the wait can probe.
+    let mut idle_conn = UnixStream::connect(&socket_path).unwrap();
+    let mut working_conn = UnixStream::connect(&socket_path).unwrap();
+    let idle_frame = report_agent_frame("req_cli_transient_3", &pane_id, "idle", 2);
+    let working_frame = report_agent_frame("req_cli_transient_4", &pane_id, "working", 3);
+    idle_conn
+        .write_all(format!("{idle_frame}\n").as_bytes())
+        .unwrap();
+    idle_conn.flush().unwrap();
+    working_conn
+        .write_all(format!("{working_frame}\n").as_bytes())
+        .unwrap();
+    working_conn.flush().unwrap();
+    for conn in [&idle_conn, &working_conn] {
+        let mut line = String::new();
+        BufReader::new(conn).read_line(&mut line).unwrap();
+        let response: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(response["result"]["type"], "ok");
+    }
+
+    let waited = waiter.join().unwrap();
+    let stdout = String::from_utf8_lossy(&waited.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&waited.stderr).to_string();
+
+    assert!(
+        !waited.status.success(),
+        "agent wait completed on a transient idle blip: stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains("timed out waiting for agent status"),
+        "stderr: {stderr}"
+    );
+
+    let current = run_cli_json(&socket_path, &["agent", "get", &pane_id]);
+    assert_eq!(current["result"]["agent"]["agent_status"], "working");
+
+    cleanup_spawned_herdr(herdr, base);
+}


### PR DESCRIPTION
Fixes the three defects reported in #2851.

## The takeover

The Oh My Pi extension enables itself from the inherited pane environment, so a nested OMP session started inside a pane reported as that pane's agent. Its session claim replaced the live one, authority re-anchored to the child, and when the child finished the pane read idle while its own agent was still mid-turn. `agent wait` returned that idle, and the parent's later reports were then rejected as stale, so polling never recovered.

Reports carry no trustworthy owner, so the server now takes one from the kernel. `src/ipc.rs` reads the connected peer's process id — `LOCAL_PEERPID` on macOS, `SO_PEERCRED` on Linux, `GetNamedPipeClientProcessId` on Windows — and `src/api/server.rs` stamps it onto `pane.report_agent` / `pane.report_agent_session`. The field is `#[serde(skip)] #[schemars(skip)]`, following the existing `owner` precedent, so it can never come from a payload and the JSON schema is unchanged.

The peer id must be read while the connection is fresh: Darwin invalidates it once the peer closes, and lifecycle reporters open one short-lived connection per report.

`TerminalState` stores that id on `HookAuthority`. A report for a leased source from any other process is refused while that authority is live. Keeping the lease on the authority record means it is released exactly when the authority is, so a restarted agent is never gated by its predecessor's process id.

Only `herdr:omp` is leased. Its extension runs inside the OMP process and reuses it for every report, which is what makes process identity meaningful. Shell-asset integrations report from a new process each time and keep the previous first-writer behavior.

Identity decides alone — the session ref is deliberately not consulted, because a nested reporter can read and replay the pane's published ref, which would itself be a takeover route.

This is an accidental-cross-talk boundary, not a security boundary: process ids are reusable and Windows' client id can be misreported. Herdr's socket is same-user and mode 0600, so this guards against unrelated processes, not an attacker already running as the user.

## The wait

Standalone `agent wait` remembered a status seen in an event and pasted it over a freshly probed snapshot, returning a current `state_change_seq` with a stale status — a result the caller had no field left to detect. The substitution is removed; the wait still wakes on every status event but reports only what a live probe observed. `agent prompt --wait` is unaffected; it already ran this way.

## The hook

Every non-retryable `agent_end` scheduled idle, including intermediate loop ends. Upstream marks an end that has already queued a continuation with `willContinue`, so those now return early. The field is optional, so `=== true` degrades to existing behavior on older builds. `OMP_INTEGRATION_VERSION` 8 -> 9.

## Testing

- `just ci` passes on this base. Two `live_handoff` tests fail in my environment for want of an agent binary on `PATH`; I confirmed they fail identically on a pristine checkout of the same base.
- New coverage: nine `TerminalState` unit tests for the lease (foreign reporter refused through session claims, bare state reports, replayed session refs; lease released on every authority teardown and on agent change; non-leased sources keep first-writer replacement), a CLI test that a transient blip does not complete a wait, and a bun test that `willContinue` suppresses idle while a real terminal end still settles the pane.
- Verified against the reported scenario end to end: a nested session reporting `startup` plus idle against a live parent no longer ends the parent's wait. I also confirmed the guard is what does the work by temporarily disabling the leased-source predicate and watching the failure return.

## Scope

This closes the nested-session takeover and the two wait/hook defects. It does not attempt general reporter authentication for unrelated processes beyond the lease described above.
