### PR TITLE
fix: wait for agy account entitlement readiness

### DIFF
--- a/src/detect/manifests/antigravity.toml
+++ b/src/detect/manifests/antigravity.toml
@@ -1,7 +1,7 @@
 id = "agy"
-version = "2026.06.24.1"
+version = "2026.08.20.1"
 min_engine_version = 1
-updated_at = "2026-06-24T00:00:00Z"
+updated_at = "2026-08-20T00:00:00Z"
 aliases = ["antigravity", "antigravity-cli"]
 
 [[rules]]
@@ -31,3 +31,20 @@ priority = 90
 region = "bottom_non_empty_lines(5)"
 visible_working = true
 line_regex = ['(?i)·\s*[1-9][0-9]*\s+task']
+
+[[rules]]
+id = "account_entitlement_initializing"
+state = "working"
+priority = 80
+region = "whole_recent"
+visible_working = true
+line_regex = ['\S+@\S+\s*$']
+
+[[rules]]
+id = "account_entitlement_ready"
+state = "idle"
+priority = 20
+region = "whole_recent"
+visible_idle = true
+line_regex = ['\S+@\S+\s+\([^)]+\)\s*$']
+

--- a/website/agent-detection/antigravity.toml
+++ b/website/agent-detection/antigravity.toml
@@ -1,7 +1,7 @@
 id = "agy"
-version = "2026.06.24.1"
+version = "2026.08.20.1"
 min_engine_version = 1
-updated_at = "2026-06-24T00:00:00Z"
+updated_at = "2026-08-20T00:00:00Z"
 aliases = ["antigravity", "antigravity-cli"]
 
 [[rules]]
@@ -31,3 +31,20 @@ priority = 90
 region = "bottom_non_empty_lines(5)"
 visible_working = true
 line_regex = ['(?i)·\s*[1-9][0-9]*\s+task']
+
+[[rules]]
+id = "account_entitlement_initializing"
+state = "working"
+priority = 80
+region = "whole_recent"
+visible_working = true
+line_regex = ['\S+@\S+\s*$']
+
+[[rules]]
+id = "account_entitlement_ready"
+state = "idle"
+priority = 20
+region = "whole_recent"
+visible_idle = true
+line_regex = ['\S+@\S+\s+\([^)]+\)\s*$']
+


### PR DESCRIPTION
### Summary

Interactive readiness and fallback idle previously preceded AGY account entitlement initialization, causing immediate first prompts after `agent start` to hit "Verifying your account" blockers.

These positive working and idle rules ensure AGY start waits for the actual entitlement resolution boundary before transitioning to idle.

### Live Observed Lifecycle (AGY 1.1.16)

- **email only** (`user@domain.com`) &rarr; matched rule `account_entitlement_initializing`, state `working`
- **`(Google AI Pro)` appears** (`user@domain.com (Google AI Pro)`) &rarr; matched rule `account_entitlement_ready`, state `idle` (with `fallback_reason: null`)
- Zero-delay Loomy fresh-worker prompt succeeds reliably without hitting account verification blockers.

Existing higher-priority blocked permission prompts, spinner working rules, and background tasks continue to outrank these entitlement rules.