### PR TITLE
fix(windows): preserve non-us shifted text

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removing a background worktree workspace no longer changes focus to its parent workspace. (#3098)
 - Prefix bindings such as `prefix+|` now recognize characters produced by macOS Option and custom keyboard layouts, while exact chords such as `prefix+alt+w` keep priority. (#3079, thanks @vlcinsky)
 - Direct terminal attaches now preserve multiline pastes as one paste instead of submitting each line separately. (#3054)
+- Windows clients now preserve layout-generated text for Shift-only keys, so characters such as `/` on German keyboards reach shell panes and pasted input. (#3045)
 - Windows panes now keep bare `cursor-agent` launches detected after Cursor hands off to its bundled Node process. (#3032)
 - Oversized Kitty images no longer prevent smaller images shown later in the same pane from rendering. (#3033)
 - Claude Code panes now use visible turn, background shell, and background agent activity as working-state fallbacks when OSC titles are unavailable or disabled. (#1630, #2241)

--- a/src/app/input/lease.rs
+++ b/src/app/input/lease.rs
@@ -57,7 +57,11 @@ impl InputLeaseTable {
         lease_key: &InputLeaseKey,
         key: TerminalKey,
     ) -> TerminalKey {
-        if key.kind != crossterm::event::KeyEventKind::Press || key.generated_text.is_some() {
+        // Generated text is normally stateless, but a native physical key still owns
+        // press/repeat/release lifecycle even when it carries a layout result.
+        if key.kind != crossterm::event::KeyEventKind::Press
+            || (key.generated_text.is_some() && !key.has_physical_identity())
+        {
             return key;
         }
         if key.has_physical_identity() && self.leases.contains_key(lease_key) {
@@ -76,7 +80,7 @@ impl InputLeaseTable {
         resulting_context: Option<&TerminalInputContext>,
         target: Option<TerminalInputTarget>,
     ) -> RepeatPlan {
-        if key.generated_text.is_some() {
+        if key.generated_text.is_some() && !key.has_physical_identity() {
             return RepeatPlan::Ignore;
         }
         if let Some(target) = target {
@@ -253,6 +257,19 @@ mod tests {
         }
     }
 
+    fn physical_generated_slash(repeat_count: u16) -> TerminalKey {
+        TerminalKey::new(KeyCode::Char('/'), KeyModifiers::SHIFT)
+            .with_generated_text(Some("/".to_owned()))
+            .with_windows_record(crate::input::WindowsKeyRecord {
+                key_down: true,
+                repeat_count,
+                virtual_key_code: 0x37,
+                virtual_scan_code: 0x08,
+                unicode: u16::from(b'/'),
+                control_key_state: 0x0010,
+            })
+    }
+
     #[test]
     fn remove_source_returns_forwarded_and_discards_consumed_leases() {
         let key = TerminalKey::new(KeyCode::Esc, KeyModifiers::empty());
@@ -330,6 +347,79 @@ mod tests {
             leases.normalize_press(&lease_key, physical.clone()).kind,
             crossterm::event::KeyEventKind::Repeat
         );
+    }
+
+    #[test]
+    fn physical_generated_text_keeps_native_repeat_lifecycle() {
+        let key = physical_generated_slash(3);
+        let lease_key = InputLeaseKey::new(7, &key);
+        let context = TerminalInputContext::Pane;
+        let forwarded_target = target();
+        let mut leases = InputLeaseTable::default();
+
+        assert_eq!(
+            leases.normalize_press(&lease_key, key.clone()).kind,
+            crossterm::event::KeyEventKind::Press
+        );
+        assert!(matches!(
+            leases.complete_press(
+                lease_key,
+                &key,
+                Some(&context),
+                Some(&context),
+                Some(forwarded_target.clone()),
+            ),
+            RepeatPlan::Ignore
+        ));
+        assert!(leases.contains(&lease_key));
+
+        let repeated = key.with_repeat_count(1);
+        let repeated = leases.normalize_press(&lease_key, repeated);
+        assert_eq!(repeated.kind, crossterm::event::KeyEventKind::Repeat);
+        assert!(matches!(
+            leases.plan_repeat(lease_key, &repeated, Some(&context)),
+            RepeatPlan::Forwarded(target) if target == forwarded_target
+        ));
+        assert!(leases.remove_forwarded(&lease_key).is_some());
+    }
+
+    #[test]
+    fn consumed_grouped_physical_generated_text_reprocesses_repeats() {
+        let key = physical_generated_slash(3);
+        let lease_key = InputLeaseKey::new(7, &key);
+        let context = TerminalInputContext::Pane;
+        let mut leases = InputLeaseTable::default();
+
+        assert!(matches!(
+            leases.complete_press(lease_key, &key, Some(&context), Some(&context), None),
+            RepeatPlan::Reprocess {
+                context: TerminalInputContext::Pane,
+                repetitions: 2,
+                tracked: true,
+            }
+        ));
+    }
+
+    #[test]
+    fn semantic_generated_text_remains_untracked() {
+        let key = TerminalKey::new(KeyCode::Char('/'), KeyModifiers::SHIFT)
+            .with_generated_text(Some("/".to_owned()))
+            .with_repeat_count(3);
+        let lease_key = InputLeaseKey::new(7, &key);
+        let context = TerminalInputContext::Pane;
+        let mut leases = InputLeaseTable::default();
+
+        assert!(matches!(
+            leases.complete_press(
+                lease_key,
+                &key,
+                Some(&context),
+                Some(&context),
+                Some(target())
+            ),
+            RepeatPlan::Ignore
+        ));
+        assert!(leases.is_empty());
     }
 
     #[test]

--- a/src/client/input/windows_vti.rs
+++ b/src/client/input/windows_vti.rs
@@ -587,15 +587,24 @@ impl WindowsInputMapper {
                         code,
                         modifiers,
                         kind,
+                        generated_text,
                         ..
-                    } => crate::protocol::ClientInputEvent::Key {
-                        code,
-                        modifiers,
-                        kind,
-                        repeat_count: key.repeat_count.max(1),
-                        generated_text: None,
-                        source: crate::protocol::ClientKeySource::WindowsConsole { record: key },
-                    },
+                    } => {
+                        // Shift may produce text that is unshifted on a US layout. Keep that
+                        // layout result alongside the native record that owns key lifecycle.
+                        let shifted_text = key.key_down
+                            && modifiers == crossterm::event::KeyModifiers::SHIFT.bits();
+                        crate::protocol::ClientInputEvent::Key {
+                            code,
+                            modifiers,
+                            kind,
+                            repeat_count: key.repeat_count.max(1),
+                            generated_text: if shifted_text { generated_text } else { None },
+                            source: crate::protocol::ClientKeySource::WindowsConsole {
+                                record: key,
+                            },
+                        }
+                    }
                     event => event,
                 })
                 .into_iter()
@@ -2026,6 +2035,146 @@ mod tests {
                 "repeat_count={repeat_count}"
             );
         }
+    }
+
+    #[test]
+    fn vti_win32_input_mode_non_us_shifted_text_preserves_generated_text() {
+        let pressed = WindowsKeyRecord {
+            key_down: true,
+            repeat_count: 1,
+            virtual_key_code: 0x37,
+            virtual_scan_code: 0x08,
+            unicode: b'/'.into(),
+            control_key_state: 0x0010,
+        };
+        let released = WindowsKeyRecord {
+            key_down: false,
+            ..pressed
+        };
+        let mut records = win32_input_mode_encoded_record(pressed);
+        records.extend(win32_input_mode_encoded_record(released));
+
+        let events = translate_with_provenance(records);
+        assert_eq!(
+            events,
+            vec![
+                crate::protocol::ClientInputEvent::Key {
+                    code: crate::protocol::ClientKeyCode::Char('/'),
+                    modifiers: crossterm::event::KeyModifiers::SHIFT.bits(),
+                    kind: crate::protocol::ClientKeyKind::Press,
+                    repeat_count: 1,
+                    generated_text: Some("/".into()),
+                    source: crate::protocol::ClientKeySource::WindowsConsole { record: pressed },
+                },
+                crate::protocol::ClientInputEvent::Key {
+                    code: crate::protocol::ClientKeyCode::Char('/'),
+                    modifiers: crossterm::event::KeyModifiers::SHIFT.bits(),
+                    kind: crate::protocol::ClientKeyKind::Release,
+                    repeat_count: 1,
+                    generated_text: None,
+                    source: crate::protocol::ClientKeySource::WindowsConsole { record: released },
+                },
+            ]
+        );
+
+        let crate::raw_input::RawInputEvent::Key(key) = events[0].to_raw_input_event() else {
+            panic!("expected translated key");
+        };
+        assert_eq!(
+            crate::input::encode_terminal_key(key.clone(), crate::input::KeyboardProtocol::Legacy),
+            b"/"
+        );
+        assert_eq!(
+            crate::input::encode_terminal_key(
+                key.clone(),
+                crate::input::KeyboardProtocol::Kitty { flags: 7 },
+            ),
+            b"/"
+        );
+        assert_eq!(
+            crate::input::encode_terminal_key(
+                key,
+                crate::input::KeyboardProtocol::Kitty { flags: 15 },
+            ),
+            b"\x1b[47;2:1u"
+        );
+    }
+
+    #[test]
+    fn vti_native_shifted_text_preserves_normal_key_encoding() {
+        let translate_key = |record| {
+            let events = translate_with_provenance(win32_input_mode_encoded_record(record));
+            let [event] = events.as_slice() else {
+                panic!("expected one translated event, got {events:?}");
+            };
+            let crate::raw_input::RawInputEvent::Key(key) = event.to_raw_input_event() else {
+                panic!("expected translated key");
+            };
+            key
+        };
+        let shift_a = translate_key(WindowsKeyRecord {
+            key_down: true,
+            repeat_count: 1,
+            virtual_key_code: 0x41,
+            virtual_scan_code: 0x1e,
+            unicode: b'A'.into(),
+            control_key_state: 0x0010,
+        });
+        let shift_bang = translate_key(WindowsKeyRecord {
+            key_down: true,
+            repeat_count: 1,
+            virtual_key_code: 0x31,
+            virtual_scan_code: 0x02,
+            unicode: b'!'.into(),
+            control_key_state: 0x0010,
+        });
+        let alt_a = translate_key(WindowsKeyRecord {
+            key_down: true,
+            repeat_count: 1,
+            virtual_key_code: 0x41,
+            virtual_scan_code: 0x1e,
+            unicode: b'a'.into(),
+            control_key_state: 0x0002,
+        });
+        let ctrl_a = translate_key(WindowsKeyRecord {
+            key_down: true,
+            repeat_count: 1,
+            virtual_key_code: 0x41,
+            virtual_scan_code: 0x1e,
+            unicode: 0x01,
+            control_key_state: 0x0008,
+        });
+
+        assert_eq!(shift_a.generated_text.as_deref(), Some("A"));
+        assert_eq!(shift_bang.generated_text.as_deref(), Some("!"));
+        assert_eq!(alt_a.generated_text, None);
+        assert_eq!(ctrl_a.generated_text, None);
+        assert_eq!(
+            crate::input::encode_terminal_key(
+                shift_a.clone(),
+                crate::input::KeyboardProtocol::Legacy,
+            ),
+            b"A"
+        );
+        assert_eq!(
+            crate::input::encode_terminal_key(
+                shift_a,
+                crate::input::KeyboardProtocol::Kitty { flags: 15 },
+            ),
+            b"\x1b[97:65;2:1u"
+        );
+        assert_eq!(
+            crate::input::encode_terminal_key(shift_bang, crate::input::KeyboardProtocol::Legacy,),
+            b"!"
+        );
+        assert_eq!(
+            crate::input::encode_terminal_key(alt_a, crate::input::KeyboardProtocol::Legacy),
+            b"\x1ba"
+        );
+        assert_eq!(
+            crate::input::encode_terminal_key(ctrl_a, crate::input::KeyboardProtocol::Legacy),
+            b"\x01"
+        );
     }
 
     #[test]

--- a/src/client/input/windows_vti.rs
+++ b/src/client/input/windows_vti.rs
@@ -590,8 +590,9 @@ impl WindowsInputMapper {
                         generated_text,
                         ..
                     } => {
-                        // Shift may produce text that is unshifted on a US layout. Keep that
-                        // layout result alongside the native record that owns key lifecycle.
+                        // Windows Unicode is the authoritative host-layout result. Plain and
+                        // AltGr characters already encode from `code`; Shift must remain on the
+                        // physical event, so carry its produced text separately.
                         let shifted_text = key.key_down
                             && modifiers == crossterm::event::KeyModifiers::SHIFT.bits();
                         crate::protocol::ClientInputEvent::Key {
@@ -2101,80 +2102,115 @@ mod tests {
     }
 
     #[test]
-    fn vti_native_shifted_text_preserves_normal_key_encoding() {
-        let translate_key = |record| {
-            let events = translate_with_provenance(win32_input_mode_encoded_record(record));
+    fn vti_native_layout_text_and_command_modifiers_encode_by_role() {
+        let cases = [
+            (
+                "plain unicode",
+                0x4c,
+                0x26,
+                'λ' as u16,
+                0,
+                0,
+                None,
+                "λ".as_bytes(),
+            ),
+            (
+                "shifted latin",
+                0x41,
+                0x1e,
+                'A' as u16,
+                0x0010,
+                crossterm::event::KeyModifiers::SHIFT.bits(),
+                Some("A"),
+                b"A".as_slice(),
+            ),
+            (
+                "shifted non-ascii",
+                0x4c,
+                0x26,
+                'Λ' as u16,
+                0x0010,
+                crossterm::event::KeyModifiers::SHIFT.bits(),
+                Some("Λ"),
+                "Λ".as_bytes(),
+            ),
+            (
+                "altgr",
+                0x45,
+                0x12,
+                '€' as u16,
+                0x0009,
+                0,
+                None,
+                "€".as_bytes(),
+            ),
+            (
+                "shift altgr",
+                0x37,
+                0x08,
+                '{' as u16,
+                0x0019,
+                crossterm::event::KeyModifiers::SHIFT.bits(),
+                Some("{"),
+                b"{".as_slice(),
+            ),
+            (
+                "left alt command",
+                0x41,
+                0x1e,
+                'a' as u16,
+                0x0002,
+                crossterm::event::KeyModifiers::ALT.bits(),
+                None,
+                b"\x1ba".as_slice(),
+            ),
+            (
+                "control command",
+                0x41,
+                0x1e,
+                0x01,
+                0x0008,
+                crossterm::event::KeyModifiers::CONTROL.bits(),
+                None,
+                b"\x01".as_slice(),
+            ),
+        ];
+
+        for (
+            name,
+            virtual_key_code,
+            virtual_scan_code,
+            unicode,
+            state,
+            modifiers,
+            text,
+            expected,
+        ) in cases
+        {
+            let events =
+                translate_with_provenance(win32_input_mode_encoded_record(WindowsKeyRecord {
+                    key_down: true,
+                    repeat_count: 1,
+                    virtual_key_code,
+                    virtual_scan_code,
+                    unicode,
+                    control_key_state: state,
+                }));
             let [event] = events.as_slice() else {
-                panic!("expected one translated event, got {events:?}");
+                panic!("{name}: expected one translated event, got {events:?}");
             };
             let crate::raw_input::RawInputEvent::Key(key) = event.to_raw_input_event() else {
-                panic!("expected translated key");
+                panic!("{name}: expected translated key");
             };
-            key
-        };
-        let shift_a = translate_key(WindowsKeyRecord {
-            key_down: true,
-            repeat_count: 1,
-            virtual_key_code: 0x41,
-            virtual_scan_code: 0x1e,
-            unicode: b'A'.into(),
-            control_key_state: 0x0010,
-        });
-        let shift_bang = translate_key(WindowsKeyRecord {
-            key_down: true,
-            repeat_count: 1,
-            virtual_key_code: 0x31,
-            virtual_scan_code: 0x02,
-            unicode: b'!'.into(),
-            control_key_state: 0x0010,
-        });
-        let alt_a = translate_key(WindowsKeyRecord {
-            key_down: true,
-            repeat_count: 1,
-            virtual_key_code: 0x41,
-            virtual_scan_code: 0x1e,
-            unicode: b'a'.into(),
-            control_key_state: 0x0002,
-        });
-        let ctrl_a = translate_key(WindowsKeyRecord {
-            key_down: true,
-            repeat_count: 1,
-            virtual_key_code: 0x41,
-            virtual_scan_code: 0x1e,
-            unicode: 0x01,
-            control_key_state: 0x0008,
-        });
 
-        assert_eq!(shift_a.generated_text.as_deref(), Some("A"));
-        assert_eq!(shift_bang.generated_text.as_deref(), Some("!"));
-        assert_eq!(alt_a.generated_text, None);
-        assert_eq!(ctrl_a.generated_text, None);
-        assert_eq!(
-            crate::input::encode_terminal_key(
-                shift_a.clone(),
-                crate::input::KeyboardProtocol::Legacy,
-            ),
-            b"A"
-        );
-        assert_eq!(
-            crate::input::encode_terminal_key(
-                shift_a,
-                crate::input::KeyboardProtocol::Kitty { flags: 15 },
-            ),
-            b"\x1b[97:65;2:1u"
-        );
-        assert_eq!(
-            crate::input::encode_terminal_key(shift_bang, crate::input::KeyboardProtocol::Legacy,),
-            b"!"
-        );
-        assert_eq!(
-            crate::input::encode_terminal_key(alt_a, crate::input::KeyboardProtocol::Legacy),
-            b"\x1ba"
-        );
-        assert_eq!(
-            crate::input::encode_terminal_key(ctrl_a, crate::input::KeyboardProtocol::Legacy),
-            b"\x01"
-        );
+            assert_eq!(key.modifiers.bits(), modifiers, "{name}: modifiers");
+            assert_eq!(key.generated_text.as_deref(), text, "{name}: text");
+            assert_eq!(
+                crate::input::encode_terminal_key(key, crate::input::KeyboardProtocol::Legacy),
+                expected,
+                "{name}: encoding"
+            );
+        }
     }
 
     #[test]

--- a/src/input/encode.rs
+++ b/src/input/encode.rs
@@ -16,7 +16,10 @@ pub fn encode_key(key: KeyEvent, protocol: KeyboardProtocol) -> Vec<u8> {
 }
 
 pub fn encode_terminal_key(key: TerminalKey, protocol: KeyboardProtocol) -> Vec<u8> {
-    if key.kind != crossterm::event::KeyEventKind::Release {
+    // REPORT_ALL_KEYS must retain physical press/repeat/release semantics instead of
+    // reducing a native key to its layout-generated text.
+    let preserve_physical_key = key.has_physical_identity() && protocol.reports_all_keys();
+    if !preserve_physical_key && key.kind != crossterm::event::KeyEventKind::Release {
         if let Some(text) = &key.generated_text {
             return text.as_bytes().to_vec();
         }

--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -4499,7 +4499,7 @@ mod tests {
     }
 
     #[test]
-    fn grouped_semantic_key_repeats_expand_at_the_destination() {
+    fn grouped_key_repeats_expand_at_the_destination() {
         let (tx, _rx) = mpsc::channel(4);
         let terminal = crate::ghostty::Terminal::new(80, 24, 0).unwrap();
         let pane = GhosttyPaneTerminal::new(terminal, tx).unwrap();
@@ -4512,6 +4512,28 @@ mod tests {
         assert_eq!(
             pane.encode_terminal_key(key, crate::input::KeyboardProtocol::Legacy),
             b"xxx"
+        );
+
+        let shifted = crate::input::TerminalKey::new(
+            crossterm::event::KeyCode::Char('/'),
+            crossterm::event::KeyModifiers::SHIFT,
+        )
+        .with_generated_text(Some("/".to_owned()))
+        .with_windows_record(crate::input::WindowsKeyRecord {
+            key_down: true,
+            repeat_count: 3,
+            virtual_key_code: 0x37,
+            virtual_scan_code: 0x08,
+            unicode: u16::from(b'/'),
+            control_key_state: 0x0010,
+        });
+        assert_eq!(
+            pane.encode_terminal_key(shifted.clone(), crate::input::KeyboardProtocol::Legacy,),
+            b"///"
+        );
+        assert_eq!(
+            pane.encode_terminal_key(shifted, crate::input::KeyboardProtocol::Kitty { flags: 15 },),
+            b"\x1b[47;2:1u\x1b[47;2:2u\x1b[47;2:2u"
         );
     }
 


### PR DESCRIPTION
## Summary
- preserve Shift-generated layout text alongside native Windows key lifecycle data
- keep physical key semantics when pane applications request Kitty report-all input
- cover German Shift+`/` plus normal Shift, Alt, Ctrl, release, and repeat behavior

## Testing
- `just check`

Refs #3045