### PR TITLE
fix: follow codex working directory changes

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -2865,6 +2865,12 @@
                 "null"
               ]
             },
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "pane_id": {
               "type": "string"
             },

--- a/docs/next/website/src/content/docs/socket-api.mdx
+++ b/docs/next/website/src/content/docs/socket-api.mdx
@@ -718,10 +718,13 @@ Session-only official integrations report native session references with `pane.r
     "pane_id": "w1:p1",
     "source": "herdr:codex",
     "agent": "codex",
-    "agent_session_id": "..."
+    "agent_session_id": "...",
+    "cwd": "/path/to/project"
   }
 }
 ```
+
+An accepted session report can include `cwd`. Herdr uses an existing absolute directory for pane identity and follow-cwd behavior.
 
 `pane.get`, `pane.list`, `agent.get`, and `agent.list` expose a read-only `agent_session` object when Herdr has a stored native session reference:
 

--- a/src/api/schema/panes.rs
+++ b/src/api/schema/panes.rs
@@ -393,6 +393,8 @@ pub struct PaneReportAgentSessionParams {
     pub agent_session_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_start_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2842,18 +2842,34 @@ impl AppState {
                 seq,
                 session_ref,
                 session_start_source,
-            } => self
-                .update_terminal_state(pane_id, |terminal| {
-                    terminal.set_agent_session_ref_for_session_start(
+                cwd,
+            } => {
+                let mut cwd_changed = false;
+                let update = self.update_terminal_state(pane_id, |terminal| {
+                    let mutation = terminal.set_agent_session_ref_for_session_start(
                         source,
                         agent_label,
                         session_ref,
                         seq,
                         session_start_source,
-                    )
-                })
-                .into_iter()
-                .collect(),
+                    )?;
+                    if let Some(cwd) = cwd.filter(|cwd| cwd.is_absolute() && cwd.is_dir()) {
+                        if terminal.session_reported_cwd.is_none() {
+                            terminal.cwd_before_agent_session = Some(terminal.cwd.clone());
+                        }
+                        cwd_changed = terminal.cwd != cwd;
+                        terminal.cwd = cwd.clone();
+                        terminal.session_reported_cwd = Some(cwd);
+                    } else {
+                        cwd_changed = terminal.restore_cwd_before_agent_session();
+                    }
+                    Some(mutation)
+                });
+                if cwd_changed {
+                    self.mark_session_dirty();
+                }
+                update.into_iter().collect()
+            }
             AppEvent::HookMetadataReported {
                 pane_id,
                 source,
@@ -2931,7 +2947,12 @@ impl AppState {
                 let Some(terminal) = self.terminals.get_mut(&terminal_id) else {
                     return Vec::new();
                 };
-                if terminal.cwd != cwd {
+                if terminal.session_reported_cwd.is_some() {
+                    if terminal.cwd_before_agent_session.as_ref() != Some(&cwd) {
+                        terminal.cwd_before_agent_session = Some(cwd);
+                        self.mark_session_dirty();
+                    }
+                } else if terminal.cwd != cwd {
                     terminal.cwd = cwd;
                     self.mark_session_dirty();
                 }
@@ -5585,6 +5606,24 @@ mod tests {
 
         assert!(updates.is_empty());
         assert_eq!(state.terminals.get(&terminal_id).unwrap().cwd, cwd);
+        assert!(state.session_dirty);
+
+        let agent_cwd = cwd.join("agent");
+        let terminal = state.terminals.get_mut(&terminal_id).unwrap();
+        terminal.cwd = agent_cwd.clone();
+        terminal.session_reported_cwd = Some(agent_cwd.clone());
+        terminal.cwd_before_agent_session = Some(cwd.clone());
+        let shell_cwd = cwd.join("shell");
+        std::fs::create_dir(&shell_cwd).unwrap();
+        state.session_dirty = false;
+        state.handle_app_event(AppEvent::TerminalCwdReported {
+            pane_id,
+            cwd: shell_cwd.clone(),
+        });
+        let terminal = &state.terminals[&terminal_id];
+        assert_eq!(terminal.cwd, agent_cwd);
+        assert_eq!(terminal.session_reported_cwd.as_ref(), Some(&agent_cwd));
+        assert_eq!(terminal.cwd_before_agent_session.as_ref(), Some(&shell_cwd));
         assert!(state.session_dirty);
         let _ = std::fs::remove_dir_all(cwd);
     }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -113,6 +113,22 @@ impl App {
         &mut self,
         ev: AppEvent,
     ) -> Vec<crate::app::actions::PaneStateUpdate> {
+        let cwd_change_pane = match &ev {
+            AppEvent::AgentSessionReported { pane_id, .. }
+            | AppEvent::StateChanged {
+                pane_id,
+                process_exited: true,
+                ..
+            } => Some(*pane_id),
+            _ => None,
+        };
+        let cwd_before = cwd_change_pane.and_then(|pane_id| {
+            let (_, pane) = self.find_pane(pane_id)?;
+            self.state
+                .terminals
+                .get(&pane.attached_terminal_id)
+                .map(|terminal| (pane.attached_terminal_id.clone(), terminal.cwd.clone()))
+        });
         if let AppEvent::TerminalBell { count, .. } = ev {
             if let Err(err) =
                 crate::terminal_effects::write_terminal_bells(&mut std::io::stdout(), count)
@@ -305,9 +321,15 @@ impl App {
             } else {
                 None
             };
-        let terminal_cwd_reported = matches!(ev, AppEvent::TerminalCwdReported { .. });
+        let mut terminal_cwd_reported = matches!(ev, AppEvent::TerminalCwdReported { .. });
         let previous_toast = self.state.toast.clone();
         let pane_updates = self.state.handle_app_event(ev);
+        terminal_cwd_reported |= cwd_before.is_some_and(|(terminal_id, cwd)| {
+            self.state
+                .terminals
+                .get(&terminal_id)
+                .is_some_and(|terminal| terminal.cwd != cwd)
+        });
         if let Some(agents) = manifest_update_agents {
             self.reset_agent_detection_for_agents(&agents);
         }
@@ -565,7 +587,10 @@ impl App {
             return false;
         };
 
-        let cwd = terminal.cwd.clone();
+        let cwd = terminal
+            .cwd_before_agent_session
+            .clone()
+            .unwrap_or_else(|| terminal.cwd.clone());
         let (rows, cols) = self
             .terminal_runtimes
             .get(&terminal_id)
@@ -604,6 +629,7 @@ impl App {
         if let Some(terminal) = self.state.terminals.get_mut(&terminal_id) {
             terminal.clear_agent_runtime_identity_after_respawn();
         }
+        self.request_git_identity_refresh(Instant::now());
         self.state.focus_pane_in_workspace(ws_idx, pane_id);
         self.schedule_session_save();
         true
@@ -1970,6 +1996,11 @@ mod tests {
             app.state.workspaces = vec![workspace];
             app.state.ensure_test_terminals();
             let terminal = app.state.terminals.get_mut(&terminal_id).unwrap();
+            let shell_cwd = terminal.cwd.clone();
+            let agent_cwd = shell_cwd.join("agent");
+            terminal.cwd_before_agent_session = Some(shell_cwd.clone());
+            terminal.session_reported_cwd = Some(agent_cwd.clone());
+            terminal.cwd = agent_cwd;
             terminal.set_detected_state(Some(Agent::Pi), AgentState::Idle);
             if let Some(agent_name) = agent_name {
                 terminal.set_agent_name(agent_name.into());
@@ -1986,6 +2017,8 @@ mod tests {
             });
 
             assert!(app.state.terminals[&terminal_id].agent_name.is_none());
+            assert_eq!(app.state.terminals[&terminal_id].cwd, shell_cwd);
+            assert!(app.git_identity_refresh_requested);
             assert!(event_hub.events_after(0).iter().any(|(_, event)| matches!(
                 &event.data,
                 crate::api::schema::EventData::PaneAgentDetected {
@@ -2157,6 +2190,11 @@ mod tests {
             .expect("test terminal should exist");
         terminal.respawn_shell_on_exit = true;
         terminal.set_agent_name("codex".into());
+        let shell_cwd = terminal.cwd.clone();
+        let agent_cwd = std::env::temp_dir().canonicalize().unwrap();
+        terminal.cwd_before_agent_session = Some(shell_cwd.clone());
+        terminal.session_reported_cwd = Some(agent_cwd.clone());
+        terminal.cwd = agent_cwd;
         terminal.set_persisted_agent_session(crate::agent_resume::PersistedAgentSession {
             source: "herdr:codex".into(),
             agent: "codex".into(),
@@ -2178,6 +2216,16 @@ mod tests {
         assert!(!terminal.respawn_shell_on_exit);
         assert!(terminal.persisted_agent_session.is_none());
         assert!(terminal.agent_name.is_none());
+        assert_eq!(terminal.cwd, shell_cwd);
+        assert_eq!(
+            app.terminal_runtimes
+                .get(&terminal_id)
+                .unwrap()
+                .cwd()
+                .as_ref(),
+            Some(&shell_cwd)
+        );
+        assert!(app.git_identity_refresh_requested);
 
         for (_, runtime) in app.terminal_runtimes.drain() {
             runtime.shutdown();

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -1282,6 +1282,7 @@ impl App {
             session_start_source: crate::agent_resume::normalize_session_start_source(
                 params.session_start_source,
             ),
+            cwd: params.cwd.map(std::path::PathBuf::from),
         });
 
         encode_success(id, ResponseResult::Ok {})
@@ -1997,6 +1998,71 @@ mod tests {
             seq: None,
             ttl_ms: None,
         }
+    }
+
+    #[tokio::test]
+    async fn pane_report_agent_session_updates_live_and_persisted_cwd() {
+        let (mut app, public_pane_id) = app_with_test_workspace();
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = app.state.workspaces[0]
+            .terminal_id(pane_id)
+            .unwrap()
+            .clone();
+        let shell_cwd = app.state.terminals[&terminal_id].cwd.clone();
+        let cwd = std::env::temp_dir().canonicalize().unwrap();
+        let params = PaneReportAgentSessionParams {
+            pane_id: public_pane_id,
+            source: "herdr:codex".into(),
+            agent: "codex".into(),
+            seq: Some(2),
+            agent_session_id: Some("codex-session".into()),
+            agent_session_path: None,
+            session_start_source: Some("startup".into()),
+            cwd: Some(cwd.display().to_string()),
+        };
+
+        let response = app.handle_pane_report_agent_session("req".into(), params.clone());
+
+        let _: SuccessResponse = serde_json::from_str(&response).unwrap();
+        let terminal = &app.state.terminals[&terminal_id];
+        assert_eq!(terminal.cwd, cwd);
+        assert_eq!(terminal.session_reported_cwd.as_ref(), Some(&cwd));
+        assert_eq!(terminal.cwd_before_agent_session.as_ref(), Some(&shell_cwd));
+        assert!(app.git_identity_refresh_requested);
+        app.git_identity_refresh_requested = false;
+
+        let stale_cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+        let mut stale = params;
+        stale.seq = Some(1);
+        stale.cwd = Some(stale_cwd.display().to_string());
+        app.handle_pane_report_agent_session("stale".into(), stale.clone());
+        assert_ne!(stale_cwd, cwd);
+        assert_eq!(
+            app.state.terminals[&terminal_id]
+                .session_reported_cwd
+                .as_ref(),
+            Some(&cwd)
+        );
+        assert!(!app.git_identity_refresh_requested);
+        app.state.terminals.get_mut(&terminal_id).unwrap().cwd = stale_cwd;
+        assert_eq!(
+            crate::app::creation::launch_cwd_for_terminal(
+                &terminal_id,
+                &app.state.terminals,
+                &app.terminal_runtimes,
+            ),
+            Some(cwd.clone())
+        );
+        app.state.terminals.get_mut(&terminal_id).unwrap().cwd = cwd;
+
+        stale.seq = Some(3);
+        stale.cwd = None;
+        app.handle_pane_report_agent_session("clear".into(), stale);
+        let terminal = &app.state.terminals[&terminal_id];
+        assert_eq!(terminal.cwd, shell_cwd);
+        assert!(terminal.session_reported_cwd.is_none());
+        assert!(terminal.cwd_before_agent_session.is_none());
+        assert!(app.git_identity_refresh_requested);
     }
 
     fn metadata_error_code(response: &str) -> String {

--- a/src/app/creation.rs
+++ b/src/app/creation.rs
@@ -38,9 +38,14 @@ pub(super) fn launch_cwd_for_terminal(
     >,
     terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
 ) -> Option<PathBuf> {
-    terminal_runtimes
+    terminals
         .get(terminal_id)
-        .and_then(|runtime| runtime.follow_cwd())
+        .and_then(|terminal| terminal.session_reported_cwd.clone())
+        .or_else(|| {
+            terminal_runtimes
+                .get(terminal_id)
+                .and_then(|runtime| runtime.follow_cwd())
+        })
         .or_else(|| {
             terminals
                 .get(terminal_id)

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -1274,7 +1274,7 @@ fn pane_report_agent(args: &[String]) -> std::io::Result<i32> {
 
 fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
     let Some(raw_pane_id) = args.first() else {
-        eprintln!("usage: herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH] [--session-start-source SOURCE]");
+        eprintln!("usage: herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH] [--session-start-source SOURCE] [--cwd PATH]");
         return Ok(2);
     };
 
@@ -1285,6 +1285,7 @@ fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
     let mut agent_session_id = None;
     let mut agent_session_path = None;
     let mut session_start_source = None;
+    let mut cwd = None;
 
     let mut index = 1;
     while index < args.len() {
@@ -1337,6 +1338,14 @@ fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
                 session_start_source = Some(value.clone());
                 index += 2;
             }
+            "--cwd" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --cwd");
+                    return Ok(2);
+                };
+                cwd = Some(value.clone());
+                index += 2;
+            }
             other => {
                 eprintln!("unknown option: {other}");
                 return Ok(2);
@@ -1365,6 +1374,7 @@ fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
             agent_session_id,
             agent_session_path,
             session_start_source,
+            cwd,
         },
     ))
 }
@@ -1655,7 +1665,7 @@ fn print_pane_help() {
     eprintln!("  herdr pane send-keys <pane_id> <key> [key ...]");
     eprintln!("  herdr pane wait-output <pane_id> (--match TEXT | --regex PATTERN) [--source visible|recent|recent-unwrapped] [--lines N] [--timeout MS] [--raw]");
     eprintln!("  herdr pane report-agent <pane_id> --source ID --agent LABEL --state idle|working|blocked|unknown [--message TEXT] [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
-    eprintln!("  herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
+    eprintln!("  herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH] [--session-start-source SOURCE] [--cwd PATH]");
     eprintln!("  herdr pane release-agent <pane_id> --source ID --agent LABEL [--seq N]");
     eprintln!("  herdr pane report-metadata <pane_id> --source ID [--agent LABEL] [--applies-to-source ID] [--title TEXT|--clear-title] [--display-agent TEXT|--clear-display-agent] [--state-label STATUS=TEXT] [--clear-state-labels] [--token NAME=VALUE] [--clear-token NAME] [--seq N] [--ttl-ms N]");
     eprintln!("  herdr pane run <pane_id> <command>");

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -663,6 +663,7 @@ fn report_agent_session_command() -> Command {
         .arg(option("agent-session-id", "ID"))
         .arg(path_option("agent-session-path", "PATH"))
         .arg(option("session-start-source", "SOURCE"))
+        .arg(path_option("cwd", "PATH"))
 }
 
 fn release_agent_command() -> Command {

--- a/src/events.rs
+++ b/src/events.rs
@@ -90,6 +90,7 @@ pub enum AppEvent {
         seq: Option<u64>,
         session_ref: Option<crate::agent_resume::AgentSessionRef>,
         session_start_source: Option<String>,
+        cwd: Option<std::path::PathBuf>,
     },
     /// Display-only agent metadata was reported for a pane.
     HookMetadataReported {

--- a/src/handoff_runtime.rs
+++ b/src/handoff_runtime.rs
@@ -27,6 +27,8 @@ pub(crate) struct HandoffRuntimeState {
     pub terminal_title: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub initial_history_ansi: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd_before_agent_session: Option<std::path::PathBuf>,
 }
 
 #[cfg(unix)]

--- a/src/integration/assets/codex/herdr-agent-state.ps1
+++ b/src/integration/assets/codex/herdr-agent-state.ps1
@@ -2,7 +2,7 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=codex
-# HERDR_INTEGRATION_VERSION=8
+# HERDR_INTEGRATION_VERSION=9
 
 param([string]$Action = "")
 
@@ -27,7 +27,7 @@ if (-not [string]::IsNullOrWhiteSpace($env:CODEX_THREAD_ID) -and $env:CODEX_THRE
 $seq = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
 $herdr = if ([string]::IsNullOrWhiteSpace($env:HERDR_BIN_PATH)) { "herdr" } else { $env:HERDR_BIN_PATH }
 try {
-    $args = @(
+    $commandArgs = @(
         "pane",
         "report-agent-session",
         $env:HERDR_PANE_ID,
@@ -41,8 +41,11 @@ try {
         "$sessionId"
     )
     if ($payload.hook_event_name -eq "SessionStart" -and $payload.source -is [string] -and -not [string]::IsNullOrWhiteSpace($payload.source)) {
-        $args += @("--session-start-source", "$($payload.source)")
+        $commandArgs += @("--session-start-source", "$($payload.source)")
     }
-    & $herdr @args 2>$null | Out-Null
+    if ($payload.cwd -is [string] -and -not [string]::IsNullOrWhiteSpace($payload.cwd)) {
+        $commandArgs += @("--cwd", "$($payload.cwd)")
+    }
+    & $herdr @commandArgs 2>$null | Out-Null
 } catch {
 }

--- a/src/integration/assets/codex/herdr-agent-state.sh
+++ b/src/integration/assets/codex/herdr-agent-state.sh
@@ -3,7 +3,7 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=codex
-# HERDR_INTEGRATION_VERSION=8
+# HERDR_INTEGRATION_VERSION=9
 
 set -eu
 
@@ -65,6 +65,9 @@ if inherited_session_id and inherited_session_id != agent_session_id:
 session_start_source = hook_input.get("source") if hook_event_name == "SessionStart" else None
 if not isinstance(session_start_source, str) or not session_start_source:
     session_start_source = None
+cwd = hook_input.get("cwd")
+if not isinstance(cwd, str) or not cwd:
+    cwd = None
 if agent_session_id:
     params = {
         "pane_id": pane_id,
@@ -75,6 +78,8 @@ if agent_session_id:
     }
     if session_start_source:
         params["session_start_source"] = session_start_source
+    if cwd:
+        params["cwd"] = cwd
     request = {
         "id": request_id,
         "method": "pane.report_agent_session",

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -49,7 +49,7 @@ const CODEX_HOOK_ASSET: &str = if cfg!(windows) {
 } else {
     include_str!("assets/codex/herdr-agent-state.sh")
 };
-const CODEX_INTEGRATION_VERSION: u32 = 8;
+const CODEX_INTEGRATION_VERSION: u32 = 9;
 const KIMI_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
     "herdr-agent-state.ps1"
 } else {

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -1223,7 +1223,7 @@ fn codex_v2_integration_status_is_outdated() {
 
     assert_eq!(codex.path, hook_path);
     assert_eq!(codex.installed_version, Some(2));
-    assert_eq!(codex.expected_version, 8);
+    assert_eq!(codex.expected_version, 9);
     assert_eq!(codex.state, IntegrationStatusKind::Outdated);
 
     std::env::remove_var("HOME");
@@ -2799,6 +2799,7 @@ fn bundled_integration_assets_report_session_refs() {
         CODEX_HOOK_ASSET.contains("pane.report_agent_session")
             || CODEX_HOOK_ASSET.contains("report-agent-session")
     );
+    assert!(CODEX_HOOK_ASSET.contains("\"cwd\"") || CODEX_HOOK_ASSET.contains("--cwd"));
     assert!(!CODEX_HOOK_ASSET.contains("\"state\": action"));
     assert!(!CODEX_HOOK_ASSET.contains("pane.release_agent"));
     assert!(KIMI_HOOK_ASSET.contains("source\": \"herdr:kimi"));

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1668,6 +1668,7 @@ impl PaneRuntime {
             input_state: self.input_state(),
             terminal_title: self.terminal_title(),
             initial_history_ansi: None,
+            cwd_before_agent_session: None,
         }
     }
 
@@ -1878,6 +1879,7 @@ impl PaneRuntime {
             input_state,
             terminal_title,
             initial_history_ansi,
+            cwd_before_agent_session: _,
         } = state;
         let pane_id = PaneId::from_raw(pane_id);
         use std::os::fd::FromRawFd;

--- a/src/persist/restore.rs
+++ b/src/persist/restore.rs
@@ -472,6 +472,11 @@ fn restore_tab(
         let saved_cwd = saved_pane
             .map(|p| p.cwd.clone())
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| "/".into()));
+        let saved_cwd_before_agent_session = saved_pane.and_then(|pane| {
+            pane.cwd_before_agent_session
+                .clone()
+                .filter(|cwd| cwd.is_absolute() && cwd.is_dir())
+        });
 
         let cwd = if saved_cwd.exists() {
             saved_cwd
@@ -528,6 +533,10 @@ fn restore_tab(
             .unwrap_or_default();
         let imported_runtime = old_pane_id.and_then(|old_id| imported_panes.remove(&old_id));
         let was_imported = imported_runtime.is_some();
+        #[cfg(unix)]
+        let cwd_before_agent_session = imported_runtime
+            .as_ref()
+            .and_then(|imported| imported.state.cwd_before_agent_session.clone());
         let pending_native_agent_restore = if was_imported {
             None
         } else {
@@ -537,6 +546,10 @@ fn restore_tab(
             let terminal_id = TerminalId::alloc();
             let mut terminal = TerminalState::new(terminal_id.clone(), cwd.clone())
                 .with_pending_agent_resume_plan(plan);
+            if let Some(cwd_before_agent_session) = saved_cwd_before_agent_session {
+                terminal.session_reported_cwd = Some(cwd.clone());
+                terminal.cwd_before_agent_session = Some(cwd_before_agent_session);
+            }
             if let Some(label) = saved_label {
                 terminal.set_manual_label(label);
             }
@@ -571,6 +584,12 @@ fn restore_tab(
             failed_imports += 1;
             continue;
         }
+
+        let cwd = if was_imported {
+            cwd
+        } else {
+            saved_cwd_before_agent_session.unwrap_or(cwd)
+        };
 
         let runtime_result = {
             #[cfg(unix)]
@@ -629,6 +648,11 @@ fn restore_tab(
             Ok(runtime) => {
                 let terminal_id = TerminalId::alloc();
                 let mut terminal = TerminalState::new(terminal_id.clone(), cwd.clone());
+                #[cfg(unix)]
+                if let Some(cwd_before_agent_session) = cwd_before_agent_session {
+                    terminal.session_reported_cwd = Some(cwd.clone());
+                    terminal.cwd_before_agent_session = Some(cwd_before_agent_session);
+                }
                 if was_imported {
                     if let Some(argv) = saved_launch_argv {
                         terminal = terminal.with_launch_argv(argv).with_respawn_shell_on_exit();
@@ -1169,13 +1193,14 @@ mod tests {
 
     #[tokio::test]
     async fn restore_carries_persisted_agent_session_metadata() {
-        let cwd = std::env::current_dir().unwrap();
+        let shell_cwd = std::env::current_dir().unwrap();
+        let agent_cwd = shell_cwd.join("src");
         let snapshot = SessionSnapshot {
             version: super::super::snapshot::SNAPSHOT_VERSION,
             workspaces: vec![WorkspaceSnapshot {
                 id: Some("workspace".into()),
                 custom_name: None,
-                identity_cwd: cwd.clone(),
+                identity_cwd: shell_cwd.clone(),
                 worktree_space: None,
                 public_pane_numbers: HashMap::new(),
                 next_public_pane_number: 0,
@@ -1187,7 +1212,8 @@ mod tests {
                     panes: HashMap::from([(
                         0,
                         super::super::snapshot::PaneSnapshot {
-                            cwd,
+                            cwd: agent_cwd,
+                            cwd_before_agent_session: Some(shell_cwd.clone()),
                             label: Some("reviewer".into()),
                             agent_name: Some("reviewer".into()),
                             managed_agent_kind: Some("opencode".into()),
@@ -1238,6 +1264,7 @@ mod tests {
         );
         assert_eq!(terminal.agent_name, None);
         assert_eq!(terminal.manual_label.as_deref(), Some("reviewer"));
+        assert_eq!(terminal.cwd, shell_cwd);
         let session = terminal
             .persisted_agent_session
             .as_ref()
@@ -1274,6 +1301,7 @@ mod tests {
                             10,
                             super::super::snapshot::PaneSnapshot {
                                 cwd: cwd.clone(),
+                                cwd_before_agent_session: None,
                                 label: None,
                                 agent_name: None,
                                 managed_agent_kind: None,
@@ -1285,6 +1313,7 @@ mod tests {
                             20,
                             super::super::snapshot::PaneSnapshot {
                                 cwd: cwd.clone(),
+                                cwd_before_agent_session: None,
                                 label: None,
                                 agent_name: None,
                                 managed_agent_kind: None,
@@ -1338,6 +1367,7 @@ mod tests {
                 id.parse::<u32>().unwrap(),
                 super::super::snapshot::PaneSnapshot {
                     cwd: cwd.clone(),
+                    cwd_before_agent_session: None,
                     label: None,
                     agent_name: None,
                     managed_agent_kind: None,
@@ -1348,6 +1378,7 @@ mod tests {
         };
         let final_pane = super::super::snapshot::PaneSnapshot {
             cwd: cwd.clone(),
+            cwd_before_agent_session: None,
             label: Some("planner".into()),
             agent_name: Some("planner".into()),
             managed_agent_kind: None,
@@ -1481,7 +1512,8 @@ mod tests {
     #[cfg(unix)]
     async fn native_agent_restore_defers_runtime_launch() {
         let cwd = std::env::current_dir().unwrap();
-        let snapshot = SessionSnapshot {
+        let shell_cwd = cwd.parent().unwrap().to_path_buf();
+        let mut snapshot = SessionSnapshot {
             version: super::super::snapshot::SNAPSHOT_VERSION,
             workspaces: vec![WorkspaceSnapshot {
                 id: Some("workspace".into()),
@@ -1498,7 +1530,8 @@ mod tests {
                     panes: HashMap::from([(
                         0,
                         super::super::snapshot::PaneSnapshot {
-                            cwd,
+                            cwd: cwd.clone(),
+                            cwd_before_agent_session: Some(shell_cwd.clone()),
                             label: None,
                             agent_name: None,
                             managed_agent_kind: None,
@@ -1525,7 +1558,7 @@ mod tests {
         };
         let (events, _event_rx) = mpsc::channel(4);
 
-        let (_workspaces, terminals, runtimes) = restore(
+        let (_workspaces, mut terminals, runtimes) = restore(
             &snapshot,
             None,
             24,
@@ -1540,7 +1573,7 @@ mod tests {
         );
 
         let terminal = terminals
-            .values()
+            .values_mut()
             .next()
             .expect("native agent restore should create terminal state");
         assert!(
@@ -1555,8 +1588,17 @@ mod tests {
             runtimes.is_empty(),
             "native agent restore should not spawn a fallback-size runtime during snapshot restore"
         );
+        assert_eq!(terminal.session_reported_cwd.as_ref(), Some(&cwd));
+        assert_eq!(terminal.cwd_before_agent_session.as_ref(), Some(&shell_cwd));
+        terminal.clear_agent_runtime_identity_after_respawn();
+        assert_eq!(terminal.cwd, shell_cwd);
+        snapshot.workspaces[0].tabs[0]
+            .panes
+            .get_mut(&0)
+            .unwrap()
+            .cwd_before_agent_session = Some(cwd.join("Cargo.toml"));
         let mut imports = HashMap::new();
-        let (_handoff_workspaces, handoff_terminals, handoff_runtimes) = restore_handoff(
+        let (_handoff_workspaces, mut handoff_terminals, handoff_runtimes) = restore_handoff(
             &snapshot,
             0,
             test_restore_shell(),
@@ -1568,7 +1610,7 @@ mod tests {
         )
         .expect("handoff restore should preserve pending native agent resume");
         let handoff_terminal = handoff_terminals
-            .values()
+            .values_mut()
             .next()
             .expect("handoff restore should create terminal state");
         assert!(
@@ -1579,6 +1621,9 @@ mod tests {
             handoff_runtimes.is_empty(),
             "handoff restore should not replace pending native agent resume with a shell runtime"
         );
+        assert!(handoff_terminal.cwd_before_agent_session.is_none());
+        handoff_terminal.clear_agent_runtime_identity_after_respawn();
+        assert_eq!(handoff_terminal.cwd, cwd);
     }
 
     #[tokio::test]
@@ -1665,6 +1710,7 @@ mod tests {
             0,
             super::super::snapshot::PaneSnapshot {
                 cwd: cwd.clone(),
+                cwd_before_agent_session: None,
                 label: None,
                 agent_name: None,
                 managed_agent_kind: None,

--- a/src/persist/snapshot.rs
+++ b/src/persist/snapshot.rs
@@ -98,6 +98,8 @@ pub struct TabSnapshot {
 pub struct PaneSnapshot {
     pub cwd: PathBuf,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd_before_agent_session: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_name: Option<String>,
@@ -363,6 +365,8 @@ fn capture_tab(
             id.raw(),
             PaneSnapshot {
                 cwd,
+                cwd_before_agent_session: terminal
+                    .and_then(|terminal| terminal.cwd_before_agent_session.clone()),
                 label,
                 agent_name,
                 managed_agent_kind,
@@ -643,6 +647,7 @@ mod tests {
             0,
             PaneSnapshot {
                 cwd: PathBuf::from("/home/can/Projects/herdr"),
+                cwd_before_agent_session: None,
                 label: None,
                 agent_name: None,
                 managed_agent_kind: None,
@@ -654,6 +659,7 @@ mod tests {
             1,
             PaneSnapshot {
                 cwd: PathBuf::from("/home/can/Projects/website"),
+                cwd_before_agent_session: None,
                 label: Some("website".into()),
                 agent_name: None,
                 managed_agent_kind: None,
@@ -1009,7 +1015,10 @@ mod tests {
         let root_terminal_id = state.workspaces[0].tabs[0].panes[&root]
             .attached_terminal_id
             .clone();
-        state.terminals.get_mut(&root_terminal_id).unwrap().cwd = PathBuf::from("/tmp/pion");
+        let root_terminal = state.terminals.get_mut(&root_terminal_id).unwrap();
+        root_terminal.cwd = PathBuf::from("/tmp/pion");
+        root_terminal.cwd_before_agent_session = Some(PathBuf::from("/tmp/shell"));
+        root_terminal.session_reported_cwd = Some(PathBuf::from("/tmp/pion"));
         let second_terminal_id = state.workspaces[0].tabs[0].panes[&second]
             .attached_terminal_id
             .clone();
@@ -1020,6 +1029,10 @@ mod tests {
         let tab = &workspace.tabs[0];
         assert_eq!(workspace.identity_cwd, PathBuf::from("/tmp/pion"));
         assert_eq!(tab.panes[&root.raw()].cwd, PathBuf::from("/tmp/pion"));
+        assert_eq!(
+            tab.panes[&root.raw()].cwd_before_agent_session,
+            Some(PathBuf::from("/tmp/shell"))
+        );
         assert_eq!(tab.panes[&second.raw()].cwd, PathBuf::from("/tmp/herdr"));
     }
 
@@ -1202,6 +1215,7 @@ mod tests {
             0,
             PaneSnapshot {
                 cwd: PathBuf::from("/tmp/this-directory-does-not-exist-for-herdr-test"),
+                cwd_before_agent_session: None,
                 label: None,
                 agent_name: None,
                 managed_agent_kind: None,
@@ -1215,6 +1229,7 @@ mod tests {
                 cwd: std::env::var("HOME")
                     .map(PathBuf::from)
                     .unwrap_or_else(|_| PathBuf::from("/tmp")),
+                cwd_before_agent_session: None,
                 label: None,
                 agent_name: None,
                 managed_agent_kind: None,

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -1306,12 +1306,11 @@ impl HeadlessServer {
                 continue;
             };
             let mut handoff_runtime = runtime.handoff_runtime_state(pane_id);
-            let has_agent_session = self
-                .app
-                .state
-                .terminals
-                .get(terminal_id)
-                .is_some_and(|terminal| terminal.persisted_agent_session.is_some());
+            let terminal = self.app.state.terminals.get(terminal_id);
+            handoff_runtime.cwd_before_agent_session =
+                terminal.and_then(|terminal| terminal.cwd_before_agent_session.clone());
+            let has_agent_session =
+                terminal.is_some_and(|terminal| terminal.persisted_agent_session.is_some());
             if !has_agent_session {
                 handoff_runtime.initial_history_ansi = runtime.handoff_history_ansi();
             }

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -120,6 +120,8 @@ struct RecentAgentProcessExit {
 pub struct TerminalState {
     pub id: TerminalId,
     pub cwd: PathBuf,
+    pub(crate) session_reported_cwd: Option<PathBuf>,
+    pub(crate) cwd_before_agent_session: Option<PathBuf>,
     pub detected_agent: Option<Agent>,
     pub fallback_state: AgentState,
     fallback_visible_blocker: bool,
@@ -154,6 +156,8 @@ impl TerminalState {
         Self {
             id,
             cwd,
+            session_reported_cwd: None,
+            cwd_before_agent_session: None,
             detected_agent: None,
             fallback_state: AgentState::Unknown,
             fallback_visible_blocker: false,
@@ -182,6 +186,16 @@ impl TerminalState {
             agent_process_acquisition_pending: false,
             pending_agent_resume_plan: None,
         }
+    }
+
+    pub(crate) fn restore_cwd_before_agent_session(&mut self) -> bool {
+        self.session_reported_cwd = None;
+        let Some(cwd) = self.cwd_before_agent_session.take() else {
+            return false;
+        };
+        let changed = self.cwd != cwd;
+        self.cwd = cwd;
+        changed
     }
 
     pub fn set_detected_agent_process_at(
@@ -573,6 +587,14 @@ impl TerminalState {
             self.persisted_agent_session = durable_session;
         }
         if agent_released {
+            if previous_session
+                .as_ref()
+                .is_none_or(|(_, session_agent, _, _)| {
+                    crate::detect::parse_agent_label(session_agent) == agent
+                })
+            {
+                self.restore_cwd_before_agent_session();
+            }
             self.clear_agent_name();
         }
         TerminalStateMutation {
@@ -2047,6 +2069,7 @@ impl TerminalState {
     }
 
     pub fn clear_agent_runtime_identity_after_respawn(&mut self) {
+        self.restore_cwd_before_agent_session();
         self.detected_agent = None;
         self.fallback_state = AgentState::Unknown;
         self.fallback_visible_blocker = false;
@@ -5594,6 +5617,11 @@ mod tests {
     #[test]
     fn process_exit_clears_matching_persisted_session_ref() {
         let mut terminal = test_terminal();
+        let shell_cwd = terminal.cwd.clone();
+        let agent_cwd = shell_cwd.join("agent-cwd");
+        terminal.cwd_before_agent_session = Some(shell_cwd.clone());
+        terminal.session_reported_cwd = Some(agent_cwd.clone());
+        terminal.cwd = agent_cwd;
         let session_ref =
             crate::agent_resume::AgentSessionRef::path(test_session_path("pi.jsonl")).unwrap();
         terminal.set_persisted_agent_session(crate::agent_resume::PersistedAgentSession {
@@ -5615,6 +5643,9 @@ mod tests {
 
         assert!(mutation.session_ref_changed);
         assert!(terminal.persisted_agent_session.is_none());
+        assert!(terminal.session_reported_cwd.is_none());
+        assert!(terminal.cwd_before_agent_session.is_none());
+        assert_eq!(terminal.cwd, shell_cwd);
 
         let delayed = terminal.set_agent_session_ref(
             "herdr:pi".into(),
@@ -5629,6 +5660,11 @@ mod tests {
     #[test]
     fn process_exit_preserves_foreign_persisted_session_ref() {
         let mut terminal = test_terminal();
+        let shell_cwd = terminal.cwd.clone();
+        let agent_cwd = shell_cwd.join("agent-cwd");
+        terminal.cwd_before_agent_session = Some(shell_cwd);
+        terminal.session_reported_cwd = Some(agent_cwd.clone());
+        terminal.cwd = agent_cwd.clone();
         terminal.set_persisted_agent_session(crate::agent_resume::PersistedAgentSession {
             source: "herdr:claude".into(),
             agent: "claude".into(),
@@ -5654,6 +5690,8 @@ mod tests {
                 .map(|session| session.session_ref.value.as_str()),
             Some("claude-session")
         );
+        assert_eq!(terminal.session_reported_cwd.as_ref(), Some(&agent_cwd));
+        assert_eq!(terminal.cwd, agent_cwd);
     }
 
     #[test]

--- a/src/workspace/tab.rs
+++ b/src/workspace/tab.rs
@@ -566,9 +566,10 @@ impl Tab {
         terminal_runtimes: &TerminalRuntimeRegistry,
     ) -> Option<PathBuf> {
         let terminal_id = self.terminal_id(pane_id)?;
-        terminal_runtimes
+        terminals
             .get(terminal_id)
-            .and_then(|rt| rt.cwd())
+            .and_then(|terminal| terminal.session_reported_cwd.clone())
+            .or_else(|| terminal_runtimes.get(terminal_id).and_then(|rt| rt.cwd()))
             .or_else(|| {
                 terminals
                     .get(terminal_id)

--- a/tests/cli/hooks.rs
+++ b/tests/cli/hooks.rs
@@ -154,12 +154,13 @@ fn claude_hook_reports_session_id_from_stdin() {
 fn codex_hook_reports_persisted_root_session_and_ignores_ephemeral_or_nested_sessions() {
     let request = run_codex_hook(
         "session",
-        r#"{"hook_event_name":"SessionStart","session_id":"codex-session","transcript_path":"/tmp/codex-session.jsonl"}"#,
+        r#"{"hook_event_name":"SessionStart","session_id":"codex-session","transcript_path":"/tmp/codex-session.jsonl","cwd":"/tmp/project"}"#,
     )
     .expect("codex hook should report session identity");
 
     assert_eq!(request["method"], "pane.report_agent_session");
     assert_eq!(request["params"]["agent_session_id"], "codex-session");
+    assert_eq!(request["params"]["cwd"], "/tmp/project");
     assert!(request["params"].get("state").is_none());
 
     let matching_request = run_shell_hook_with_env(

--- a/tests/live_handoff.rs
+++ b/tests/live_handoff.rs
@@ -1260,36 +1260,6 @@ fn live_handoff_keeps_unmanaged_agent_name_bound_to_saved_session() {
         }),
     ));
     support::wait_for_file(&started_marker, Duration::from_secs(5));
-    assert_ok(request(
-        &api_socket,
-        serde_json::json!({
-            "id": "test:agent:session",
-            "method": "pane.report_agent_session",
-            "params": {
-                "pane_id": pane_id,
-                "source": "herdr:pi",
-                "agent": "pi",
-                "seq": 1,
-                "agent_session_path": old_session,
-                "session_start_source": "startup"
-            }
-        }),
-    ));
-    assert_ok(request(
-        &api_socket,
-        serde_json::json!({
-            "id": "test:agent:report",
-            "method": "pane.report_agent",
-            "params": {
-                "pane_id": pane_id,
-                "source": "herdr:pi",
-                "agent": "pi",
-                "state": "idle",
-                "seq": 2,
-                "agent_session_path": old_session
-            }
-        }),
-    ));
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         let response = request(
@@ -1312,6 +1282,37 @@ fn live_handoff_keeps_unmanaged_agent_name_bound_to_saved_session() {
     assert_ok(request(
         &api_socket,
         serde_json::json!({
+            "id": "test:agent:session",
+            "method": "pane.report_agent_session",
+            "params": {
+                "pane_id": pane_id,
+                "source": "herdr:pi",
+                "agent": "pi",
+                "seq": 1,
+                "agent_session_path": old_session,
+                "session_start_source": "startup",
+                "cwd": base.display().to_string()
+            }
+        }),
+    ));
+    assert_ok(request(
+        &api_socket,
+        serde_json::json!({
+            "id": "test:agent:report",
+            "method": "pane.report_agent",
+            "params": {
+                "pane_id": pane_id,
+                "source": "herdr:pi",
+                "agent": "pi",
+                "state": "idle",
+                "seq": 2,
+                "agent_session_path": old_session
+            }
+        }),
+    ));
+    assert_ok(request(
+        &api_socket,
+        serde_json::json!({
             "id": "test:agent:rename",
             "method": "agent.rename",
             "params": {"target": pane_id, "name": "reviewer"}
@@ -1324,6 +1325,21 @@ fn live_handoff_keeps_unmanaged_agent_name_bound_to_saved_session() {
     ));
     drop(spawned);
     wait_for_api(&api_socket, Duration::from_secs(10));
+
+    let split = request(
+        &api_socket,
+        serde_json::json!({
+            "id": "test:pane:split-after-handoff",
+            "method": "pane.split",
+            "params": {
+                "target_pane_id": pane_id,
+                "direction": "right",
+                "focus": false
+            }
+        }),
+    );
+    assert_ok(split.clone());
+    assert_eq!(split["result"]["pane"]["cwd"], base.display().to_string());
 
     assert_ok(request(
         &api_socket,


### PR DESCRIPTION
## What

Codex 0.149 added `/cd`, plus `/pwd` and `/cwd` for checking the active directory.

Herdr's Codex integration already receives the active working directory in the `SessionStart` hook. It now forwards that value with the existing session report, so Herdr follows directory changes made through `/cd`.

## Why

Before this, Codex changed its own session directory but Herdr still kept the directory where the pane started. That left workspace naming, Git status, new panes, and restored sessions on the old path.

The accepted Codex session report owns the pane directory while that session is active. Delayed shell reports cannot overwrite it. When Codex exits, the shell takes ownership again. Live handoff keeps the same behavior.

## Test

- Codex hook forwarding on PowerShell and shell
- accepted, stale, delayed, and cleared CWD reports
- workspace identity and Git refresh
- process exit and live handoff lifecycle
- `just check`
