### PR TITLE
fix: keep omp panes working through scheduled continuations

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Windows users whose endpoint security blocks the fileless PowerShell install command can now use a local `install.cmd` bootstrap; installer downloads use `curl.exe` while preserving package checksum verification. (#2751)
+- Oh My Pi panes now stay working when a turn ends with an automatic continuation already scheduled, instead of briefly reporting idle and completing `agent wait` early. (#2851, thanks @taoeffect)
 - Retained mouse selections now copy when Ctrl+C or Cmd+C arrives before a delayed mouse release instead of forwarding the copy shortcut to the pane. (#3100, thanks @moret)
 - Removing a background worktree workspace no longer changes focus to its parent workspace. (#3098)
 - Prefix bindings such as `prefix+|` now recognize characters produced by macOS Option and custom keyboard layouts, while exact chords such as `prefix+alt+w` keep priority. (#3079, thanks @vlcinsky)

--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -498,6 +498,45 @@ test("Oh My Pi retries working before a queued idle state", async () => {
   expect(requestState(attemptedRequests[2])).toBe("idle");
 });
 
+test("Oh My Pi keeps working when a turn ends with a scheduled continuation", async () => {
+  const requests = await startRecordingServer("omp-will-continue");
+  process.env.HERDR_OMP_IDLE_DEBOUNCE_MS = "0";
+  const { handlers, pi } = createExtensionHarness();
+
+  const { default: install } = await importFresh("./omp/herdr-agent-state.ts");
+  install(pi);
+
+  let idle = true;
+  const context = {
+    hasUI: true,
+    isIdle: () => idle,
+    sessionManager: {
+      getSessionFile: () => undefined,
+      getSessionId: () => undefined,
+    },
+  };
+
+  handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+
+  idle = false;
+  handlers.get("agent_start")?.({}, context);
+  await waitFor(() => requestStates(requests).length === 2);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  // OMP already scheduled an automatic continuation, so this loop end is not a
+  // user-visible settle and must not publish idle. See issue #2851.
+  handlers.get("agent_end")?.({ messages: [], willContinue: true }, context);
+  await Bun.sleep(50);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  // The real terminal end still settles the pane.
+  idle = true;
+  handlers.get("agent_end")?.({ messages: [] }, context);
+  await waitFor(() => requestStates(requests).length === 3);
+  expect(requestStates(requests)).toEqual(["idle", "working", "idle"]);
+});
+
 test("Pi retries working state after an unanswered socket attempt", async () => {
   const { attemptedRequests, deliveredRequests, connectionCount } =
     await startDroppedFirstResponseServer("pi-retry");

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -2,7 +2,7 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=omp
-// HERDR_INTEGRATION_VERSION=8
+// HERDR_INTEGRATION_VERSION=9
 // @ts-nocheck
 
 import net from "node:net";
@@ -440,6 +440,11 @@ export default function (pi) {
       // OMP can emit duplicate/late end events while auto-retry is already
       // holding the pane in Working. Do not let an unqualified duplicate end
       // cancel the retry hold and publish a false Idle.
+      return;
+    }
+    if (event?.willContinue === true) {
+      // A continuation is already scheduled, so this end is not a settle.
+      // Older builds omit the field and fall through as before.
       return;
     }
 

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -27,7 +27,7 @@ const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
 const PI_INTEGRATION_VERSION: u32 = 8;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
-const OMP_INTEGRATION_VERSION: u32 = 8;
+const OMP_INTEGRATION_VERSION: u32 = 9;
 const CLAUDE_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
     "herdr-agent-state.ps1"
 } else {


### PR DESCRIPTION
Follow-up to #3026, reduced to only the `willContinue` fix as requested.

refs #2851

## Problem

Oh My Pi's herdr extension published `idle` on every `agent_end` that was not a
retryable error. OMP also emits `agent_end` for turns it has *already* scheduled
a continuation for (auto-retry, compaction continuation, hidden `session_stop`
turns), so the pane briefly settled to idle mid-turn and `agent wait` completed
against a turn that was still running.

## Fix

Return early from `agent_end` when the event carries `willContinue: true`.

`willContinue` is part of OMP's public extension event API and is set by the
producer exactly when a continuation is already scheduled, so an end carrying it
is not a user-visible settle. Upstream's own subscriber uses the same
`if (event.willContinue) return;` guard.

The guard sits after the existing duplicate-end check and before `agentActive`
is cleared, so the pane stays Working and the real terminal `agent_end` still
settles it normally. Builds older than the field simply omit it and fall through
to the previous behaviour, so this does not depend on a minimum OMP version.

## Scope

This does not change `agent wait`, which keeps returning when an agent reports
idle or done. The premature idle is fixed at the source that reported it.

It also does not add reporter process authentication; the nested-session
takeover path discussed on #3026 is left alone and would need its own issue if
it is worth pursuing.

## Tests

`src/integration/assets/herdr-agent-state.test.ts` gains
`"Oh My Pi keeps working when a turn ends with a scheduled continuation"`,
modelled on the existing OMP retry test. It asserts the pane stays `working`
after an `agent_end` with `willContinue: true`, then settles to `idle` on the
real end. Removing the guard fails the test on the first assertion.

`OMP_INTEGRATION_VERSION` moves 8 -> 9 alongside the asset marker; v0.8.2
shipped 8.

- `just integration-assets-test` — 16 pass / 0 fail
- `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings` — clean
- `cargo nextest run --locked --no-fail-fast` — 3342 passed, 2 failed
  (`live_handoff_*`, pre-existing on this machine, they need an agent binary on
  PATH and fail identically on a pristine checkout)
