### PR TITLE
fix: clear Windows Terminal identity in panes

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -78,6 +78,7 @@ fn apply_pane_terminal_env(cmd: &mut CommandBuilder) {
     // when the remote side lacks matching terminfo entries.
     cmd.env("TERM", PANE_TERM);
     cmd.env("COLORTERM", PANE_COLORTERM);
+    cmd.env_remove("WT_SESSION");
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -3099,6 +3100,16 @@ mod tests {
         apply_pane_launch_env(&mut cmd, &PaneLaunchEnv::default());
 
         assert!(cmd.get_env("CODEX_THREAD_ID").is_none());
+    }
+
+    #[test]
+    fn pane_terminal_identity_removes_outer_windows_terminal_session() {
+        let mut cmd = CommandBuilder::new("shell");
+        cmd.env("WT_SESSION", "outer-session");
+
+        apply_pane_terminal_env(&mut cmd);
+
+        assert!(cmd.get_env("WT_SESSION").is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Herdr already replaces `TERM` and `COLORTERM` for new panes because its own terminal layer sits between child processes and the outer terminal.

On Windows, panes still inherited `WT_SESSION` from Windows Terminal. Child programs could thus identify themselves as running directly in Windows Terminal even though Herdr owns the PTY.

This clears `WT_SESSION` in the same shared pane environment setup.

## Why

I hit this while resuming a very long Codex 0.149 session. Codex uses `WT_SESSION` to select its Windows Terminal history path, including full-screen history insertion and a 9,001-row resize/reflow budget.

Inside Herdr that produced a rapid transcript repaint and scroll jumps during startup.

I tested the same upstream Codex version, thread, pane size, and machine against current master and this change:

| | Current master | This PR |
|---|---:|---:|
| `WT_SESSION` inherited | yes | no |
| Peak scroll offset during resume | 16,053 rows | 1,229 rows |

Both restored the same transcript. Herdr's existing `TERM` and `COLORTERM` contract stays as-is. This does not change Codex behavior when it runs directly in Windows Terminal.

## Testing

- `just check`
- focused pane environment contract test
- A/B resume with upstream Codex 0.149.0 in disposable Herdr sessions

## Note

Eventually, it could make sense to make a more general pass over what herdr strips. But this was an obvious annoyance, hence starting with this.