### PR TITLE
fix(windows): avoid PowerShell web downloads in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ https://github.com/user-attachments/assets/043ec09f-4bdd-41d5-aee0-8fda6b83e267
 curl -fsSL https://herdr.dev/install.sh | sh
 ```
 
-or `brew install herdr` · `mise use -g herdr` · windows: `powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"` · [binaries](https://github.com/herdrdev/herdr/releases)
+or `brew install herdr` · `mise use -g herdr` · windows: [installer](https://herdr.dev/docs/windows-beta/) · [binaries](https://github.com/herdrdev/herdr/releases)
 
 then start it where the work lives:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,7 @@ https://github.com/user-attachments/assets/043ec09f-4bdd-41d5-aee0-8fda6b83e267
 curl -fsSL https://herdr.dev/install.sh | sh
 ```
 
-或者 `brew install herdr` · `mise use -g herdr` · Windows：`powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"` · [二进制文件](https://github.com/herdrdev/herdr/releases)
+或者 `brew install herdr` · `mise use -g herdr` · Windows：[安装程序](https://herdr.dev/docs/zh-cn/windows-beta/) · [二进制文件](https://github.com/herdrdev/herdr/releases)
 
 然后在工作所在的目录启动它：
 

--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- The public Windows installer now downloads through `curl.exe` and runs from a local file instead of piping a PowerShell web response into `Invoke-Expression`, avoiding the downloader pattern blocked by endpoint security tools. (#2751)
 - Retained mouse selections now copy when Ctrl+C or Cmd+C arrives before a delayed mouse release instead of forwarding the copy shortcut to the pane. (#3100, thanks @moret)
 - Removing a background worktree workspace no longer changes focus to its parent workspace. (#3098)
 - Prefix bindings such as `prefix+|` now recognize characters produced by macOS Option and custom keyboard layouts, while exact chords such as `prefix+alt+w` keep priority. (#3079, thanks @vlcinsky)

--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -44,7 +44,7 @@ https://github.com/user-attachments/assets/043ec09f-4bdd-41d5-aee0-8fda6b83e267
 curl -fsSL https://herdr.dev/install.sh | sh
 ```
 
-or `brew install herdr` · `mise use -g herdr` · windows: `powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"` · [binaries](https://github.com/herdrdev/herdr/releases)
+or `brew install herdr` · `mise use -g herdr` · windows: [installer](https://herdr.dev/docs/windows-beta/) · [binaries](https://github.com/herdrdev/herdr/releases)
 
 then start it where the work lives:
 

--- a/docs/next/README.zh-CN.md
+++ b/docs/next/README.zh-CN.md
@@ -42,7 +42,7 @@ https://github.com/user-attachments/assets/043ec09f-4bdd-41d5-aee0-8fda6b83e267
 curl -fsSL https://herdr.dev/install.sh | sh
 ```
 
-或者 `brew install herdr` · `mise use -g herdr` · Windows：`powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"` · [二进制文件](https://github.com/herdrdev/herdr/releases)
+或者 `brew install herdr` · `mise use -g herdr` · Windows：[安装程序](https://herdr.dev/docs/zh-cn/windows-beta/) · [二进制文件](https://github.com/herdrdev/herdr/releases)
 
 然后在工作所在的目录启动它：
 

--- a/docs/next/website/src/content/docs/install.mdx
+++ b/docs/next/website/src/content/docs/install.mdx
@@ -16,7 +16,16 @@ curl -fsSL https://herdr.dev/install.sh | sh
 On Windows, run:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 The installer downloads the release binary for your platform and places it on your PATH. New direct installs use the stable update channel. Existing Windows preview installs stay on preview until you switch them with `herdr channel set stable`. The Windows installer uses versioned install folders and updates a `current` junction, so updates do not need to overwrite a running `herdr.exe`.

--- a/docs/next/website/src/content/docs/ja/install.mdx
+++ b/docs/next/website/src/content/docs/ja/install.mdx
@@ -16,7 +16,16 @@ curl -fsSL https://herdr.dev/install.sh | sh
 Windows では次を実行します:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 インストーラーはプラットフォームに合ったリリースバイナリをダウンロードして PATH 上に配置します。新しい直接インストールは安定版アップデートチャンネルを使います。既存の Windows プレビューインストールは、`herdr channel set stable` で切り替えるまでプレビューに残ります。Windows インストーラーはバージョン付きインストールフォルダーを使い、`current` ジャンクションを更新します。そのため、アップデート時に実行中の `herdr.exe` を上書きする必要がありません。

--- a/docs/next/website/src/content/docs/ja/windows-beta.mdx
+++ b/docs/next/website/src/content/docs/ja/windows-beta.mdx
@@ -10,7 +10,16 @@ Windows 上の Herdr は、Herdr が本来前提としていた Unix の PTY モ
 Windows に Herdr をネイティブインストールするには PowerShell を使います:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 Windows ビルドは安定版とプレビューの両方のアップデートチャンネルで提供されます。新規インストールはデフォルトで安定版を使い、通常の利用には安定版を推奨します。既存のプレビューインストールは、`herdr channel set stable` を実行するまでプレビューに残ります。古いプレビュービルドでこのコマンドが拒否される場合は、プレビューのまま一度 `herdr update` を実行してから再試行してください。プレビューでは `master` からの新しく検証の少ない修正を受け取れますが、リグレッションが起きる可能性があります。そのトレードオフを望む場合に限り、`herdr channel set preview` でオプトインしてください。

--- a/docs/next/website/src/content/docs/windows-beta.mdx
+++ b/docs/next/website/src/content/docs/windows-beta.mdx
@@ -10,7 +10,16 @@ Herdr on Windows uses ConPTY and Windows process/runtime behavior instead of the
 Install Herdr natively on Windows with PowerShell:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 Windows builds are available through both stable and preview update channels. New installs use stable by default, and stable is recommended for normal use. Existing preview installs stay on preview until you run `herdr channel set stable`. If an older preview build rejects that command, run `herdr update` once on preview and retry. Preview provides newer, less-tested fixes from `master` and may regress; opt in with `herdr channel set preview` only when you want that tradeoff.

--- a/docs/next/website/src/content/docs/zh-cn/install.mdx
+++ b/docs/next/website/src/content/docs/zh-cn/install.mdx
@@ -16,7 +16,16 @@ curl -fsSL https://herdr.dev/install.sh | sh
 在 Windows 上运行:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 安装器会下载适合你平台的发布二进制文件并放到 PATH 上。新的直接安装默认使用稳定更新通道。现有的 Windows 预览安装会继续留在预览通道,直到你运行 `herdr channel set stable`。Windows 安装器使用带版本号的安装文件夹,并更新一个 `current` 联接点,因此更新时不需要覆盖正在运行的 `herdr.exe`。

--- a/docs/next/website/src/content/docs/zh-cn/windows-beta.mdx
+++ b/docs/next/website/src/content/docs/zh-cn/windows-beta.mdx
@@ -10,7 +10,16 @@ Windows 上的 Herdr 使用 ConPTY 和 Windows 的进程/运行时行为,而不�
 使用 PowerShell 在 Windows 上原生安装 Herdr:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 Windows 构建同时通过稳定版和预览版更新通道提供。新安装默认使用稳定版,常规使用也建议选择稳定版。现有预览安装会继续留在预览通道,直到你运行 `herdr channel set stable`。如果旧预览构建拒绝该命令,请先在预览通道运行一次 `herdr update`,再重试。预览版会提供来自 `master` 的更新、测试较少的修复,也可能出现回归;只有在接受这一取舍时,才应通过 `herdr channel set preview` 主动启用。

--- a/docs/versions/0.8.2/website/src/content/docs/install.mdx
+++ b/docs/versions/0.8.2/website/src/content/docs/install.mdx
@@ -16,7 +16,16 @@ curl -fsSL https://herdr.dev/install.sh | sh
 On Windows, run:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 The installer downloads the release binary for your platform and places it on your PATH. New direct installs use the stable update channel. Existing Windows preview installs stay on preview until you switch them with `herdr channel set stable`. The Windows installer uses versioned install folders and updates a `current` junction, so updates do not need to overwrite a running `herdr.exe`.

--- a/docs/versions/0.8.2/website/src/content/docs/ja/install.mdx
+++ b/docs/versions/0.8.2/website/src/content/docs/ja/install.mdx
@@ -16,7 +16,16 @@ curl -fsSL https://herdr.dev/install.sh | sh
 Windows では次を実行します:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 インストーラーはプラットフォームに合ったリリースバイナリをダウンロードして PATH 上に配置します。新しい直接インストールは安定版アップデートチャンネルを使います。既存の Windows プレビューインストールは、`herdr channel set stable` で切り替えるまでプレビューに残ります。Windows インストーラーはバージョン付きインストールフォルダーを使い、`current` ジャンクションを更新します。そのため、アップデート時に実行中の `herdr.exe` を上書きする必要がありません。

--- a/docs/versions/0.8.2/website/src/content/docs/ja/windows-beta.mdx
+++ b/docs/versions/0.8.2/website/src/content/docs/ja/windows-beta.mdx
@@ -10,7 +10,16 @@ Windows 上の Herdr は、Herdr が本来前提としていた Unix の PTY モ
 Windows に Herdr をネイティブインストールするには PowerShell を使います:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 Windows ビルドは安定版とプレビューの両方のアップデートチャンネルで提供されます。新規インストールはデフォルトで安定版を使い、通常の利用には安定版を推奨します。既存のプレビューインストールは、`herdr channel set stable` を実行するまでプレビューに残ります。古いプレビュービルドでこのコマンドが拒否される場合は、プレビューのまま一度 `herdr update` を実行してから再試行してください。プレビューでは `master` からの新しく検証の少ない修正を受け取れますが、リグレッションが起きる可能性があります。そのトレードオフを望む場合に限り、`herdr channel set preview` でオプトインしてください。

--- a/docs/versions/0.8.2/website/src/content/docs/windows-beta.mdx
+++ b/docs/versions/0.8.2/website/src/content/docs/windows-beta.mdx
@@ -10,7 +10,16 @@ Herdr on Windows uses ConPTY and Windows process/runtime behavior instead of the
 Install Herdr natively on Windows with PowerShell:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 Windows builds are available through both stable and preview update channels. New installs use stable by default, and stable is recommended for normal use. Existing preview installs stay on preview until you run `herdr channel set stable`. If an older preview build rejects that command, run `herdr update` once on preview and retry. Preview provides newer, less-tested fixes from `master` and may regress; opt in with `herdr channel set preview` only when you want that tradeoff.

--- a/docs/versions/0.8.2/website/src/content/docs/zh-cn/install.mdx
+++ b/docs/versions/0.8.2/website/src/content/docs/zh-cn/install.mdx
@@ -16,7 +16,16 @@ curl -fsSL https://herdr.dev/install.sh | sh
 在 Windows 上运行:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 安装器会下载适合你平台的发布二进制文件并放到 PATH 上。新的直接安装默认使用稳定更新通道。现有的 Windows 预览安装会继续留在预览通道,直到你运行 `herdr channel set stable`。Windows 安装器使用带版本号的安装文件夹,并更新一个 `current` 联接点,因此更新时不需要覆盖正在运行的 `herdr.exe`。

--- a/docs/versions/0.8.2/website/src/content/docs/zh-cn/windows-beta.mdx
+++ b/docs/versions/0.8.2/website/src/content/docs/zh-cn/windows-beta.mdx
@@ -10,7 +10,16 @@ Windows 上的 Herdr 使用 ConPTY 和 Windows 的进程/运行时行为,而不�
 使用 PowerShell 在 Windows 上原生安装 Herdr:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 ```
 
 Windows 构建同时通过稳定版和预览版更新通道提供。新安装默认使用稳定版,常规使用也建议选择稳定版。现有预览安装会继续留在预览通道,直到你运行 `herdr channel set stable`。如果旧预览构建拒绝该命令,请先在预览通道运行一次 `herdr update`,再重试。预览版会提供来自 `master` 的更新、测试较少的修复,也可能出现回归;只有在接受这一取舍时,才应通过 `herdr channel set preview` 主动启用。

--- a/scripts/windows_install_conpty_package_test.ps1
+++ b/scripts/windows_install_conpty_package_test.ps1
@@ -17,6 +17,17 @@ $installerAst = [System.Management.Automation.Language.Parser]::ParseFile(
 if ($parseErrors.Count -ne 0) {
     throw ($parseErrors | Out-String)
 }
+$forbiddenNetworkCommands = @(
+    $installerAst.FindAll(
+        { param($node) $node -is [System.Management.Automation.Language.CommandAst] },
+        $true
+    ) |
+        ForEach-Object { $_.GetCommandName() } |
+        Where-Object { $_ -in @("Invoke-RestMethod", "Invoke-WebRequest") }
+)
+if ($forbiddenNetworkCommands.Count -ne 0) {
+    throw "installer performs network downloads through PowerShell: $($forbiddenNetworkCommands -join ', ')"
+}
 foreach ($functionName in @("Prepend-PathEntry", "Update-PathRegistryEntry")) {
     $definition = $installerAst.FindAll(
         {

--- a/website/agent-guide.md
+++ b/website/agent-guide.md
@@ -35,7 +35,16 @@ herdr
 Windows:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"
+$installer = Join-Path $env:TEMP "herdr-install-$([guid]::NewGuid().ToString('N')).ps1"
+try {
+    $curl = (Get-Command curl.exe -CommandType Application -ErrorAction Stop).Source
+    & $curl --fail --silent --show-error --location --proto "=https" --tlsv1.2 --output $installer -- https://herdr.dev/install.ps1
+    if ($LASTEXITCODE -ne 0) { throw "Failed to download the Herdr installer." }
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer
+    if ($LASTEXITCODE -ne 0) { throw "The Herdr installer failed." }
+} finally {
+    Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+}
 herdr
 ```
 

--- a/website/index.html
+++ b/website/index.html
@@ -475,7 +475,7 @@
                         <button type="button" id="copy-btn-2" aria-label="Copy install command">copy</button>
                     </div>
                 </div>
-                <div class="meta">Windows: <code>irm https://herdr.dev/install.ps1 | iex</code> &nbsp;—&nbsp; <a href="/docs/">all install methods →</a></div>
+                <div class="meta">Windows: <a href="/docs/windows-beta/">local PowerShell installer</a> &nbsp;—&nbsp; <a href="/docs/">all install methods →</a></div>
             </div>
         </section>
 

--- a/website/install.ps1
+++ b/website/install.ps1
@@ -216,6 +216,48 @@ function Get-ManifestAsset {
     }
 }
 
+function Invoke-CurlDownload {
+    param(
+        [string]$Uri,
+        [string]$Destination
+    )
+
+    $parsedUri = $null
+    if (-not [System.Uri]::TryCreate($Uri, [System.UriKind]::Absolute, [ref]$parsedUri) -or
+        $parsedUri.Scheme -notin @("http", "https")) {
+        throw "Herdr download URL must use HTTP or HTTPS: $Uri"
+    }
+
+    $curl = Get-Command curl.exe -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $curl) {
+        throw "Herdr installation requires curl.exe, which is included with supported Windows versions."
+    }
+
+    $arguments = @(
+        "--fail",
+        "--silent",
+        "--show-error",
+        "--location",
+        "--connect-timeout", "30"
+    )
+    if ($parsedUri.Scheme -eq "https") {
+        $arguments += @("--proto", "=https", "--tlsv1.2")
+    }
+    $arguments += @("--output", $Destination, "--", $Uri)
+
+    $curlOutput = & $curl.Source @arguments 2>&1
+    $curlExitCode = $LASTEXITCODE
+    if ($curlExitCode -ne 0) {
+        $detail = ($curlOutput | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
+        $message = "Failed to download $Uri (curl exit code $curlExitCode)."
+        if (-not [string]::IsNullOrWhiteSpace($detail)) {
+            $message += " $detail"
+        }
+        throw $message
+    }
+}
+
 function ConvertTo-ManifestObject {
     param([object]$Manifest)
 
@@ -230,6 +272,18 @@ function ConvertTo-ManifestObject {
     }
 
     return $json | ConvertFrom-Json
+}
+
+function Get-RemoteManifest {
+    param([string]$Uri)
+
+    $manifestPath = Join-Path ([System.IO.Path]::GetTempPath()) ("herdr-manifest-" + [System.Guid]::NewGuid().ToString("N") + ".json")
+    try {
+        Invoke-CurlDownload -Uri $Uri -Destination $manifestPath
+        return ConvertTo-ManifestObject -Manifest ([System.IO.File]::ReadAllText($manifestPath))
+    } finally {
+        Remove-Item -LiteralPath $manifestPath -Force -ErrorAction SilentlyContinue
+    }
 }
 
 function Test-FileDigest {
@@ -685,7 +739,7 @@ if ($useLocalPackage) {
     }
 
     Write-Step "Fetching Herdr $Channel manifest"
-    $manifest = ConvertTo-ManifestObject -Manifest (Invoke-RestMethod -Uri $ManifestUrl)
+    $manifest = Get-RemoteManifest -Uri $ManifestUrl
     $manifestChannelProperty = $manifest.PSObject.Properties["channel"]
     if (-not $channelWasExplicit -and $null -ne $manifestChannelProperty -and [string]$manifestChannelProperty.Value -eq "preview") {
         $Channel = "preview"
@@ -704,7 +758,7 @@ if ($useLocalPackage) {
         $Channel = "preview"
         $ManifestUrl = $ManifestUrl.Substring(0, $ManifestUrl.Length - "latest.json".Length) + "preview.json"
         Write-Step "Fetching Herdr preview manifest"
-        $manifest = ConvertTo-ManifestObject -Manifest (Invoke-RestMethod -Uri $ManifestUrl)
+        $manifest = Get-RemoteManifest -Uri $ManifestUrl
     }
     $asset = Get-ManifestAsset -Manifest $manifest -Target $target
     if (-not [string]::IsNullOrWhiteSpace($ExpectedBuildId) -and [string]$manifest.build_id -ne $ExpectedBuildId) {
@@ -733,7 +787,7 @@ try {
             $stagingDir = Join-Path $releasesDir ".staging.$releaseName.$PID"
             if (-not $useLocalPackage) {
                 Write-Step "Downloading Herdr"
-                Invoke-WebRequest -Uri $asset.Url -OutFile $downloadPath
+                Invoke-CurlDownload -Uri $asset.Url -Destination $downloadPath
             }
             Test-FileDigest -Path $downloadPath -ExpectedDigest $asset.Sha256
 


### PR DESCRIPTION
## What

The v0.8.2 updater fix removed the PowerShell download cradle from `herdr update`, but the public first-install path still used `irm ... | iex` and the installer itself downloaded through PowerShell web cmdlets.

This change:

- downloads the public installer to a random local file with `curl.exe`
- removes `Invoke-RestMethod` and `Invoke-WebRequest` from `install.ps1`
- restricts HTTPS downloads to HTTPS redirects and TLS 1.2 or newer
- keeps SHA-256 package verification before activation
- updates current public install instructions and the published v0.8.2 docs
- prevents PowerShell network cmdlets from returning to the installer

## Validation

- `just check`
- website build and documentation validation
- full Windows installer integration test on `windows-wirt`
- public bootstrap installed v0.8.2 with Microsoft Defender real-time protection enabled and produced no new detection
- 20 consecutive fresh curl-based Windows installs with no new Defender detection

Cortex XDR is not installed on the validation VM, so the issue reporter still needs to confirm that product-specific rule.

Refs #2751