### PR TITLE
fix(cli): put id argument first in report/release usage lines

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Active Space and Agent rows now use dedicated theme colors that remain visible when the host terminal background matches the selected Herdr theme. (#2792)
 - `agent prompt` now rejects agents already waiting at approval or question dialogs with `agent_blocked`, without sending text or Enter. (#2788)
 - `prefix+e` now preserves logical lines when opening soft-wrapped scrollback in an editor. (#2733)
+- `--help` for `pane report-agent`, `pane report-agent-session`, `pane release-agent`, `pane report-metadata`, and `workspace report-metadata` now shows the id argument before required options in the usage line, matching what the hand-written parsers actually require. Following the previous usage line's argument order produced a confusing `unknown option` error instead of working.
 - Tab bar clicks are now properly registered when using Ghostty in native fullscreen. (#796, #2736, thanks @HackAttack)
 - Prefix keybindings now disambiguate layout-aware shifted punctuation, so a shifted `\` no longer triggers `prefix+|` on keyboard layouts where the same key produces both characters. (#2674)
 - Remote clients now continue redrawing at very large terminal sizes instead of freezing when a full ANSI frame exceeds the transport limit. (#2670)

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -217,6 +217,9 @@ fn workspace_command() -> Command {
         .subcommand(
             Command::new("report-metadata")
                 .about("Report display-only workspace metadata")
+                .override_usage(
+                    "herdr workspace report-metadata <WORKSPACE_ID> --source <ID> [OPTIONS]",
+                )
                 .arg(required("workspace_id", "WORKSPACE_ID"))
                 .arg(option("source", "ID").required(true))
                 .arg(repeatable_option("token", "NAME=VALUE"))
@@ -638,6 +641,7 @@ fn pane_command() -> Command {
 fn report_agent_command() -> Command {
     Command::new("report-agent")
         .about("Report pane agent lifecycle state")
+        .override_usage("herdr pane report-agent <PANE_ID> --source <ID> --agent <LABEL> [OPTIONS]")
         .arg(required("pane_id", "PANE_ID"))
         .arg(option("source", "ID").required(true))
         .arg(option("agent", "LABEL").required(true))
@@ -651,6 +655,9 @@ fn report_agent_command() -> Command {
 fn report_agent_session_command() -> Command {
     Command::new("report-agent-session")
         .about("Report pane agent session identity")
+        .override_usage(
+            "herdr pane report-agent-session <PANE_ID> --source <ID> --agent <LABEL> [OPTIONS]",
+        )
         .arg(required("pane_id", "PANE_ID"))
         .arg(option("source", "ID").required(true))
         .arg(option("agent", "LABEL").required(true))
@@ -663,6 +670,9 @@ fn report_agent_session_command() -> Command {
 fn release_agent_command() -> Command {
     Command::new("release-agent")
         .about("Release pane agent lifecycle authority")
+        .override_usage(
+            "herdr pane release-agent <PANE_ID> --source <ID> --agent <LABEL> [OPTIONS]",
+        )
         .arg(required("pane_id", "PANE_ID"))
         .arg(option("source", "ID").required(true))
         .arg(option("agent", "LABEL").required(true))
@@ -672,6 +682,7 @@ fn release_agent_command() -> Command {
 fn report_metadata_command() -> Command {
     Command::new("report-metadata")
         .about("Report display-only pane metadata")
+        .override_usage("herdr pane report-metadata <PANE_ID> --source <ID> [OPTIONS]")
         .arg(required("pane_id", "PANE_ID"))
         .arg(option("source", "ID").required(true))
         .arg(option("agent", "LABEL"))
@@ -1202,6 +1213,49 @@ mod tests {
         assert!(String::from_utf8(help)
             .unwrap()
             .contains("Usage: herdr agent rename <TARGET> <NAME>|--clear"));
+    }
+
+    #[test]
+    fn pane_and_workspace_id_reporting_commands_show_id_before_required_options() {
+        // These commands take their id positionally and a hand-written parser (not
+        // clap) requires it strictly first. Without an explicit override, clap's
+        // default usage synopsis places positionals after required options, which
+        // misleads users into an argument order the parser rejects.
+        for (path, expected_usage) in [
+            (
+                &["workspace", "report-metadata"][..],
+                "Usage: herdr workspace report-metadata <WORKSPACE_ID> --source <ID> [OPTIONS]",
+            ),
+            (
+                &["pane", "report-agent"][..],
+                "Usage: herdr pane report-agent <PANE_ID> --source <ID> --agent <LABEL> [OPTIONS]",
+            ),
+            (
+                &["pane", "report-agent-session"][..],
+                "Usage: herdr pane report-agent-session <PANE_ID> --source <ID> --agent <LABEL> [OPTIONS]",
+            ),
+            (
+                &["pane", "release-agent"][..],
+                "Usage: herdr pane release-agent <PANE_ID> --source <ID> --agent <LABEL> [OPTIONS]",
+            ),
+            (
+                &["pane", "report-metadata"][..],
+                "Usage: herdr pane report-metadata <PANE_ID> --source <ID> [OPTIONS]",
+            ),
+        ] {
+            let mut args = vec!["herdr".to_string()];
+            args.extend(path.iter().map(|s| s.to_string()));
+            args.push("--help".to_string());
+
+            let mut help = Vec::new();
+            super::write_requested_help(&args, &mut help).unwrap();
+            let help = String::from_utf8(help).unwrap();
+            assert!(
+                help.contains(expected_usage),
+                "herdr {}: expected usage line {expected_usage:?}, got: {help}",
+                path.join(" ")
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Root Cause:** `herdr pane report-agent`, `report-agent-session`, `release-agent`, `report-metadata`, and `herdr workspace report-metadata` each take their id as the first positional argument in a hand-written parser (`args.first()`). clap's default usage synopsis renders required options before positionals, so `--help` shows the id last, e.g. `Usage: herdr pane report-metadata [OPTIONS] --source <ID> <PANE_ID>`. Following that order (`--source foo bar`) makes the parser treat `--source` itself as the id, then fail on the next token with `unknown option: bar` — a misleading error unrelated to the actual problem.

**The Fix:** Add `.override_usage(...)` to each of the five affected `Command` builders in `src/cli/spec.rs`, listing the id first, matching the convention already used for several `agent` subcommands (`read`/`prompt`/`rename`/`wait`/`attach`) in the same file. No parser or behavior change — only the displayed usage line.

**Validation:** Added `pane_and_workspace_id_reporting_commands_show_id_before_required_options`, checking the exact `Usage:` line for all five commands via `write_requested_help`. `cargo fmt --check` and `cargo clippy --all-targets --locked -- -D warnings` are clean. Full `cargo nextest run` passes except 5 pre-existing, unrelated failures (locale-dependent git-error-text assertions in the worktree test suite — reproduced identically against pristine `origin/master` before this change).

**References:** none — no existing issue or PR covers this; found while working on an unrelated feature branch.
