### PR TITLE
docs: document HERDR_AGENT hint for agents run as a different local user

### DIFF
--- a/docs/next/website/src/content/docs/agents.mdx
+++ b/docs/next/website/src/content/docs/agents.mdx
@@ -54,6 +54,14 @@ On Linux and macOS, a host-visible wrapper can hide the real agent process from 
 
 Some restricted Linux runtimes do not expose a terminal foreground process group. Start the Herdr server with `HERDR_PROCESS_DETECTION=child-groups` to opt into direct child-process-group inference when native detection is unavailable. Native detection remains preferred, and the default `native` mode never performs this inference. The opt-in mode is best effort: a newer background job can be mistaken for the foreground job. The variable is read by the server and requires a restart; set it in the remote server environment rather than on an attaching client.
 
+Running an agent as a different local user hides the agent process the same way. The target account owns the agent's environment, and account-switching tools such as `sudo` strip inherited variables from the child command, so the hint cannot reach or be read from the agent process itself. Set the hint on an ordinary shell owned by your own user and let that wrapper stay in the foreground:
+
+```
+HERDR_AGENT=pi sh -c 'sudo -u agent -i pi'
+```
+
+The intermediate shell must stay alive while the agent runs; do not add `exec` between the shell and `sudo`, because Herdr reads the hint from that host-visible foreground process. Setting the hint directly on the account-switching command is not reliable. Lifecycle integrations are installed per user account, so screen-manifest detection through this hint is also the expected path when a pane's agent runs under another local account.
+
 ## Blocked state
 
 Blocked detection is deliberately strict for screen-manifest agents. Herdr only marks `blocked` when the live bottom-buffer snapshot matches known visible approval, question, or permission UI. If no manifest rule matches for a known agent, Herdr falls back to `idle` and labels that fallback as `default_known_agent_idle_fallback` in explain output.


### PR DESCRIPTION
## Motivation

Running a coding agent under a different local account (for example `sudo -u agent -i pi` inside a pane) hides the agent from Herder's process detection, and the existing [VMs and sandbox wrappers](https://herdr.dev/docs/agents/#vms-and-sandbox-wrappers) guidance only shows sandbox-wrapper examples (`fence`, `nono`). The supported pattern is non-obvious in this case because:

- `sudo` strips inherited variables (`env_reset`), so the hint never reaches the agent process.
- Even if it did, the agent's `/proc/<pid>/environ` belongs to the target account and is unreadable by the Herder server (kernel ptrace-access rules).
- Setting the hint directly on the privileged wrapper command is unreliable.

The working pattern is to keep the hint on an ordinary, same-user shell that stays alive in the pane's foreground process group:

```
HERDR_AGENT=pi sh -c 'sudo -u agent -i pi'
```

This was confirmed as expected behavior for ssh+`sudo` transport chains in #2961, but nothing in the docs covers the local different-account case, so each user has to rediscover the incantation (and why an apparently redundant `sh -c` layer — without `exec` — is required).

## Change

Adds three short paragraphs to the "VMs and sandbox wrappers" section of `docs/next/website/src/content/docs/agents.mdx`, matching the existing prose style:

- explains why the hint cannot be placed on or read from the agent process itself,
- gives the `sh -c 'sudo -u ...'` example,
- warns against adding `exec` between the shell and the account switch, and notes lifecycle integrations are installed per user account, so the screen-manifest hint is the expected path here.

Docs-only change, no code touched.