### PR TITLE
fix: detect agents in descendant process groups

### DIFF
--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -335,6 +335,13 @@ pub fn foreground_process_group_id(child_pid: u32) -> Option<u32> {
     crate::platform::foreground_process_group_id(child_pid)
 }
 
+/// Walk the descendant process tree from `shell_pid` looking for an agent.
+/// Used as a fallback when the foreground process group yields no agent
+/// (e.g. when the agent runs inside a nested process group).
+pub fn descendant_agent_job(shell_pid: u32) -> Option<crate::platform::ForegroundJob> {
+    crate::platform::descendant_agent_job(shell_pid)
+}
+
 fn normalized_process_name(process: &crate::platform::ForegroundProcess) -> String {
     let effective = process.argv0.as_deref().unwrap_or(&process.name);
     let lower_effective = effective.to_lowercase();

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -617,6 +617,24 @@ fn probe_foreground_process_from_jobs(
     foreground_job: impl FnOnce() -> Option<crate::platform::ForegroundJob>,
     read_hint: impl Fn(u32) -> Option<Agent> + Copy,
 ) -> ProcessProbeResult {
+    probe_foreground_process_from_jobs_with_descendant(
+        pid,
+        foreground_pgid,
+        leader_job,
+        foreground_job,
+        read_hint,
+        || crate::detect::descendant_agent_job(pid),
+    )
+}
+
+fn probe_foreground_process_from_jobs_with_descendant(
+    pid: u32,
+    foreground_pgid: Option<u32>,
+    leader_job: Option<crate::platform::ForegroundJob>,
+    foreground_job: impl FnOnce() -> Option<crate::platform::ForegroundJob>,
+    read_hint: impl Fn(u32) -> Option<Agent> + Copy,
+    descendant_job: impl FnOnce() -> Option<crate::platform::ForegroundJob>,
+) -> ProcessProbeResult {
     if let Some(job) = leader_job.as_ref() {
         if let Some(hinted) = hinted_process_probe_result(job, pid, read_hint) {
             return hinted;
@@ -649,12 +667,36 @@ fn probe_foreground_process_from_jobs(
         }
 
         let identified = crate::detect::identify_agent_in_job(job);
+        if identified.is_some() {
+            return ProcessProbeResult {
+                process_group_id: Some(job.process_group_id),
+                foreground_is_pane_shell: job.processes.iter().any(|process| process.pid == pid),
+                agent: identified.as_ref().map(|(agent, _)| *agent),
+                process_name: identified.map(|(_, process_name)| process_name),
+            };
+        }
+
+        if let Some(descendant_job) = descendant_job() {
+            if let Some((agent, process_name)) =
+                crate::detect::identify_agent_in_job(&descendant_job)
+            {
+                return process_probe_result(&descendant_job, pid, agent, process_name);
+            }
+        }
+
         return ProcessProbeResult {
             process_group_id: Some(job.process_group_id),
             foreground_is_pane_shell: job.processes.iter().any(|process| process.pid == pid),
-            agent: identified.as_ref().map(|(agent, _)| *agent),
-            process_name: identified.map(|(_, process_name)| process_name),
+            agent: None,
+            process_name: None,
         };
+    }
+
+    if let Some(descendant_job) = descendant_job() {
+        if let Some((agent, process_name)) = crate::detect::identify_agent_in_job(&descendant_job)
+        {
+            return process_probe_result(&descendant_job, pid, agent, process_name);
+        }
     }
 
     ProcessProbeResult {
@@ -4516,5 +4558,108 @@ mod tests {
                 observed_at: _,
             } if delivered_pane == pane_id
         ));
+    }
+
+    #[test]
+    fn descendant_fallback_finds_agent_when_foreground_group_has_none() {
+        let fg_job = crate::platform::ForegroundJob {
+            process_group_id: 200,
+            processes: vec![foreground_process(200, "kv")],
+        };
+        let descendant = crate::platform::ForegroundJob {
+            process_group_id: 500,
+            processes: vec![crate::platform::ForegroundProcess {
+                pid: 500,
+                name: "cursor-agent".to_string(),
+                argv0: None,
+                argv: Some(vec!["cursor-agent".to_string()]),
+                cmdline: Some("cursor-agent".to_string()),
+            }],
+        };
+
+        let result = probe_foreground_process_from_jobs_with_descendant(
+            100,
+            Some(200),
+            None,
+            || Some(fg_job),
+            |_| None,
+            || Some(descendant),
+        );
+
+        assert_eq!(result.agent, Some(Agent::Cursor));
+        assert_eq!(result.process_name.as_deref(), Some("cursor-agent"));
+    }
+
+    #[test]
+    fn descendant_fallback_not_called_when_foreground_group_identifies_agent() {
+        let fg_job = crate::platform::ForegroundJob {
+            process_group_id: 200,
+            processes: vec![foreground_process(200, "codex")],
+        };
+        let mut descendant_called = false;
+
+        let result = probe_foreground_process_from_jobs_with_descendant(
+            100,
+            Some(200),
+            None,
+            || Some(fg_job),
+            |_| None,
+            || {
+                descendant_called = true;
+                Some(crate::platform::ForegroundJob {
+                    process_group_id: 500,
+                    processes: vec![foreground_process(500, "claude")],
+                })
+            },
+        );
+
+        assert_eq!(result.agent, Some(Agent::Codex));
+        assert!(!descendant_called);
+    }
+
+    #[test]
+    fn descendant_fallback_returns_no_agent_when_descendant_yields_none() {
+        let fg_job = crate::platform::ForegroundJob {
+            process_group_id: 200,
+            processes: vec![foreground_process(200, "nvim")],
+        };
+
+        let result = probe_foreground_process_from_jobs_with_descendant(
+            100,
+            Some(200),
+            None,
+            || Some(fg_job),
+            |_| None,
+            || None,
+        );
+
+        assert_eq!(result.agent, None);
+        assert_eq!(result.process_group_id, Some(200));
+    }
+
+    #[test]
+    fn descendant_fallback_works_when_no_foreground_job_available() {
+        let descendant = crate::platform::ForegroundJob {
+            process_group_id: 500,
+            processes: vec![crate::platform::ForegroundProcess {
+                pid: 500,
+                name: "claude".to_string(),
+                argv0: None,
+                argv: Some(vec!["claude".to_string()]),
+                cmdline: Some("claude".to_string()),
+            }],
+        };
+
+        let result = probe_foreground_process_from_jobs_with_descendant(
+            100,
+            None,
+            None,
+            || None,
+            |_| None,
+            || Some(descendant),
+        );
+
+        assert_eq!(result.agent, Some(Agent::Claude));
+        assert_eq!(result.process_name.as_deref(), Some("claude"));
     }
 }

--- a/src/platform/fallback.rs
+++ b/src/platform/fallback.rs
@@ -194,6 +194,11 @@ pub fn session_processes(_child_pid: u32) -> Vec<u32> {
 }
 
 /// Unsupported platform stub.
+pub fn descendant_agent_job(_shell_pid: u32) -> Option<ForegroundJob> {
+    None
+}
+
+/// Unsupported platform stub.
 pub fn signal_processes(_pids: &[u32], _signal: Signal) {}
 
 /// Unsupported platform stub.

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -420,6 +420,92 @@ pub fn session_processes(child_pid: u32) -> Vec<u32> {
     pids
 }
 
+const DESCENDANT_SCAN_LIMIT: usize = 128;
+
+/// Walk the descendant process tree from `shell_pid` looking for an agent.
+/// Returns a synthetic `ForegroundJob` containing only the identified agent
+/// process, or `None` if no agent is found within the scan limit.
+pub fn descendant_agent_job(shell_pid: u32) -> Option<ForegroundJob> {
+    if shell_pid == 0 {
+        return None;
+    }
+
+    let mut children_by_parent: std::collections::HashMap<u32, Vec<u32>> =
+        std::collections::HashMap::new();
+    for entry in std::fs::read_dir("/proc").into_iter().flatten().flatten() {
+        let file_name = entry.file_name();
+        let Some(pid_str) = file_name.to_str() else {
+            continue;
+        };
+        if !pid_str.bytes().all(|b| b.is_ascii_digit()) {
+            continue;
+        }
+        let Ok(pid) = pid_str.parse::<u32>() else {
+            continue;
+        };
+        if let Some(ppid) = process_ppid(pid) {
+            if ppid > 0 {
+                children_by_parent.entry(ppid).or_default().push(pid);
+            }
+        }
+    }
+
+    let mut queue = std::collections::VecDeque::new();
+    let mut visited = std::collections::HashSet::new();
+    visited.insert(shell_pid);
+    if let Some(children) = children_by_parent.get(&shell_pid) {
+        for &child in children {
+            if visited.insert(child) {
+                queue.push_back(child);
+            }
+        }
+    }
+
+    let mut scanned = 0usize;
+    while let Some(pid) = queue.pop_front() {
+        scanned += 1;
+        if scanned > DESCENDANT_SCAN_LIMIT {
+            return None;
+        }
+
+        let name = process_pgrp_and_comm(pid).map(|(_, comm)| comm);
+        let argv = process_argv(pid);
+        let process = ForegroundProcess {
+            pid,
+            name: name.unwrap_or_default(),
+            argv0: None,
+            cmdline: argv.as_ref().map(|parts| parts.join(" ")),
+            argv,
+        };
+
+        let job = ForegroundJob {
+            process_group_id: pid,
+            processes: vec![process],
+        };
+        if crate::detect::identify_agent_in_job(&job).is_some() {
+            return Some(job);
+        }
+
+        if let Some(children) = children_by_parent.get(&pid) {
+            for &child in children {
+                if visited.insert(child) {
+                    queue.push_back(child);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn process_ppid(pid: u32) -> Option<u32> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let rest = stat.get(stat.rfind(')')? + 2..)?;
+    let fields: Vec<&str> = rest.split_whitespace().collect();
+    // After (comm): state(0) ppid(1)
+    fields.get(1)?.parse::<u32>().ok()
+}
+
 pub fn signal_processes(pids: &[u32], signal: Signal) {
     let sig = match signal {
         Signal::Hangup => libc::SIGHUP,

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -928,6 +928,77 @@ pub fn session_processes(child_pid: u32) -> Vec<u32> {
         .collect()
 }
 
+const DESCENDANT_SCAN_LIMIT: usize = 128;
+
+/// Walk the descendant process tree from `shell_pid` looking for an agent.
+/// Returns a synthetic `ForegroundJob` containing only the identified agent
+/// process, or `None` if no agent is found within the scan limit.
+pub fn descendant_agent_job(shell_pid: u32) -> Option<ForegroundJob> {
+    if shell_pid == 0 {
+        return None;
+    }
+
+    let pids = all_pids();
+    let mut children_by_parent: std::collections::HashMap<u32, Vec<u32>> =
+        std::collections::HashMap::new();
+    for &pid in &pids {
+        let Some(info) = process_bsdinfo(pid) else {
+            continue;
+        };
+        let ppid = info.pbi_ppid;
+        if ppid > 0 {
+            children_by_parent.entry(ppid).or_default().push(pid);
+        }
+    }
+
+    let mut queue = std::collections::VecDeque::new();
+    let mut visited = std::collections::HashSet::new();
+    visited.insert(shell_pid);
+    if let Some(children) = children_by_parent.get(&shell_pid) {
+        for &child in children {
+            if visited.insert(child) {
+                queue.push_back(child);
+            }
+        }
+    }
+
+    let mut scanned = 0usize;
+    while let Some(pid) = queue.pop_front() {
+        scanned += 1;
+        if scanned > DESCENDANT_SCAN_LIMIT {
+            return None;
+        }
+
+        let name = process_bsdinfo(pid).and_then(|info| comm_from_bsdinfo(&info));
+        let argv = process_argv(pid);
+        let process = ForegroundProcess {
+            pid,
+            name: name.unwrap_or_default(),
+            argv0: process_argv0_name(pid),
+            cmdline: argv.as_ref().map(|parts| parts.join(" ")),
+            argv,
+        };
+
+        let job = ForegroundJob {
+            process_group_id: pid,
+            processes: vec![process],
+        };
+        if crate::detect::identify_agent_in_job(&job).is_some() {
+            return Some(job);
+        }
+
+        if let Some(children) = children_by_parent.get(&pid) {
+            for &child in children {
+                if visited.insert(child) {
+                    queue.push_back(child);
+                }
+            }
+        }
+    }
+
+    None
+}
+
 fn all_pids() -> Vec<u32> {
     let initial_count = unsafe { libc::proc_listallpids(std::ptr::null_mut(), 0) };
     let mut capacity = if initial_count > 0 {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1806,6 +1806,12 @@ pub fn session_processes(child_pid: u32) -> Vec<u32> {
     session_processes_from_snapshot(child_pid, &snapshot)
 }
 
+/// Windows `foreground_job` already walks the full descendant tree, so this
+/// fallback is not needed. Always returns `None`.
+pub fn descendant_agent_job(_shell_pid: u32) -> Option<ForegroundJob> {
+    None
+}
+
 fn session_processes_from_snapshot(child_pid: u32, snapshot: &ProcessSnapshot) -> Vec<u32> {
     if snapshot.entry(child_pid).is_none() {
         return Vec::new();


### PR DESCRIPTION
## Summary

**Declaimer**
> The change has been vibe coded, im not familiar with the codebase and the change might be not clean codewise.
Let me know if any changes are required
Thanks for your time reviewing this :)

- Add a descendant process tree walk as a fallback when the foreground process group yields no recognized agent, fixing detection for agents running inside neovim or other programs that create child process groups
- Implement platform-specific BFS on macOS (`all_pids` + `pbi_ppid`) and Linux (`/proc` ppid walk), bounded to 128 processes; Windows already scans descendants in its `foreground_job`
- Refactor `probe_foreground_process_from_jobs` to accept an injectable descendant walk closure for testability

## Motivation

When an agent like `cursor-agent` runs inside neovim (which creates its own process group for child processes via `setpgid`/`setsid`), the agent ends up in a different process group than the terminal's foreground group. Since Herdr only scanned the foreground process group (`tcgetpgrp`), the agent was invisible.

Example process tree where detection failed:

```
zsh (shell, pgid=83131)
  └── kv --ai --         (pgid=20077, foreground group) # nvim wrapper
       └── nvim          (pgid=20077)
            └── nvim --embed  (pgid=20079, new group)   # nvim spinned terminal via sidekick.nvim
                 └── cursor-agent (pgid=20493, new group) ← not found
```

