### PR TITLE
fix(input): preserve doubled-escape alt-arrow sequences during host input

### DIFF
--- a/src/client/input.rs
+++ b/src/client/input.rs
@@ -697,9 +697,8 @@ mod tests {
         assert!(timeout_ms <= 20);
     }
 
-    #[cfg(not(target_os = "macos"))]
     #[test]
-    fn windows_repeated_escape_keeps_second_escape_pending() {
+    fn host_input_repeated_escape_keeps_second_escape_pending() {
         let mut framer = crate::raw_input::RawInputFramer::for_host_input();
 
         let events = framer.push(b"\x1b\x1b");

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -58,14 +58,12 @@ fn configure_background_command_platform(_command: &mut std::process::Command) {
 pub(crate) struct PlatformCapabilities {
     pub(crate) live_handoff: bool,
     pub(crate) direct_terminal_attach: bool,
-    pub(crate) preserve_legacy_doubled_escape_input: bool,
 }
 
 pub(crate) const fn capabilities() -> PlatformCapabilities {
     PlatformCapabilities {
         live_handoff: cfg!(unix),
         direct_terminal_attach: cfg!(unix),
-        preserve_legacy_doubled_escape_input: cfg!(target_os = "macos"),
     }
 }
 

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -235,14 +235,8 @@ const MAX_ORPHANED_SGR_MOUSE_TAIL_BYTES: usize = 32;
 
 impl RawInputByteFramer {
     pub(crate) fn for_host_input() -> Self {
-        Self::with_host_input_policy(
-            crate::platform::capabilities().preserve_legacy_doubled_escape_input,
-        )
-    }
-
-    fn with_host_input_policy(preserve_legacy_doubled_escape_input: bool) -> Self {
         Self {
-            split_coalesced_escape: !preserve_legacy_doubled_escape_input,
+            split_coalesced_escape: true,
             ..Self::default()
         }
     }
@@ -540,13 +534,12 @@ impl RawInputByteFramer {
                 continue;
             }
 
-            if self.split_coalesced_escape && self.buffer.starts_with(b"\x1b\x1b") {
-                chunks.push(vec![ESC]);
-                self.buffer.drain(..1);
-                continue;
-            }
-
             let Some((event, consumed)) = extract_one_event(&self.buffer) else {
+                if self.split_coalesced_escape && self.buffer.starts_with(b"\x1b\x1b") {
+                    chunks.push(vec![ESC]);
+                    self.buffer.drain(..1);
+                    continue;
+                }
                 break;
             };
             if matches!(
@@ -2076,22 +2069,14 @@ mod tests {
         assert!(framer.flush_timeout().is_empty());
     }
 
-    #[cfg(not(target_os = "macos"))]
     #[test]
-    fn non_macos_host_input_splits_lone_escape_from_arrow() {
+    fn host_input_preserves_legacy_doubled_escape_alt_arrow() {
         let mut framer = RawInputByteFramer::for_host_input();
 
-        assert_eq!(
-            framer.push(b"\x1b\x1b[D"),
-            vec![b"\x1b".to_vec(), b"\x1b[D".to_vec()]
-        );
-    }
-
-    #[test]
-    fn macos_host_input_policy_preserves_legacy_doubled_escape_alt_arrow() {
-        let mut framer = RawInputByteFramer::with_host_input_policy(true);
-
         assert_eq!(framer.push(b"\x1b\x1b[D"), vec![b"\x1b\x1b[D".to_vec()]);
+        assert_eq!(framer.push(b"\x1b\x1b[C"), vec![b"\x1b\x1b[C".to_vec()]);
+        assert_eq!(framer.push(b"\x1b\x1b[A"), vec![b"\x1b\x1b[A".to_vec()]);
+        assert_eq!(framer.push(b"\x1b\x1b[B"), vec![b"\x1b\x1b[B".to_vec()]);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Terminals that send doubled-escape sequences for Alt-arrow chords (e.g. `\x1b\x1b[D` for `Alt+Left`, `\x1b\x1b[C` for `Alt+Right`, `\x1b\x1b[A` for `Alt+Up`, and `\x1b\x1b[B` for `Alt+Down`) were having their chords split into a lone escape (`\x1b`) and a plain arrow sequence (`\x1b[D`) on non-macOS hosts because `RawInputByteFramer` checked `split_coalesced_escape` before running `extract_one_event`.

This change runs complete event extraction first so valid multi-byte escape sequences like `\x1b\x1b[A/B/C/D` are parsed as whole key chords before splitting any remaining coalesced escape bytes.

## Verification

- `cargo test -p herdr raw_input`: All 112 unit tests pass.
- `cargo test -p herdr client::input`: All 74 unit tests pass.
- `cargo clippy` & `cargo fmt -- --check`: 0 errors / 0 warnings.