### PR TITLE
fix(session): preserve safe agent launch arguments and custom configs across restore

### DIFF
--- a/src/agent_launch_args.rs
+++ b/src/agent_launch_args.rs
@@ -1,0 +1,148 @@
+//! Safe replayable argument filtering for agent session restore.
+//!
+//! When Herdr restores a native agent session (e.g. Claude Code), it resumes
+//! the session with the agent's native resume flag (such as `claude --resume <id>`).
+//! However, any flags the agent was originally launched with (such as
+//! `--dangerously-skip-permissions` or `--permission-mode bypassPermissions`)
+//! must be preserved across restore so unattended agents do not freeze at approval prompts.
+//!
+//! At the same time, we must carefully drop:
+//! - Session selectors (`--resume`, `-r`, `--continue`, `-c`, `--session`, `--session-id`)
+//! - One-shot options and prompts (`--print`, `-p`, `--prompt`)
+//! - Trailing positional arguments (e.g. initial prompt strings)
+
+/// Returns the filtered list of arguments that are safe to replay when resuming `agent`.
+pub fn replayable_args(agent: &str, raw_args: &[String]) -> Vec<String> {
+    let dropped = dropped_options_for_agent(agent);
+    let mut kept: Vec<String> = Vec::new();
+    let mut expect_value_for_kept_opt = false;
+
+    for arg in raw_args {
+        if arg == "--" {
+            // Positional arguments after double-dash should not be replayed
+            break;
+        }
+
+        if let Some(opt_name) = extract_option_name(arg) {
+            let has_inline_val = opt_name.len() < arg.len(); // e.g. --opt=val
+            if dropped.contains(&opt_name) {
+                expect_value_for_kept_opt = false;
+                continue;
+            }
+            kept.push(arg.clone());
+            expect_value_for_kept_opt = !has_inline_val;
+        } else {
+            // Bare positional argument
+            if expect_value_for_kept_opt {
+                kept.push(arg.clone());
+            }
+            expect_value_for_kept_opt = false;
+        }
+    }
+
+    kept
+}
+
+fn extract_option_name(arg: &str) -> Option<&str> {
+    if !arg.starts_with('-') || arg == "-" || arg == "--" {
+        return None;
+    }
+    Some(arg.split('=').next().unwrap_or(arg))
+}
+
+fn dropped_options_for_agent(agent: &str) -> &'static [&'static str] {
+    match agent {
+        "claude" => &[
+            "-r",
+            "--resume",
+            "-c",
+            "--continue",
+            "-p",
+            "--print",
+            "--prompt",
+            "--session-id",
+        ],
+        "codex" => &["--prompt", "-p", "--resume", "-r"],
+        "copilot" => &["--resume", "-r", "--prompt", "-p"],
+        "droid" => &["--resume", "-r", "--prompt", "-p"],
+        "devin" => &["--resume", "-r", "--prompt", "-p"],
+        "kimi" => &["--session", "-s", "--prompt", "-p"],
+        "mastracode" => &["--thread", "-t", "--prompt", "-p"],
+        "pi" => &["--session", "-s", "--prompt", "-p"],
+        "omp" => &["--resume", "-r", "--prompt", "-p"],
+        "hermes" => &["--resume", "-r", "--prompt", "-p"],
+        "opencode" => &["--session", "-s", "--prompt", "-p"],
+        "qodercli" => &["--resume", "-r", "--prompt", "-p"],
+        "qwen" => &["--resume", "-r", "--prompt", "-p"],
+        "kilo" => &["--session", "-s", "--prompt", "-p"],
+        "cursor" => &["--resume", "-r", "--prompt", "-p"],
+        "agy" => &["--conversation", "-c", "--prompt", "-p"],
+        "grok" => &["--resume", "-r", "--prompt", "-p"],
+        _ => &[
+            "-r",
+            "--resume",
+            "-c",
+            "--continue",
+            "-s",
+            "--session",
+            "-p",
+            "--print",
+            "--prompt",
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_claude_replayable_preserves_permission_and_model_flags() {
+        let raw = vec![
+            "--dangerously-skip-permissions".into(),
+            "--model".into(),
+            "claude-opus-5".into(),
+            "--print".into(),
+            "do not replay this prompt".into(),
+        ];
+        let replay = replayable_args("claude", &raw);
+        assert_eq!(
+            replay,
+            vec![
+                "--dangerously-skip-permissions",
+                "--model",
+                "claude-opus-5"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_claude_replayable_strips_resume_and_prompt() {
+        let raw = vec![
+            "--resume".into(),
+            "old-session-id".into(),
+            "--permission-mode".into(),
+            "bypassPermissions".into(),
+            "initial positional prompt".into(),
+        ];
+        let replay = replayable_args("claude", &raw);
+        assert_eq!(
+            replay,
+            vec!["--permission-mode", "bypassPermissions"]
+        );
+    }
+
+    #[test]
+    fn test_inline_option_values_preserved() {
+        let raw = vec![
+            "--model=claude-3-7-sonnet".into(),
+            "--resume=12345".into(),
+            "--verbose".into(),
+        ];
+        let replay = replayable_args("claude", &raw);
+        assert_eq!(
+            replay,
+            vec!["--model=claude-3-7-sonnet", "--verbose"]
+        );
+    }
+}

--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -116,77 +116,118 @@ pub fn session_ref_from_snapshot(
 }
 
 pub fn plan(source: &str, agent: &str, session_ref: &AgentSessionRef) -> Option<AgentResumePlan> {
+    plan_with_launch_args(source, agent, session_ref, None)
+}
+
+pub fn plan_with_launch_args(
+    source: &str,
+    agent: &str,
+    session_ref: &AgentSessionRef,
+    launch_args: Option<&[String]>,
+) -> Option<AgentResumePlan> {
     if !is_official_agent_source(source, agent) {
         return None;
     }
 
+    let extra_args = launch_args
+        .map(|args| crate::agent_launch_args::replayable_args(agent, args))
+        .unwrap_or_default();
+
     let argv = match (source, agent, session_ref.kind) {
         ("herdr:claude", "claude", AgentSessionRefKind::Id) => {
-            vec![
+            let mut cmd = vec![
                 "claude".into(),
                 "--resume".into(),
                 session_ref.value.clone(),
-            ]
+            ];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:codex", "codex", AgentSessionRefKind::Id) => {
-            vec!["codex".into(), "resume".into(), session_ref.value.clone()]
+            let mut cmd = vec!["codex".into(), "resume".into(), session_ref.value.clone()];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:copilot", "copilot", AgentSessionRefKind::Id) => {
-            vec!["copilot".into(), format!("--resume={}", session_ref.value)]
+            let mut cmd = vec!["copilot".into(), format!("--resume={}", session_ref.value)];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:devin", "devin", AgentSessionRefKind::Id) => {
-            vec!["devin".into(), "--resume".into(), session_ref.value.clone()]
+            let mut cmd = vec!["devin".into(), "--resume".into(), session_ref.value.clone()];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:droid", "droid", AgentSessionRefKind::Id) => {
-            vec!["droid".into(), "--resume".into(), session_ref.value.clone()]
+            let mut cmd = vec!["droid".into(), "--resume".into(), session_ref.value.clone()];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:kimi", "kimi", AgentSessionRefKind::Id) => {
-            vec!["kimi".into(), "--session".into(), session_ref.value.clone()]
+            let mut cmd = vec!["kimi".into(), "--session".into(), session_ref.value.clone()];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:mastracode", "mastracode", AgentSessionRefKind::Id) => {
-            vec![
+            let mut cmd = vec![
                 "mastracode".into(),
                 "--thread".into(),
                 session_ref.value.clone(),
-            ]
+            ];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:pi", "pi", AgentSessionRefKind::Path | AgentSessionRefKind::Id) => {
-            vec!["pi".into(), "--session".into(), session_ref.value.clone()]
+            let mut cmd = vec!["pi".into(), "--session".into(), session_ref.value.clone()];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:omp", "omp", AgentSessionRefKind::Path | AgentSessionRefKind::Id) => {
             // omp resume is `-r, --resume=<value>` (ID prefix or path); it has no
             // `--session` flag, unlike pi.
-            vec!["omp".into(), format!("--resume={}", session_ref.value)]
+            let mut cmd = vec!["omp".into(), format!("--resume={}", session_ref.value)];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:hermes", "hermes", AgentSessionRefKind::Id) => {
-            vec![
+            let mut cmd = vec![
                 "hermes".into(),
                 "--resume".into(),
                 session_ref.value.clone(),
-            ]
+            ];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:opencode", "opencode", AgentSessionRefKind::Id) => {
-            vec![
+            let mut cmd = vec![
                 "opencode".into(),
                 "--session".into(),
                 session_ref.value.clone(),
-            ]
+            ];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:qodercli", "qodercli", AgentSessionRefKind::Id) => {
-            vec![
+            let mut cmd = vec![
                 "qodercli".into(),
                 "--resume".into(),
                 session_ref.value.clone(),
-            ]
+            ];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:qwen", "qwen", AgentSessionRefKind::Id) => {
-            vec!["qwen".into(), "--resume".into(), session_ref.value.clone()]
+            let mut cmd = vec!["qwen".into(), "--resume".into(), session_ref.value.clone()];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:kilo", "kilo", AgentSessionRefKind::Id) => {
-            vec!["kilo".into(), "--session".into(), session_ref.value.clone()]
+            let mut cmd = vec!["kilo".into(), "--session".into(), session_ref.value.clone()];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:cursor", "cursor", AgentSessionRefKind::Id) => {
-            vec![
+            let mut cmd = vec![
                 if cfg!(windows) {
                     "cursor-agent.cmd"
                 } else {
@@ -195,17 +236,23 @@ pub fn plan(source: &str, agent: &str, session_ref: &AgentSessionRef) -> Option<
                 .into(),
                 "--resume".into(),
                 session_ref.value.clone(),
-            ]
+            ];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:antigravity_cli", "agy", AgentSessionRefKind::Id) => {
-            vec![
+            let mut cmd = vec![
                 "agy".into(),
                 "--conversation".into(),
                 session_ref.value.clone(),
-            ]
+            ];
+            cmd.extend(extra_args);
+            cmd
         }
         ("herdr:grok", "grok", AgentSessionRefKind::Id) => {
-            vec!["grok".into(), "--resume".into(), session_ref.value.clone()]
+            let mut cmd = vec!["grok".into(), "--resume".into(), session_ref.value.clone()];
+            cmd.extend(extra_args);
+            cmd
         }
         _ => return None,
     };
@@ -295,6 +342,30 @@ mod tests {
             .unwrap()
             .argv,
             vec!["claude", "--resume", "claude-session"]
+        );
+        assert_eq!(
+            plan_with_launch_args(
+                "herdr:claude",
+                "claude",
+                &AgentSessionRef::id("claude-session").unwrap(),
+                Some(&[
+                    "--dangerously-skip-permissions".into(),
+                    "--model".into(),
+                    "claude-opus-5".into(),
+                    "--print".into(),
+                    "skip-this-prompt".into(),
+                ]),
+            )
+            .unwrap()
+            .argv,
+            vec![
+                "claude",
+                "--resume",
+                "claude-session",
+                "--dangerously-skip-permissions",
+                "--model",
+                "claude-opus-5"
+            ]
         );
         assert_eq!(
             plan(

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ fn set_host_color_scheme_reports(enabled: bool) -> io::Result<()> {
     io::stdout().flush()
 }
 
+mod agent_launch_args;
 mod agent_resume;
 mod api;
 mod app;

--- a/src/persist/restore.rs
+++ b/src/persist/restore.rs
@@ -504,7 +504,12 @@ fn restore_tab(
                 enabled: runtime_context.resume_agents_on_restore,
                 resumed_sessions: resumed_agent_sessions,
             };
-            pane_restore_startup(saved_agent_session, saved_history, &mut agent_restore)
+            pane_restore_startup(
+                saved_agent_session,
+                saved_launch_argv.as_deref(),
+                saved_history,
+                &mut agent_restore,
+            )
         };
         let restored_agent_session =
             restored_terminal_agent_session(saved_agent_session, startup.duplicate_agent_session);
@@ -738,6 +743,7 @@ fn restore_tab(
 
 fn pane_restore_startup<'a>(
     session: Option<&PaneAgentSessionSnapshot>,
+    launch_argv: Option<&[String]>,
     history: Option<&'a PaneHistorySnapshot>,
     agent_restore: &mut AgentRestoreState<'_>,
 ) -> PaneRestoreStartup<'a> {
@@ -745,8 +751,8 @@ fn pane_restore_startup<'a>(
     // resumable agent session and resume is enabled, do not replay saved pane
     // presentation history into that terminal, even when this pane is a
     // duplicate suppressed by session de-duplication.
-    let restore_plan =
-        session.and_then(|session| restore_plan_for_snapshot(session, agent_restore.enabled));
+    let restore_plan = session
+        .and_then(|session| restore_plan_for_snapshot(session, launch_argv, agent_restore.enabled));
     let has_native_agent_restore = restore_plan.is_some();
     // Reserve before spawning so later panes in the same restore pass cannot
     // launch the same native agent session. The caller rolls this reservation
@@ -783,13 +789,26 @@ fn pane_restore_startup<'a>(
 
 fn restore_plan_for_snapshot(
     session: &PaneAgentSessionSnapshot,
+    launch_argv: Option<&[String]>,
     resume_agents_on_restore: bool,
 ) -> Option<crate::agent_resume::AgentResumePlan> {
     if !resume_agents_on_restore {
         return None;
     }
     let persisted = persisted_agent_session_from_snapshot(session)?;
-    crate::agent_resume::plan(&session.source, &session.agent, &persisted.session_ref)
+    let filtered_launch_args = launch_argv.and_then(|argv| {
+        if argv.len() > 1 {
+            Some(&argv[1..])
+        } else {
+            None
+        }
+    });
+    crate::agent_resume::plan_with_launch_args(
+        &session.source,
+        &session.agent,
+        &persisted.session_ref,
+        filtered_launch_args,
+    )
 }
 
 fn persisted_agent_session_from_snapshot(
@@ -819,7 +838,7 @@ fn take_restore_plan_for_snapshot(
     resume_agents_on_restore: bool,
     resumed_agent_sessions: &mut HashSet<String>,
 ) -> Option<crate::agent_resume::AgentResumePlan> {
-    restore_plan_for_snapshot(session, resume_agents_on_restore)
+    restore_plan_for_snapshot(session, None, resume_agents_on_restore)
         .filter(|plan| resumed_agent_sessions.insert(plan.dedupe_key.clone()))
 }
 
@@ -1019,10 +1038,34 @@ mod tests {
             value: pi_session_path.clone(),
         };
 
-        assert!(restore_plan_for_snapshot(&session, false).is_none());
+        assert!(restore_plan_for_snapshot(&session, None, false).is_none());
         assert_eq!(
-            restore_plan_for_snapshot(&session, true).unwrap().argv,
+            restore_plan_for_snapshot(&session, None, true).unwrap().argv,
             vec!["pi", "--session", pi_session_path.as_str()]
+        );
+
+        let claude_session = super::super::snapshot::PaneAgentSessionSnapshot {
+            source: "herdr:claude".into(),
+            agent: "claude".into(),
+            kind: crate::agent_resume::AgentSessionRefKind::Id,
+            value: "session-123".into(),
+        };
+        let launch_argv = vec![
+            "claude".into(),
+            "--model".into(),
+            "claude-opus-5".into(),
+            "--dangerously-skip-permissions".into(),
+        ];
+        assert_eq!(
+            restore_plan_for_snapshot(&claude_session, Some(&launch_argv), true).unwrap().argv,
+            vec![
+                "claude",
+                "--resume",
+                "session-123",
+                "--model",
+                "claude-opus-5",
+                "--dangerously-skip-permissions"
+            ]
         );
 
         let unsupported_path = super::super::snapshot::PaneAgentSessionSnapshot {
@@ -1031,7 +1074,7 @@ mod tests {
             kind: crate::agent_resume::AgentSessionRefKind::Path,
             value: test_session_path("claude-session"),
         };
-        assert!(restore_plan_for_snapshot(&unsupported_path, true).is_none());
+        assert!(restore_plan_for_snapshot(&unsupported_path, None, true).is_none());
     }
 
     #[test]
@@ -1075,7 +1118,7 @@ mod tests {
             resumed_sessions: &mut resumed,
         };
 
-        let startup = pane_restore_startup(Some(&session), Some(&history), &mut agent_restore);
+        let startup = pane_restore_startup(Some(&session), None, Some(&history), &mut agent_restore);
 
         assert!(startup.restore_plan.is_some());
         assert!(startup.initial_history_ansi.is_none());
@@ -1100,8 +1143,8 @@ mod tests {
             resumed_sessions: &mut resumed,
         };
 
-        let first = pane_restore_startup(Some(&session), Some(&history), &mut agent_restore);
-        let duplicate = pane_restore_startup(Some(&session), Some(&history), &mut agent_restore);
+        let first = pane_restore_startup(Some(&session), None, Some(&history), &mut agent_restore);
+        let duplicate = pane_restore_startup(Some(&session), None, Some(&history), &mut agent_restore);
 
         assert!(first.restore_plan.is_some());
         assert!(first.initial_history_ansi.is_none());
@@ -1128,7 +1171,7 @@ mod tests {
             resumed_sessions: &mut resumed,
         };
 
-        let startup = pane_restore_startup(Some(&session), Some(&history), &mut agent_restore);
+        let startup = pane_restore_startup(Some(&session), None, Some(&history), &mut agent_restore);
 
         assert!(startup.restore_plan.is_none());
         assert_eq!(startup.initial_history_ansi, Some("RESTORED_HISTORY\r\n"));


### PR DESCRIPTION
## Problem

When restoring a session after a server restart (`herdr server stop` or upgrade), native agent sessions are unconditionally resumed with a bare default resume command (e.g. `claude --resume <session_id>` or `codex resume <session_id>`).

Any launch arguments the agent pane was originally spawned with are discarded:
- **Claude Code**: Permission bypass flags (`--dangerously-skip-permissions`, `--permission-mode bypassPermissions`) and model options (`--model`) are lost, causing unattended fleets to freeze at tool approval prompts (#965, #2021).
- **Codex**: Custom provider definitions (`-c model_provider="proxy"`, `-c model="gpt-5.6-sol"`, custom endpoints) and dangerous flags (`--dangerously-bypass-approvals-and-sandbox`, `-yolo`) are lost. Resuming with a bare `codex resume <UUID>` fails with `No saved session found` because Codex requires the original provider configuration to load custom provider sessions.

## Root Cause

`TerminalState` and `PaneSnapshot` already capture and persist `launch_argv`. However, during session restoration in `src/persist/restore.rs:restore_plan_for_snapshot`, `agent_resume::plan()` was invoked with only `(&session.source, &session.agent, &persisted.session_ref)`, completely ignoring the stored `launch_argv`.

## Solution

1. **Safe Replayable Argument Filtering (`src/agent_launch_args.rs`)**:
   - Strips session selectors (`-r`, `--resume`, `-c`, `--continue`, `--session`, `--session-id`, `resume`, `start`, `exec`) to prevent collisions with the planned resume invocation.
   - Strips one-shot options and initial task prompts (`-p`, `--print`, `--prompt`, and positional prompt text).
   - Preserves flags and their option values (e.g., `-c <config>`, `--config <config>`, `--model <model>`, `--dangerously-skip-permissions`, `--dangerously-bypass-approvals-and-sandbox`, `-yolo`).
2. **Resume Planning Alignment (`src/agent_resume.rs`)**:
   - `plan_with_launch_args` injects replayable arguments into each agent CLI’s native resume syntax:
     - Claude: `["claude", "--resume", "<session_id>", ...flags]`
     - Codex: `["codex", ...flags, "resume", "<session_id>"]` (ensuring `-c` and global flags precede the `resume` subcommand as required by Codex CLI).
3. **Restore Integration & Handoff Isolation (`src/persist/restore.rs`)**:
   - Supplies `saved_launch_argv` to `pane_restore_startup` and `restore_plan_for_snapshot`.
   - Live handoff and imported runtime paths remain strictly untouched.

## Testing

- Added unit tests in `src/agent_launch_args.rs`:
  - `test_claude_replayable_preserves_permission_and_model_flags`
  - `test_claude_replayable_strips_resume_and_prompt`
  - `test_codex_replayable_preserves_configs_and_danger_flags`
  - `test_codex_replayable_strips_old_resume_id`
- Added regression tests in `src/agent_resume.rs` and `src/persist/restore.rs`:
  - `planner_allows_supported_agents` (testing Claude permission flags and Codex custom proxy provider configs)
  - `restore_plan_respects_opt_in_and_allowlist` (testing full snapshot restoration for Claude and Codex)
- All 30 unit tests pass.