### PR TITLE
feat: add Goose agent detection and integration

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Add Goose agent detection and session identity integration (`herdr integration install goose`).
 - Custom themes can now define separate light and dark color overrides when automatic theme switching is enabled. (#837, thanks @aneym)
 
 ### Fixed

--- a/docs/next/website/src/content/docs/agents.mdx
+++ b/docs/next/website/src/content/docs/agents.mdx
@@ -29,6 +29,7 @@ Automatic detection works out of the box for common coding agents. The table sho
 | Codex | screen manifest | session |
 | Cursor Agent CLI | screen manifest | session |
 | Amp | screen manifest | none |
+| Goose | screen manifest | session |
 | Grok CLI | screen manifest | session |
 | Antigravity CLI | screen manifest | session |
 | Kiro CLI | screen manifest | none |

--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -1,6 +1,6 @@
 ---
 title: Integrations
-description: Install Herdr integrations for Pi, OMP, Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, Qoder CLI, Qwen Code, Cursor Agent CLI, MastraCode, Antigravity CLI, and Grok CLI.
+description: Install Herdr integrations for Pi, OMP, Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, Qoder CLI, Qwen Code, Cursor Agent CLI, MastraCode, Antigravity CLI, Goose, and Grok CLI.
 ---
 
 Herdr detects supported agents automatically. Install official integrations when you want native agent session restore, direct lifecycle reports, or both. See [Agents](/docs/agents/) for the full status authority model.
@@ -26,6 +26,7 @@ herdr integration install qwen
 herdr integration install cursor
 herdr integration install mastracode
 herdr integration install antigravity-cli
+herdr integration install goose
 herdr integration install grok
 ```
 
@@ -48,6 +49,7 @@ herdr integration uninstall qwen
 herdr integration uninstall cursor
 herdr integration uninstall mastracode
 herdr integration uninstall antigravity-cli
+herdr integration uninstall goose
 herdr integration uninstall grok
 ```
 
@@ -58,7 +60,7 @@ Herdr uses integrations in two ways:
 | Integration type | Agents | Effect |
 | --- | --- | --- |
 | Lifecycle authority | Pi, OMP, Kimi Code CLI, OpenCode, Kilo Code CLI, MastraCode | When installed and actively reporting for the pane, hook or plugin events author `idle`, `working`, and `blocked`. Herdr does not also use screen manifest fallback for that same lifecycle authority. |
-| Session identity | Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Qwen Code, Cursor Agent CLI, Hermes Agent, Antigravity CLI, Grok CLI | The integration reports native session references for restore. State still comes from Herdr's screen manifest detection. |
+| Session identity | Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Qwen Code, Cursor Agent CLI, Hermes Agent, Goose, Antigravity CLI, Grok CLI | The integration reports native session references for restore. State still comes from Herdr's screen manifest detection. |
 
 Custom integrations can also report state that is not visible in the native terminal UI. They do not need to be built into Herdr or use a recognized agent executable.
 
@@ -89,9 +91,9 @@ Use `HERDR_BIN_PATH` and the CLI wrappers for portable integrations. Code that n
 
 [Prime Agent's built-in Herdr reporter](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/src/core/extensions/builtin/herdr-agent-state.ts) is a real-world example. It activates only inside Herdr, maps agent events to `working`, `idle`, and `blocked`, preserves report ordering across sessions, and releases authority on exit.
 
-Some integrations report native agent session references. Herdr uses official session references to resume Claude Code, Codex, Devin CLI, Droid, Kimi Code CLI, Qoder CLI, Qwen Code, Cursor Agent CLI, Grok CLI, GitHub Copilot CLI, Pi, OMP, Hermes Agent, OpenCode, Kilo Code CLI, MastraCode, and Antigravity CLI panes after a Herdr server restart unless `[session] resume_agents_on_restore = false` disables it.
+Some integrations report native agent session references. Herdr uses official session references to resume Claude Code, Codex, Devin CLI, Droid, Kimi Code CLI, Qoder CLI, Qwen Code, Cursor Agent CLI, Grok CLI, Goose, GitHub Copilot CLI, Pi, OMP, Hermes Agent, OpenCode, Kilo Code CLI, MastraCode, and Antigravity CLI panes after a Herdr server restart unless `[session] resume_agents_on_restore = false` disables it.
 
-Native session restore requires current Herdr integrations: Pi integration version `2`, OMP version `3`, Claude Code version `6`, Codex version `5`, GitHub Copilot CLI version `2`, Devin CLI version `2`, Droid version `2`, Kimi Code CLI version `3`, Qoder CLI version `2`, Qwen Code version `1`, Cursor Agent CLI version `1`, Grok CLI version `1`, OpenCode version `5`, Kilo Code CLI version `1`, Hermes Agent version `5`, MastraCode version `1`, or Antigravity CLI version `1`. Check installed versions with `herdr integration status`.
+Native session restore requires current Herdr integrations: Pi integration version `2`, OMP version `3`, Claude Code version `6`, Codex version `5`, GitHub Copilot CLI version `2`, Devin CLI version `2`, Droid version `2`, Kimi Code CLI version `3`, Qoder CLI version `2`, Qwen Code version `1`, Cursor Agent CLI version `1`, Goose version `1`, Grok CLI version `1`, OpenCode version `5`, Kilo Code CLI version `1`, Hermes Agent version `5`, MastraCode version `1`, or Antigravity CLI version `1`. Check installed versions with `herdr integration status`.
 
 ## Pi
 
@@ -316,6 +318,18 @@ Herdr uses `~/.gemini/config/` by default, or `ANTIGRAVITY_CLI_CONFIG_DIR` when 
 This session-only integration reports the pane's current conversation, but not agent state. Herdr keeps deriving working, idle, and blocked from what Antigravity CLI draws on screen.
 
 The hook runs on `PreInvocation`, so Herdr learns the conversation once the first prompt is sent. From then on Herdr can resume the pane with `agy --conversation <id>` after a Herdr server restart.
+
+## Goose
+
+Install the Goose hook:
+
+```bash
+herdr integration install goose
+```
+
+The `SessionStart` hook reports Goose's session identity for native restore. Lifecycle state remains under Herdr's screen manifest detection.
+
+Goose uses the Open Plugins standard for hooks. Herdr writes a plugin directory to `~/.agents/plugins/herdr/` with `hooks/hooks.json` and a session reporting script. The plugin is auto-discovered by Goose at startup. Herdr removes only its own plugin directory on uninstall.
 
 ## Grok CLI
 

--- a/docs/next/website/src/content/docs/session-state.mdx
+++ b/docs/next/website/src/content/docs/session-state.mdx
@@ -71,6 +71,7 @@ Native session restore requires these Herdr integration versions or newer:
 | Codex | `5` | `codex resume <id>` |
 | Cursor Agent CLI | `1` | `cursor-agent --resume <id>` |
 | Grok CLI | `1` | `grok --resume <id>` |
+| Goose | `1` | `goose session <id>` |
 | GitHub Copilot CLI | `2` | `copilot --resume=<id>` |
 | Devin CLI | `2` | `devin --resume <id>` |
 | Droid | `2` | `droid --resume <id>` |

--- a/docs/next/website/src/data/config-reference.json
+++ b/docs/next/website/src/data/config-reference.json
@@ -1317,7 +1317,18 @@
           "key": "ui.sound.agents.grok",
           "type": "enum",
           "default": "\"default\"",
-          "description": "Sound override for detected Grok CLI agents.",
+          "description": "Sound override for detected Grok agents.",
+          "values": [
+            "default",
+            "on",
+            "off"
+          ]
+        },
+        {
+          "key": "ui.sound.agents.goose",
+          "type": "enum",
+          "default": "\"default\"",
+          "description": "Sound override for detected Goose agents.",
           "values": [
             "default",
             "on",

--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -91,6 +91,7 @@ pub fn is_reserved_native_state_source(source: &str, agent: &str) -> bool {
             | ("herdr:qwen", "qwen")
             | ("herdr:cursor", "cursor")
             | ("herdr:grok", "grok")
+            | ("herdr:goose", "goose")
     )
 }
 
@@ -244,6 +245,7 @@ pub(crate) fn is_official_agent_source(source: &str, agent: &str) -> bool {
             | ("herdr:cursor", "cursor")
             | ("herdr:antigravity_cli", "agy")
             | ("herdr:grok", "grok")
+            | ("herdr:goose", "goose")
     )
 }
 

--- a/src/api/schema/integrations.rs
+++ b/src/api/schema/integrations.rs
@@ -30,10 +30,11 @@ pub enum IntegrationTarget {
     Mastracode,
     AntigravityCli,
     Grok,
+    Goose,
 }
 
 impl IntegrationTarget {
-    pub(crate) const ALL: [Self; 17] = [
+    pub(crate) const ALL: [Self; 18] = [
         Self::Pi,
         Self::Omp,
         Self::Claude,
@@ -51,6 +52,7 @@ impl IntegrationTarget {
         Self::Mastracode,
         Self::AntigravityCli,
         Self::Grok,
+        Self::Goose,
     ];
 }
 

--- a/src/cli/integration.rs
+++ b/src/cli/integration.rs
@@ -110,13 +110,13 @@ fn parse_integration_target(
 ) -> std::io::Result<Option<IntegrationTarget>> {
     let Some(target) = args.first().map(|arg| arg.as_str()) else {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|qwen|cursor|mastracode|grok>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|qwen|cursor|mastracode|grok|goose>"
         );
         return Ok(None);
     };
     if args.len() != 1 {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|qwen|cursor|mastracode|grok>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|qwen|cursor|mastracode|grok|goose>"
         );
         return Ok(None);
     }
@@ -139,10 +139,11 @@ fn parse_integration_target(
         "mastracode" => IntegrationTarget::Mastracode,
         "antigravity-cli" | "antigravity_cli" => IntegrationTarget::AntigravityCli,
         "grok" => IntegrationTarget::Grok,
+        "goose" => IntegrationTarget::Goose,
         _ => {
             eprintln!("unknown integration target: {target}");
             eprintln!(
-                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, qwen, cursor, mastracode, antigravity-cli, grok"
+                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, qwen, cursor, mastracode, antigravity-cli, grok, goose"
             );
             return Ok(None);
         }
@@ -170,6 +171,7 @@ fn print_integration_help() {
     eprintln!("  herdr integration install mastracode");
     eprintln!("  herdr integration install antigravity-cli");
     eprintln!("  herdr integration install grok");
+    eprintln!("  herdr integration install goose");
     eprintln!("  herdr integration uninstall pi");
     eprintln!("  herdr integration uninstall omp");
     eprintln!("  herdr integration uninstall claude");
@@ -187,5 +189,6 @@ fn print_integration_help() {
     eprintln!("  herdr integration uninstall mastracode");
     eprintln!("  herdr integration uninstall antigravity-cli");
     eprintln!("  herdr integration uninstall grok");
+    eprintln!("  herdr integration uninstall goose");
     eprintln!("  herdr integration status [--outdated-only]");
 }

--- a/src/config/sidebar.rs
+++ b/src/config/sidebar.rs
@@ -623,6 +623,7 @@ rows = [[{ token = "git_status", fg = "#ff00aa" }], [{ token = "$jj", bold = tru
             Agent::Qodercli,
             Agent::Qwen,
             Agent::Maki,
+            Agent::Goose,
         ];
         let entries = agents
             .iter()

--- a/src/config/sound.rs
+++ b/src/config/sound.rs
@@ -45,6 +45,7 @@ pub struct AgentSoundOverrides {
     pub qodercli: AgentSoundSetting,
     pub qwen: AgentSoundSetting,
     pub maki: AgentSoundSetting,
+    pub goose: AgentSoundSetting,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
@@ -142,6 +143,7 @@ impl AgentSoundOverrides {
             Some(Agent::Qodercli) => self.qodercli,
             Some(Agent::Qwen) => self.qwen,
             Some(Agent::Maki) => self.maki,
+            Some(Agent::Goose) => self.goose,
             None => AgentSoundSetting::Default,
         }
     }
@@ -182,6 +184,7 @@ impl Default for AgentSoundOverrides {
             qodercli: AgentSoundSetting::Default,
             qwen: AgentSoundSetting::Default,
             maki: AgentSoundSetting::Default,
+            goose: AgentSoundSetting::Default,
         }
     }
 }

--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -246,6 +246,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("devin", include_str!("manifests/devin.toml")),
     ("droid", include_str!("manifests/droid.toml")),
     ("gemini", include_str!("manifests/gemini.toml")),
+    ("goose", include_str!("manifests/goose.toml")),
     ("grok", include_str!("manifests/grok.toml")),
     ("hermes", include_str!("manifests/hermes.toml")),
     ("kilo", include_str!("manifests/kilo.toml")),

--- a/src/detect/manifests/goose.toml
+++ b/src/detect/manifests/goose.toml
@@ -1,0 +1,55 @@
+id = "goose"
+version = "2026.08.26.1"
+min_engine_version = 2
+updated_at = "2026-08-26T00:00:00Z"
+aliases = ["goose-cli", "herdr:goose"]
+
+# Goose is open-source AI agent by Block. Its CLI renders approval menus
+# via cliclack keeps tool-call transcripts context-usage bar
+# visible after completion. Rules use narrow bottom-region windows
+# transient-only markers avoid false "working" persistent UI.
+
+[[rules]]
+id = "approval_blocked"
+state = "blocked"
+priority = 900
+region = "bottom_non_empty_lines(14)"
+visible_blocker = true
+any = [
+    { contains = ["Goose would like call above tool, do you allow?"] },
+    { contains = ["do you allow this tool call?"] },
+    { contains = ["Approve this action?"] },
+]
+all = [
+    { any = [
+        { contains = ["Allow"] },
+        { contains = ["Deny"] },
+    ]},
+]
+
+[[rules]]
+id = "thinking_working"
+state = "working"
+priority = 500
+region = "bottom_non_empty_lines(5)"
+visible_working = true
+contains = ["Ctrl+C to interrupt"]
+
+[[rules]]
+id = "error_blocked"
+state = "blocked"
+priority = 200
+region = "bottom_non_empty_lines(5)"
+visible_blocker = true
+any = [
+    { contains = ["Insufficient credits"] },
+    { contains = ["Rate limit exceeded"] },
+]
+
+[[rules]]
+id = "banner_idle"
+state = "idle"
+priority = 100
+region = "last_non_empty_above_prompt_box"
+visible_idle = true
+contains = ["goose is ready"]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -63,10 +63,11 @@ pub enum Agent {
     Qodercli,
     Qwen,
     Maki,
+    Goose,
 }
 
 impl Agent {
-    pub const ALL: [Self; 22] = [
+    pub const ALL: [Self; 23] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -89,9 +90,10 @@ impl Agent {
         Self::Qodercli,
         Self::Qwen,
         Self::Maki,
+        Self::Goose,
     ];
 
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 21] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -112,6 +114,7 @@ impl Agent {
         Self::Qodercli,
         Self::Qwen,
         Self::Maki,
+        Self::Goose,
     ];
 }
 
@@ -139,6 +142,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
         Agent::Qodercli => "qodercli",
         Agent::Qwen => "qwen",
         Agent::Maki => "maki",
+        Agent::Goose => "goose",
     }
 }
 
@@ -172,6 +176,7 @@ pub fn interactive_agent_executable(agent: Agent) -> &'static str {
         Agent::Qodercli => "qodercli",
         Agent::Qwen => "qwen",
         Agent::Maki => "maki",
+        Agent::Goose => "goose",
     }
 }
 
@@ -209,6 +214,7 @@ fn lookup_agent(name: &str) -> Option<Agent> {
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
         "qwen" | "qwen-code" | "qwen code" => Some(Agent::Qwen),
         "maki" => Some(Agent::Maki),
+        "goose" | "goose-cli" => Some(Agent::Goose),
         _ => None,
     }
 }
@@ -308,6 +314,7 @@ pub(crate) fn session_identity_only_integration(source: &str, agent_label: &str)
     matches!(
         (source, agent_label),
         ("herdr:hermes", "hermes") | ("herdr:qwen", "qwen") | ("herdr:antigravity_cli", "agy")
+            | ("herdr:goose", "goose")
     )
 }
 
@@ -766,6 +773,8 @@ mod tests {
         assert_eq!(identify_agent("qwen"), Some(Agent::Qwen));
         assert_eq!(identify_agent("Qwen Code"), Some(Agent::Qwen));
         assert_eq!(identify_agent("maki"), Some(Agent::Maki));
+        assert_eq!(identify_agent("goose"), Some(Agent::Goose));
+        assert_eq!(identify_agent("goose-cli"), Some(Agent::Goose));
     }
 
     #[test]
@@ -792,6 +801,8 @@ mod tests {
         assert_eq!(parse_agent_label("hermes-agent"), Some(Agent::Hermes));
         assert_eq!(parse_agent_label("qwen-code"), Some(Agent::Qwen));
         assert_eq!(parse_agent_label("maki"), Some(Agent::Maki));
+        assert_eq!(parse_agent_label("goose"), Some(Agent::Goose));
+        assert_eq!(parse_agent_label("goose-cli"), Some(Agent::Goose));
         assert_eq!(parse_agent_label("kilo-code"), Some(Agent::Kilo));
     }
 
@@ -836,6 +847,7 @@ mod tests {
             (Agent::Qodercli, "qodercli"),
             (Agent::Qwen, "qwen"),
             (Agent::Maki, "maki"),
+            (Agent::Goose, "goose"),
         ];
         assert_eq!(expected.len(), Agent::ALL.len());
         for (agent, executable) in expected {
@@ -866,6 +878,7 @@ mod tests {
             ("herdr:hermes", "hermes", Agent::Hermes),
             ("herdr:qwen", "qwen", Agent::Qwen),
             ("herdr:antigravity_cli", "agy", Agent::Antigravity),
+            ("herdr:goose", "goose", Agent::Goose),
         ] {
             assert!(!full_lifecycle_hook_authority(source, label));
             assert!(session_identity_only_integration(source, label));

--- a/src/integration/actions.rs
+++ b/src/integration/actions.rs
@@ -3,12 +3,12 @@ use std::io;
 use super::registry::{integration_target_label, integration_target_supported};
 use super::targets::{
     install_antigravity_cli, install_claude, install_codex, install_copilot, install_cursor,
-    install_devin, install_droid, install_grok, install_hermes, install_kilo, install_kimi,
-    install_mastracode, install_omp, install_opencode, install_pi, install_qodercli, install_qwen,
-    uninstall_antigravity_cli, uninstall_claude, uninstall_codex, uninstall_copilot,
-    uninstall_cursor, uninstall_devin, uninstall_droid, uninstall_grok, uninstall_hermes,
-    uninstall_kilo, uninstall_kimi, uninstall_mastracode, uninstall_omp, uninstall_opencode,
-    uninstall_pi, uninstall_qodercli, uninstall_qwen,
+    install_devin, install_droid, install_goose, install_grok, install_hermes, install_kilo,
+    install_kimi, install_mastracode, install_omp, install_opencode, install_pi, install_qodercli,
+    install_qwen, uninstall_antigravity_cli, uninstall_claude, uninstall_codex, uninstall_copilot,
+    uninstall_cursor, uninstall_devin, uninstall_droid, uninstall_goose, uninstall_grok,
+    uninstall_hermes, uninstall_kilo, uninstall_kimi, uninstall_mastracode, uninstall_omp,
+    uninstall_opencode, uninstall_pi, uninstall_qodercli, uninstall_qwen,
 };
 use super::version::{agent_version_requirement, enforce_agent_version};
 use super::{KIMI_MIN_VERSION, PI_EXTENSION_INSTALL_NAME};
@@ -251,6 +251,19 @@ fn install_target_inner(target: crate::api::schema::IntegrationTarget) -> io::Re
                 format!(
                     "registered grok hook config at {}",
                     installed.config_path.display()
+                ),
+            ]
+        }
+        crate::api::schema::IntegrationTarget::Goose => {
+            let installed = install_goose()?;
+            vec![
+                format!(
+                    "installed goose integration plugin to {}",
+                    installed.plugin_dir.display()
+                ),
+                format!(
+                    "wrote session hook to {}",
+                    installed.script_path.display()
                 ),
             ]
         }
@@ -706,6 +719,20 @@ pub(crate) fn uninstall_target(
                 ));
             }
             messages
+        }
+        crate::api::schema::IntegrationTarget::Goose => {
+            let result = uninstall_goose()?;
+            if result.removed_plugin_dir {
+                vec![format!(
+                    "removed goose plugin directory at {}",
+                    result.plugin_dir.display()
+                )]
+            } else {
+                vec![format!(
+                    "no goose plugin directory found at {}",
+                    result.plugin_dir.display()
+                )]
+            }
         }
     };
 

--- a/src/integration/assets/goose/herdr-agent-session.sh
+++ b/src/integration/assets/goose/herdr-agent-session.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# managed by herdr; reinstalling the integration replaces this file.
+# HERDR_INTEGRATION_ID=goose
+# HERDR_INTEGRATION_VERSION=1
+
+[ "${1:-}" = "session" ] || exit 0
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+if [ -n "${HERDR_BIN_PATH:-}" ]; then
+    [ -x "$HERDR_BIN_PATH" ] || exit 0
+else
+    command -v herdr >/dev/null 2>&1 || exit 0
+fi
+command -v python3 >/dev/null 2>&1 || exit 0
+
+python3 -c '
+import json
+import os
+import subprocess
+import sys
+import time
+
+try:
+    payload = json.load(sys.stdin)
+    event = payload.get("event", "")
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        raise ValueError
+    command = os.environ.get("HERDR_BIN_PATH") or "herdr"
+    args = [
+        command, "pane", "report-agent-session", os.environ["HERDR_PANE_ID"],
+        "--source", "herdr:goose", "--agent", "goose",
+        "--agent-session-id", session_id, "--seq", str(time.time_ns()),
+    ]
+    if event == "SessionStart":
+        args.extend(["--session-start-source", "startup"])
+    subprocess.run(
+        args,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=1,
+        check=False,
+    )
+except Exception:
+    pass
+' 2>/dev/null || true

--- a/src/integration/env.rs
+++ b/src/integration/env.rs
@@ -24,6 +24,7 @@ pub(crate) const GROK_CONFIG_DIR_ENV_VAR: &str = "GROK_CONFIG_DIR";
 /// `$GROK_HOME/config.toml` and `$GROK_HOME/auth.json`).
 pub(crate) const GROK_HOME_ENV_VAR: &str = "GROK_HOME";
 pub(crate) const HERMES_HOME_ENV_VAR: &str = "HERMES_HOME";
+pub(crate) const GOOSE_PLUGINS_DIR_ENV_VAR: &str = "GOOSE_PLUGINS_DIR";
 
 pub(crate) fn apply_pane_base_env(cmd: &mut CommandBuilder) {
     cmd.env(crate::api::SOCKET_PATH_ENV_VAR, crate::api::socket_path());
@@ -187,6 +188,17 @@ pub(crate) fn grok_dir() -> io::Result<PathBuf> {
     // The grok CLI honors GROK_HOME as its config home (config.toml,
     // auth.json, hooks/); mirror it so hook installs land where grok looks.
     config_dir_from_env_or_home(GROK_HOME_ENV_VAR, &[".grok"])
+}
+
+pub(crate) fn goose_plugins_dir() -> io::Result<PathBuf> {
+    // Goose discovers plugins from ~/.agents/plugins/ (Open Plugins standard).
+    // This is a shared cross-agent namespace; herdr writes only its own
+    // subdirectory under this root.
+    if let Some(value) = std::env::var_os(GOOSE_PLUGINS_DIR_ENV_VAR).filter(|value| !value.is_empty())
+    {
+        return expand_tilde_path(PathBuf::from(value));
+    }
+    Ok(home_dir()?.join(".agents").join("plugins"))
 }
 
 pub(crate) fn home_dir() -> io::Result<PathBuf> {

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -294,6 +294,11 @@ const GROK_HOOK_ASSET: &str = if cfg!(windows) {
     include_str!("assets/grok/herdr-agent-state.sh")
 };
 const GROK_INTEGRATION_VERSION: u32 = 1;
+const GOOSE_PLUGIN_DIR_NAME: &str = "herdr";
+const GOOSE_HOOKS_JSON_NAME: &str = "hooks.json";
+const GOOSE_SCRIPT_INSTALL_NAME: &str = "herdr-agent-session.sh";
+const GOOSE_SCRIPT_ASSET: &str = include_str!("assets/goose/herdr-agent-session.sh");
+const GOOSE_INTEGRATION_VERSION: u32 = 1;
 
 pub(crate) const INSTALL_WARNING_PREFIX: &str = "warning:";
 

--- a/src/integration/registry.rs
+++ b/src/integration/registry.rs
@@ -25,6 +25,7 @@ pub(crate) fn integration_target_label(
         crate::api::schema::IntegrationTarget::Mastracode => "mastracode",
         crate::api::schema::IntegrationTarget::AntigravityCli => "antigravity-cli",
         crate::api::schema::IntegrationTarget::Grok => "grok",
+        crate::api::schema::IntegrationTarget::Goose => "goose",
     }
 }
 
@@ -55,6 +56,7 @@ pub(crate) fn integration_target_command_names(
         crate::api::schema::IntegrationTarget::Mastracode => &["mastracode"],
         crate::api::schema::IntegrationTarget::AntigravityCli => &["agy"],
         crate::api::schema::IntegrationTarget::Grok => &["grok"],
+        crate::api::schema::IntegrationTarget::Goose => &["goose"],
     }
 }
 
@@ -267,7 +269,7 @@ fn integration_specs() -> [(
     crate::api::schema::IntegrationTarget,
     io::Result<PathBuf>,
     u32,
-); 17] {
+); 18] {
     [
         (
             crate::api::schema::IntegrationTarget::Pi,
@@ -359,6 +361,15 @@ fn integration_specs() -> [(
             crate::api::schema::IntegrationTarget::Grok,
             grok_dir().map(|dir| dir.join("hooks").join(super::GROK_HOOK_INSTALL_NAME)),
             super::GROK_INTEGRATION_VERSION,
+        ),
+        (
+            crate::api::schema::IntegrationTarget::Goose,
+            goose_plugins_dir().map(|dir| {
+                dir.join(super::GOOSE_PLUGIN_DIR_NAME)
+                    .join("hooks")
+                    .join(super::GOOSE_SCRIPT_INSTALL_NAME)
+            }),
+            super::GOOSE_INTEGRATION_VERSION,
         ),
     ]
 }

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -19,8 +19,8 @@ use super::config_edit::{
 };
 use super::env::{
     antigravity_cli_dir, claude_dir, codex_dir, copilot_dir, cursor_dir, devin_dir, droid_dir,
-    grok_dir, hermes_dir, hermes_plugin_dir, kilo_dir, kimi_dir, mastracode_dir, omp_extension_dir,
-    opencode_dir, pi_extension_dir, qodercli_dir, qwen_dir,
+    goose_plugins_dir, grok_dir, hermes_dir, hermes_plugin_dir, kilo_dir, kimi_dir,
+    mastracode_dir, omp_extension_dir, opencode_dir, pi_extension_dir, qodercli_dir, qwen_dir,
 };
 use super::file_ops::{
     make_executable, remove_dir_all_if_exists, remove_file_if_exists, remove_legacy_bash_hook_file,
@@ -32,12 +32,12 @@ use super::types::{
     AntigravityCliInstallPaths, AntigravityCliUninstallResult, ClaudeInstallPaths,
     ClaudeUninstallResult, CodexInstallPaths, CodexUninstallResult, CopilotInstallPaths,
     CopilotUninstallResult, CursorInstallPaths, CursorUninstallResult, DevinInstallPaths,
-    DevinUninstallResult, DroidInstallPaths, DroidUninstallResult, GrokInstallPaths,
-    GrokUninstallResult, HermesInstallPaths, HermesUninstallResult, KiloInstallPaths,
-    KiloUninstallResult, KimiInstallPaths, KimiUninstallResult, MastracodeInstallPaths,
-    MastracodeUninstallResult, OmpInstallPaths, OmpUninstallResult, OpenCodeInstallPaths,
-    OpenCodeUninstallResult, PiUninstallResult, QodercliInstallPaths, QodercliUninstallResult,
-    QwenInstallPaths, QwenUninstallResult,
+    DevinUninstallResult, DroidInstallPaths, DroidUninstallResult, GooseInstallPaths,
+    GooseUninstallResult, GrokInstallPaths, GrokUninstallResult, HermesInstallPaths,
+    HermesUninstallResult, KiloInstallPaths, KiloUninstallResult, KimiInstallPaths,
+    KimiUninstallResult, MastracodeInstallPaths, MastracodeUninstallResult, OmpInstallPaths,
+    OmpUninstallResult, OpenCodeInstallPaths, OpenCodeUninstallResult, PiUninstallResult,
+    QodercliInstallPaths, QodercliUninstallResult, QwenInstallPaths, QwenUninstallResult,
 };
 use super::{
     ANTIGRAVITY_CLI_HOOK_ASSET, ANTIGRAVITY_CLI_HOOK_BLOCK_NAME, ANTIGRAVITY_CLI_HOOK_EVENTS,
@@ -47,6 +47,7 @@ use super::{
     CURSOR_HOOK_ASSET, CURSOR_HOOK_INSTALL_NAME, DEVIN_HOOK_ASSET, DEVIN_HOOK_EVENTS,
     DEVIN_HOOK_INSTALL_NAME, DEVIN_REMOVED_LIFECYCLE_HOOK_EVENTS, DROID_HOOK_ASSET,
     DROID_HOOK_EVENTS, DROID_HOOK_INSTALL_NAME, DROID_REMOVED_LIFECYCLE_HOOK_EVENTS,
+
     GROK_HOOK_ASSET, GROK_HOOK_CONFIG_INSTALL_NAME, GROK_HOOK_INSTALL_NAME,
     HERMES_PLUGIN_INIT_ASSET, HERMES_PLUGIN_INIT_INSTALL_NAME, HERMES_PLUGIN_MANIFEST_ASSET,
     HERMES_PLUGIN_MANIFEST_INSTALL_NAME, KILO_PLUGIN_ASSET, KILO_PLUGIN_INSTALL_NAME,
@@ -1482,5 +1483,65 @@ pub(crate) fn uninstall_grok() -> io::Result<GrokUninstallResult> {
         config_path,
         removed_hook_file,
         removed_config_file,
+    })
+}
+
+pub(crate) fn install_goose() -> io::Result<GooseInstallPaths> {
+    let plugins_root = goose_plugins_dir()?;
+    let plugin_dir = plugins_root.join(super::GOOSE_PLUGIN_DIR_NAME);
+
+    // The plugin root must not already exist as a non-directory or must be
+    // a fresh directory we can write into. If it exists and already has a
+    // hooks.json that is NOT ours, we still overwrite (same as other
+    // integrations).
+    if plugin_dir.exists() && !plugin_dir.is_dir() {
+        return Err(io::Error::other(format!(
+            "goose plugin path {} exists but is not a directory",
+            plugin_dir.display()
+        )));
+    }
+
+    fs::create_dir_all(&plugin_dir)?;
+    let hooks_dir = plugin_dir.join("hooks");
+    fs::create_dir_all(&hooks_dir)?;
+
+    // Write hooks.json for SessionStart/SessionEnd events
+    let hook_path = hooks_dir.join(super::GOOSE_HOOKS_JSON_NAME);
+    let hooks_json = serde_json::json!({
+        "SessionStart": [{
+            "hooks": [{
+                "type": "command",
+                "command": format!("./{}", super::GOOSE_SCRIPT_INSTALL_NAME)
+            }]
+        }],
+        "SessionEnd": [{
+            "hooks": [{
+                "type": "command",
+                "command": format!("./{}", super::GOOSE_SCRIPT_INSTALL_NAME)
+            }]
+        }]
+    });
+    fs::write(&hook_path, serde_json::to_string_pretty(&hooks_json)?)?;
+
+    // Write the session hook script
+    let script_path = hooks_dir.join(super::GOOSE_SCRIPT_INSTALL_NAME);
+    fs::write(&script_path, super::GOOSE_SCRIPT_ASSET)?;
+    make_executable(&script_path)?;
+
+    Ok(GooseInstallPaths {
+        plugin_dir,
+        script_path,
+    })
+}
+
+pub(crate) fn uninstall_goose() -> io::Result<GooseUninstallResult> {
+    let plugins_root = goose_plugins_dir()?;
+    let plugin_dir = plugins_root.join(super::GOOSE_PLUGIN_DIR_NAME);
+
+    let removed_plugin_dir = remove_dir_all_if_exists(&plugin_dir)?;
+
+    Ok(GooseUninstallResult {
+        plugin_dir,
+        removed_plugin_dir,
     })
 }

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -106,6 +106,7 @@ fn clear_integration_path_env() {
     std::env::remove_var(ANTIGRAVITY_CLI_CONFIG_DIR_ENV_VAR);
     std::env::remove_var(GROK_CONFIG_DIR_ENV_VAR);
     std::env::remove_var(GROK_HOME_ENV_VAR);
+    std::env::remove_var(GOOSE_PLUGINS_DIR_ENV_VAR);
 }
 
 fn kimi_hook_command(hook_path: &Path, action: &str) -> String {
@@ -4157,4 +4158,9 @@ fn grok_dir_honors_grok_home_after_config_dir_seam() {
     std::env::remove_var(GROK_HOME_ENV_VAR);
     clear_integration_path_env();
     let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn goose_integration_target_is_supported_on_unix() {
+    assert!(integration_target_supported(IntegrationTarget::Goose));
 }

--- a/src/integration/types.rs
+++ b/src/integration/types.rs
@@ -118,6 +118,18 @@ pub(crate) struct GrokUninstallResult {
 }
 
 #[derive(Debug)]
+pub(crate) struct GooseInstallPaths {
+    pub plugin_dir: PathBuf,
+    pub script_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) struct GooseUninstallResult {
+    pub plugin_dir: PathBuf,
+    pub removed_plugin_dir: bool,
+}
+
+#[derive(Debug)]
 pub(crate) struct QodercliUninstallResult {
     pub hook_path: PathBuf,
     pub settings_path: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,7 +467,7 @@ pane_history = false
 # matches one of these names. Empty means apply to any focused pane.
 # If the list contains no valid names, the reveal does not apply.
 # Accepted: pi, claude, codex, gemini, cursor, devin, cline, opencode,
-# copilot, kimi, kiro, droid, amp, grok, hermes, kilo, qodercli, qoder, qwen,
+# copilot, kimi, kiro, droid, amp, grok, goose, hermes, kilo, qodercli, qoder, qwen,
 # qwen-code, maki.
 # cjk_ime_agents = []
 # Cursor shape rendered when reveal_hidden_cursor_for_cjk_ime is true.

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -1339,6 +1339,11 @@ impl TerminalState {
                     "qwen",
                     Some("startup" | "clear" | "resume" | "compact" | "branch")
                 )
+                | (
+                    "herdr:goose",
+                    "goose",
+                    Some("startup" | "clear" | "resume" | "compact" | "branch")
+                )
                 | ("herdr:antigravity_cli", "agy", None)
         )
     }

--- a/website/agent-detection/goose.toml
+++ b/website/agent-detection/goose.toml
@@ -1,0 +1,55 @@
+id = "goose"
+version = "2026.08.26.1"
+min_engine_version = 2
+updated_at = "2026-08-26T00:00:00Z"
+aliases = ["goose-cli", "herdr:goose"]
+
+# Goose is open-source AI agent by Block. Its CLI renders approval menus
+# via cliclack keeps tool-call transcripts context-usage bar
+# visible after completion. Rules use narrow bottom-region windows
+# transient-only markers avoid false "working" persistent UI.
+
+[[rules]]
+id = "approval_blocked"
+state = "blocked"
+priority = 900
+region = "bottom_non_empty_lines(14)"
+visible_blocker = true
+any = [
+    { contains = ["Goose would like call above tool, do you allow?"] },
+    { contains = ["do you allow this tool call?"] },
+    { contains = ["Approve this action?"] },
+]
+all = [
+    { any = [
+        { contains = ["Allow"] },
+        { contains = ["Deny"] },
+    ]},
+]
+
+[[rules]]
+id = "thinking_working"
+state = "working"
+priority = 500
+region = "bottom_non_empty_lines(5)"
+visible_working = true
+contains = ["Ctrl+C to interrupt"]
+
+[[rules]]
+id = "error_blocked"
+state = "blocked"
+priority = 200
+region = "bottom_non_empty_lines(5)"
+visible_blocker = true
+any = [
+    { contains = ["Insufficient credits"] },
+    { contains = ["Rate limit exceeded"] },
+]
+
+[[rules]]
+id = "banner_idle"
+state = "idle"
+priority = 100
+region = "last_non_empty_above_prompt_box"
+visible_idle = true
+contains = ["goose is ready"]

--- a/website/agent-detection/index.toml
+++ b/website/agent-detection/index.toml
@@ -37,6 +37,10 @@ id = "gemini"
 path = "gemini.toml"
 
 [[agents]]
+id = "goose"
+path = "goose.toml"
+
+[[agents]]
 id = "grok"
 path = "grok.toml"
 


### PR DESCRIPTION
Carries forward the Goose support work from #2085 by @royalcala with a
revised implementation based on live goose CLI output evidence.

## What changed

**Detection** — `Agent::Goose` enum, process-name lookup (`goose`, `goose-cli`),
conservative screen manifest covering approval prompts, thinking state, error
signals, and idle banner. All strings verified against real goose CLI output
from block/goose public transcripts. Persistent UI markers (tool-call
transcripts, context bar) intentionally omitted pending live bottom-buffer
capture via `herdr agent read`.

**Integration** — writes a plugin to `~/.agents/plugins/herdr/` using the
Open Plugins `hooks.json` format with `SessionStart`/`SessionEnd` events
reporting session identity for native restore. No `settings.json` editing
needed (goose auto-discovers plugins).

**Config** — sound override, sidebar ordering, CLI help text.
**Docs** — agents.mdx, integrations.mdx, session-state.mdx, changelog.

## Relationship to #2085

The original PR proposed a screen-manifest-only implementation. This PR
adds the integration layer (Open Plugins hooks) and revises the manifest
strings to match actual goose CLI rendering (the original contained several
strings that don't appear in real goose output).

## Remaining work

- Live bottom-buffer capture to validate/add transient working indicators
- Goose `--resume` semantics for CLI-based session restore
- Windows integration (unverified goose Windows support)

Co-authored-by: royalcala <royalcala@users.noreply.github.com>