### PR TITLE
fix(detect): identify kiro-cli desktop app pty-host wrapper

### DIFF
--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -177,7 +177,22 @@ pub fn interactive_agent_executable(agent: Agent) -> &'static str {
 
 pub fn parse_agent_label(agent: &str) -> Option<Agent> {
     let name = normalized_agent_lookup_name(agent);
-    parse_canonical_agent_label(&name).or_else(|| lookup_agent(&name))
+    parse_canonical_agent_label(&name)
+        .or_else(|| lookup_agent(&name))
+        .or_else(|| kiro_term_wrapper_agent(agent))
+}
+
+/// The Kiro CLI desktop app runs its PTY host under a process name shaped like
+/// `zsh (kiro-cli-term)` (the shell prefix varies: bash/fish/nu), which
+/// disguises the foreground process as the user's shell while the real
+/// `kiro-cli` runs in a descendant process group Herdr does not read. The
+/// `(kiro-cli-term)` suffix is Kiro-specific, so treat any process carrying it
+/// as Kiro. Applies to both the v2 and v3 engines, which share the wrapper.
+fn kiro_term_wrapper_agent(name: &str) -> Option<Agent> {
+    name.trim()
+        .to_lowercase()
+        .contains("(kiro-cli-term)")
+        .then_some(Agent::Kiro)
 }
 
 pub(crate) fn parse_canonical_agent_label(label: &str) -> Option<Agent> {
@@ -755,6 +770,11 @@ mod tests {
         assert_eq!(identify_agent("Kimi Code"), Some(Agent::Kimi));
         assert_eq!(identify_agent("kiro"), Some(Agent::Kiro));
         assert_eq!(identify_agent("kiro-cli"), Some(Agent::Kiro));
+        // Kiro CLI desktop app PTY-host wrapper names (shell prefix varies).
+        assert_eq!(identify_agent("zsh (kiro-cli-term)"), Some(Agent::Kiro));
+        assert_eq!(identify_agent("bash (kiro-cli-term)"), Some(Agent::Kiro));
+        assert_eq!(identify_agent("fish (kiro-cli-term)"), Some(Agent::Kiro));
+        assert_eq!(identify_agent("nu (kiro-cli-term)"), Some(Agent::Kiro));
         assert_eq!(identify_agent("copilot"), Some(Agent::GithubCopilot));
         assert_eq!(identify_agent("ghcs"), Some(Agent::GithubCopilot));
         assert_eq!(identify_agent("grok"), Some(Agent::Grok));
@@ -887,6 +907,29 @@ mod tests {
         assert_eq!(identify_agent("CLAUDE"), Some(Agent::Claude));
         assert_eq!(identify_agent("Codex"), Some(Agent::Codex));
         assert_eq!(identify_agent("Devin"), Some(Agent::Devin));
+    }
+
+    #[test]
+    fn identify_agent_in_job_detects_kiro_cli_term_wrapper() {
+        // The Kiro CLI desktop app runs its PTY host as the foreground group
+        // leader under a name like `zsh (kiro-cli-term)`; the real kiro-cli
+        // lives in a descendant process group Herdr does not read. The full
+        // wrapper name is carried on argv0 (process.name may be truncated).
+        let job = crate::platform::ForegroundJob {
+            process_group_id: 123,
+            processes: vec![crate::platform::ForegroundProcess {
+                pid: 123,
+                name: "zsh (kiro-cli-t".to_string(),
+                argv0: Some("zsh (kiro-cli-term)".to_string()),
+                argv: Some(vec!["zsh (kiro-cli-term)".to_string()]),
+                cmdline: Some("zsh (kiro-cli-term)".to_string()),
+            }],
+        };
+
+        assert_eq!(
+            identify_agent_in_job(&job),
+            Some((Agent::Kiro, "zsh (kiro-cli-term)".to_string()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
The Kiro CLI desktop app runs its PTY host under a process name shaped like `zsh (kiro-cli-term)` (shell prefix varies: bash/fish/nu), which disguises the foreground process as the user's shell. The real kiro-cli runs in a descendant process group Herdr does not read, so agent identification failed and kiro panes were never recognized — for both the v2 and v3 engines.

Recognize the Kiro-specific `(kiro-cli-term)` suffix so these panes are identified as kiro, which lets the existing screen-detection manifest run. Verified end-to-end: agent list reports kiro and idle/working states detect correctly under `kiro-cli chat --v3`.

---

  fix(detect): identify kiro-cli desktop app pty-host wrapper

  Description:

  ## Summary

  The Kiro CLI desktop app runs its PTY host under a process name shaped like
  `zsh (kiro-cli-term)` (the shell prefix varies: `bash`/`fish`/`nu`), which
  disguises the foreground process as the user's shell. The real `kiro-cli`
  process runs in a descendant process group that Herdr does not read, so agent
  identification failed and kiro panes were never recognized as an agent — for
  both the v2 and v3 engines.

  Because identification failed upstream of everything else, the existing
  `kiro.toml` screen-detection manifest never ran, so state (idle/working/blocked)
  was never reported for kiro panes on this install layout.

  This change recognizes the Kiro-specific `(kiro-cli-term)` process-name suffix
  in `parse_agent_label`, so these panes are identified as `Agent::Kiro`. Once
  identified, the existing screen-detection manifest takes over unchanged.

  ## Root cause (observed via `ps`)

  zsh (kiro-cli-term)   (foreground process group leader — all Herdr reads)
    └ /bin/zsh --login
        └ kiro-cli chat [--v3]   (the real kiro, in a separate process group)
            └ kiro-cli-chat → bun tui.js → node acp-server.js

  `~/.local/bin/` (desktop app install) ships multiple copies of the same
  `kiro-cli-term` PTY-host binary named `zsh (kiro-cli-term)`,
  `bash (kiro-cli-term)`, `fish (kiro-cli-term)`, `nu (kiro-cli-term)` — the
  wrapper deliberately presents itself as the user's shell. The `(kiro-cli-term)`
  suffix is Kiro-specific, so matching it is safe against false positives.

  ## Changes

  - `src/detect/mod.rs`: add `kiro_term_wrapper_agent` helper matching the
    `(kiro-cli-term)` suffix; chain it after the existing lookups in
    `parse_agent_label`. No change to `kiro.toml`.

  ## Testing

  - `cargo fmt --check`: clean
  - `cargo clippy --all-targets --locked -- -D warnings`: clean
  - `cargo nextest run` (excluding `live_handoff`): 3352 passed, 0 failed
    - includes new unit tests: `identify_agent_in_job_detects_kiro_cli_term_wrapper`
      and added wrapper-name assertions in `identify_known_agents`
  - End-to-end on macOS with a real `kiro-cli chat --v3` pane:
    - `agent list` now reports `kiro` (was empty before the fix)
    - `prompt_idle` matches at idle; `kiro_working_marker` matches while working;
      idle → working → idle transitions detected correctly
    - `agent prompt` submission works (scheduling path confirmed)

  ## Not covered

  - The `blocked` (tool-approval) state was not exercised end-to-end to avoid
    running real tool operations during throwaway verification. The relevant
    `tool_approval`/`subagent_approval` rules correctly did not match while idle
    or working.
  - Only the desktop app install layout was inspected. If a standalone/npm
    install exposes `kiro-cli` directly as the foreground process, identification
    already works and this change is simply additive.

  ## Notes

  - Environment: verified with Zig 0.15.2 (`brew install zig@0.15`).
  - Two `live_handoff` integration tests failed in my local environment, but they
    are unrelated to this change: they use a fake `pi` shell-script agent, and
    they fail identically with the change stashed. Recommend re-running full
    `just check` in a clean CI environment.