### PR TITLE
fix: opencode scrubbing without animations

### DIFF
--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -301,6 +301,30 @@ fn all_bundled_manifests_parse_and_validate() {
 }
 
 #[test]
+fn opencode_static_interrupt_footer_is_working() {
+    with_manifest_dirs("opencode-static-interrupt", || {
+        let explain = explain(
+            Agent::OpenCode,
+            "Build · GPT-5.6 Sol Fast OpenAI · high\n[⋯]  esc interrupttrl+t variants 34.1K (3%) ctrl+p commands",
+        );
+
+        assert_eq!(explain.state, AgentState::Working);
+        assert_eq!(
+            explain.matched_rule.as_ref().map(|rule| rule.id.as_str()),
+            Some("static_interrupt_footer_working")
+        );
+        assert!(explain.visible_working);
+
+        let stale_transcript = explain(
+            Agent::OpenCode,
+            "[⋯]  esc interrupt from an earlier status\nBuild · GPT-5.6 Sol Fast\nctrl+p commands",
+        );
+        assert_eq!(stale_transcript.state, AgentState::Idle);
+        assert!(!stale_transcript.visible_working);
+    });
+}
+
+#[test]
 fn devin_manifest_detects_idle_working_and_blocked_states() {
     let idle = explain(
         Agent::Devin,

--- a/src/detect/manifests/opencode.toml
+++ b/src/detect/manifests/opencode.toml
@@ -1,7 +1,7 @@
 id = "opencode"
-version = "2026.06.10.1"
+version = "2026.08.27.1"
 min_engine_version = 1
-updated_at = "2026-06-10T00:00:00Z"
+updated_at = "2026-08-27T00:00:00Z"
 aliases = ["open-code", "herdr:opencode"]
 
 [[rules]]
@@ -27,6 +27,14 @@ any = [
   { contains = ["press esc to interrupt"] },
   { line_regex = ['(?i).*opencode.*esc (again to )?interrupt'] },
 ]
+
+[[rules]]
+id = "static_interrupt_footer_working"
+state = "working"
+priority = 110
+region = "bottom_non_empty_lines(1)"
+visible_working = true
+line_regex = ['^\s*\[⋯\]\s+esc interrupt']
 
 [[rules]]
 id = "progress_bar_working"

--- a/website/agent-detection/opencode.toml
+++ b/website/agent-detection/opencode.toml
@@ -1,7 +1,7 @@
 id = "opencode"
-version = "2026.06.10.1"
+version = "2026.08.27.1"
 min_engine_version = 1
-updated_at = "2026-06-10T00:00:00Z"
+updated_at = "2026-08-27T00:00:00Z"
 aliases = ["open-code", "herdr:opencode"]
 
 [[rules]]
@@ -27,6 +27,14 @@ any = [
   { contains = ["press esc to interrupt"] },
   { line_regex = ['(?i).*opencode.*esc (again to )?interrupt'] },
 ]
+
+[[rules]]
+id = "static_interrupt_footer_working"
+state = "working"
+priority = 110
+region = "bottom_non_empty_lines(1)"
+visible_working = true
+line_regex = ['^\s*\[⋯\]\s+esc interrupt']
 
 [[rules]]
 id = "progress_bar_working"


### PR DESCRIPTION
When animations are turned off in OpenCode, the screen scrubbing does not work, this adds the correct footer to match the 'working' process.

Here is a screenshot from opencode:
<img width="1292" height="217" alt="image" src="https://github.com/user-attachments/assets/9830fdbe-ded1-43ff-8fcf-f606e54c6678" />
