### PR TITLE
fix: keep OSC evidence through first agent acquisition

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -374,6 +374,15 @@ fn foreground_shell_agent_action(
     ForegroundShellAgentAction::ObserveProbe
 }
 
+/// Drops retained OSC evidence when changing away from an identified agent.
+/// First acquisition keeps bytes that the newly identified process may have
+/// emitted before the process probe recognized it.
+fn clear_osc_evidence_for_agent_transition(terminal: &PaneTerminal, previous_agent: Option<Agent>) {
+    if previous_agent.is_some() {
+        terminal.clear_agent_osc_state();
+    }
+}
+
 fn apply_foreground_shell_agent_action(
     agent_presence: &mut AgentDetectionPresence,
     action: ForegroundShellAgentAction,
@@ -831,9 +840,10 @@ fn spawn_basic_detection_task(
                     if agent_changed {
                         pending_idle.clear();
                         last_screen_scan_detection_content_seq = None;
-                        // A new foreground agent must not inherit OSC
-                        // title/progress evidence from the previous process.
-                        terminal.clear_agent_osc_state();
+                        // A replacement agent must not inherit OSC evidence
+                        // from the previous process; a first acquisition keeps
+                        // the evidence its own process already emitted.
+                        clear_osc_evidence_for_agent_transition(&terminal, previous_agent);
                         if let Some(agent) = agent {
                             agent_startup_grace_until = Some(now + AGENT_STARTUP_GRACE_WINDOW);
                             state = AgentState::Unknown;
@@ -2363,9 +2373,14 @@ impl PaneRuntime {
                                 {
                                     pending_idle.clear();
                                     last_screen_scan_detection_content_seq = None;
-                                    // A new foreground agent must not inherit OSC
-                                    // title/progress evidence from the previous process.
-                                    terminal.clear_agent_osc_state();
+                                    // A replacement agent must not inherit OSC
+                                    // evidence from the previous process; a first
+                                    // acquisition keeps the evidence its own
+                                    // process already emitted.
+                                    clear_osc_evidence_for_agent_transition(
+                                        &terminal,
+                                        previous_agent,
+                                    );
                                     if let Some(agent) = agent {
                                         agent_startup_grace_until =
                                             Some(now + AGENT_STARTUP_GRACE_WINDOW);
@@ -3730,6 +3745,20 @@ mod tests {
             foreground_shell_agent_action(Some(Agent::Claude), None, false, false),
             ForegroundShellAgentAction::ObserveProbe
         );
+    }
+
+    #[tokio::test]
+    async fn first_agent_acquisition_keeps_osc_evidence_replacement_clears_it() {
+        let runtime = PaneRuntime::test_with_screen_bytes(80, 24, b"");
+        runtime.test_process_pty_bytes(b"\x1b]2;startup title\x1b\\\x1b]9;4;1;\x1b\\");
+
+        clear_osc_evidence_for_agent_transition(&runtime.terminal, None);
+        assert_eq!(runtime.agent_osc_title(), "startup title");
+        assert_eq!(runtime.agent_osc_progress(), "4;1;");
+
+        clear_osc_evidence_for_agent_transition(&runtime.terminal, Some(Agent::Claude));
+        assert_eq!(runtime.agent_osc_title(), "");
+        assert_eq!(runtime.agent_osc_progress(), "");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

An agent can emit its OSC title and progress before the foreground-process probe identifies it. The first `None -> Some(agent)` transition currently clears that evidence, so agents that set a title once at startup lose a valid detection signal.

## Approach

Keep retained OSC title and progress on first acquisition. Continue clearing it when changing away from an already identified agent, including replacements and agent switches. Apply the same rule in both detection loops.

## Tests

- Regression test passes with the fix and fails against the previous behavior.
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `just test-one first_agent_acquisition_keeps_osc_evidence_replacement_clears_it`
- `just ci` reached the suite, then failed in three unrelated live handoff/API integration tests because their disposable agent processes were not detected or timed out. The targeted test and lint gates pass.

## Risk

Narrow to the first process-acquisition transition. Evidence still clears whenever the pane was already associated with an agent, so one process cannot pass stale OSC state to its replacement.