### PR TITLE
fix: retain selected text for plugin actions

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1657,6 +1657,20 @@ impl AppState {
         pane_ids: impl IntoIterator<Item = PaneId>,
     ) {
         let pane_ids = pane_ids.into_iter().collect::<Vec<_>>();
+        if self
+            .selection
+            .as_ref()
+            .is_some_and(|selection| pane_ids.contains(&selection.pane_id))
+        {
+            self.clear_selection_highlight();
+        }
+        if self
+            .selection_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| pane_ids.contains(&snapshot.pane_id))
+        {
+            self.selection_snapshot = None;
+        }
         self.clear_copy_mode_for_removed_panes(pane_ids.iter().copied());
         if self
             .previous_pane_focus
@@ -1674,8 +1688,7 @@ impl AppState {
         if self.workspaces.is_empty() {
             return;
         }
-        self.selection = None;
-        self.selection_autoscroll = None;
+        self.clear_selection();
         self.mark_session_dirty();
         let close_indices = self.workspace_close_indices(self.selected);
 
@@ -2052,8 +2065,7 @@ impl AppState {
             }
         }
 
-        self.selection = None;
-        self.selection_autoscroll = None;
+        self.clear_selection();
         self.mark_session_dirty();
         let terminal_ids = active
             .and_then(|i| {
@@ -2099,8 +2111,7 @@ impl AppState {
             }
         }
 
-        self.selection = None;
-        self.selection_autoscroll = None;
+        self.clear_selection();
         self.mark_session_dirty();
         let should_close_workspace = self
             .active
@@ -2147,8 +2158,33 @@ impl AppState {
 
 impl AppState {
     pub fn clear_selection(&mut self) {
+        self.clear_selection_highlight();
+        self.selection_snapshot = None;
+    }
+
+    pub(crate) fn clear_selection_highlight(&mut self) {
         self.selection = None;
         self.selection_autoscroll = None;
+    }
+
+    pub(crate) fn snapshot_selection_text(
+        &mut self,
+        terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
+    ) {
+        let Some(selection) = self.selection.as_ref() else {
+            return;
+        };
+        let pane_id = selection.pane_id;
+        let text = self
+            .active
+            .filter(|ws_idx| self.workspaces.get(*ws_idx).is_some())
+            .and_then(|ws_idx| {
+                self.runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, pane_id)
+            })
+            .and_then(|runtime| runtime.extract_selection(selection))
+            .filter(|text| !text.is_empty());
+        self.selection_snapshot =
+            text.map(|text| crate::app::state::SelectionSnapshot { pane_id, text });
     }
 
     pub(crate) fn stop_selection_autoscroll_state(&mut self) {
@@ -2207,24 +2243,25 @@ impl AppState {
             return false;
         }
 
-        let text = if self.copy_on_select {
-            let Some(text) = rt
-                .extract_selection(&selection)
-                .filter(|text| !text.is_empty())
-            else {
-                self.clear_selection();
-                return false;
-            };
-            Some(text)
-        } else {
-            None
-        };
+        let text = rt
+            .extract_selection(&selection)
+            .filter(|text| !text.is_empty());
+        if self.copy_on_select && text.is_none() {
+            self.clear_selection();
+            return false;
+        }
 
         self.selection = Some(selection);
         self.selection_autoscroll = None;
         if let Some(text) = text {
-            self.request_clipboard_write = Some(text.into_bytes());
-            info!("copied double-clicked token to clipboard");
+            self.selection_snapshot = Some(crate::app::state::SelectionSnapshot {
+                pane_id,
+                text: text.clone(),
+            });
+            if self.copy_on_select {
+                self.request_clipboard_write = Some(text.into_bytes());
+                info!("copied double-clicked token to clipboard");
+            }
         }
         true
     }
@@ -2291,15 +2328,19 @@ impl AppState {
 
         let text = self
             .runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, sel.pane_id)
-            .and_then(|rt| rt.extract_selection(&sel));
+            .and_then(|rt| rt.extract_selection(&sel))
+            .filter(|text| !text.is_empty());
+        self.selection_snapshot = None;
         if let Some(text) = text {
-            if !text.is_empty() {
-                self.request_clipboard_write = Some(text.into_bytes());
-                info!("copied selection to clipboard");
-            }
+            self.request_clipboard_write = Some(text.clone().into_bytes());
+            self.selection_snapshot = Some(crate::app::state::SelectionSnapshot {
+                pane_id: sel.pane_id,
+                text,
+            });
+            info!("copied selection to clipboard");
         }
 
-        self.clear_selection();
+        self.clear_selection_highlight();
     }
 }
 
@@ -3350,15 +3391,6 @@ impl AppState {
             return;
         };
 
-        if self
-            .selection
-            .as_ref()
-            .is_some_and(|s| s.pane_id == pane_id)
-        {
-            self.selection = None;
-            self.selection_autoscroll = None;
-        }
-
         let pane_terminal_id = self.terminal_id_for_pane(ws_idx, pane_id);
         let workspace_terminal_ids = self.terminal_ids_for_workspace(ws_idx);
         self.pane_id_aliases.retain(|_, alias| *alias != pane_id);
@@ -3439,6 +3471,20 @@ mod tests {
             state.mode = Mode::Terminal;
         }
         state
+    }
+
+    #[test]
+    fn removing_pane_clears_its_selection_snapshot() {
+        let mut state = AppState::test_new();
+        let pane_id = PaneId::alloc();
+        state.selection_snapshot = Some(crate::app::state::SelectionSnapshot {
+            pane_id,
+            text: "selected".to_string(),
+        });
+
+        state.remove_plugin_pane_records([pane_id]);
+
+        assert!(state.selection_snapshot.is_none());
     }
 
     fn mark_linked_worktree(state: &mut AppState, ws_idx: usize) {

--- a/src/app/api/plugins/context.rs
+++ b/src/app/api/plugins/context.rs
@@ -381,19 +381,27 @@ impl App {
     }
 
     fn selected_text_for_pane(&self, pane_id: crate::layout::PaneId) -> Option<String> {
-        let selection = self.state.selection.as_ref()?;
-        if selection.pane_id != pane_id || !selection.is_visible() {
-            return None;
-        }
-        let terminal_id = self
-            .state
-            .workspaces
-            .iter()
-            .find_map(|workspace| workspace.terminal_id(pane_id))?;
-        self.terminal_runtimes
-            .get(terminal_id)
-            .and_then(|runtime| runtime.extract_selection(selection))
-            .filter(|text| !text.is_empty())
+        let live_selection = self.state.selection.as_ref().and_then(|selection| {
+            if selection.pane_id != pane_id || !selection.is_visible() {
+                return None;
+            }
+            let terminal_id = self
+                .state
+                .workspaces
+                .iter()
+                .find_map(|workspace| workspace.terminal_id(pane_id))?;
+            self.terminal_runtimes
+                .get(terminal_id)
+                .and_then(|runtime| runtime.extract_selection(selection))
+                .filter(|text| !text.is_empty())
+        });
+        live_selection.or_else(|| {
+            self.state
+                .selection_snapshot
+                .as_ref()
+                .filter(|snapshot| snapshot.pane_id == pane_id)
+                .map(|snapshot| snapshot.text.clone())
+        })
     }
 
     fn default_cwd_for_workspace(&self, ws_idx: usize) -> std::path::PathBuf {

--- a/src/app/api/plugins/mod.rs
+++ b/src/app/api/plugins/mod.rs
@@ -2419,25 +2419,146 @@ command = ["sh", "-c", "printf '%s\n%s\n%s' \"$HERDR_PLUGIN_ROOT\" \"$HERDR_PLUG
     }
 
     #[tokio::test]
-    async fn current_plugin_context_includes_selected_text_for_focused_pane() {
+    async fn current_plugin_context_keeps_mouse_selection_after_auto_copy() {
         let mut app = test_app();
         let workspace = crate::workspace::Workspace::test_new("plugin-selection");
         let pane_id = workspace.tabs[0].root_pane;
         let terminal_id = workspace.terminal_id(pane_id).cloned().unwrap();
+        let pane_infos = workspace.tabs[0]
+            .layout
+            .panes(ratatui::layout::Rect::new(26, 2, 80, 18));
+        let info = pane_infos[0].clone();
         app.state.workspaces = vec![workspace];
         app.state.ensure_test_terminals();
         app.state.active = Some(0);
         app.state.selected = 0;
         app.state.mode = crate::app::Mode::Terminal;
+        app.state.view.pane_infos = pane_infos;
         app.terminal_runtimes.insert(
             terminal_id,
-            crate::terminal::TerminalRuntime::test_with_screen_bytes(80, 24, b"hello plugin\n"),
+            crate::terminal::TerminalRuntime::test_with_screen_bytes(
+                info.inner_rect.width,
+                info.inner_rect.height,
+                b"hello plugin\n",
+            ),
+        );
+        let mouse = |kind, column| crossterm::event::MouseEvent {
+            kind,
+            column,
+            row: info.inner_rect.y,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        app.handle_mouse(mouse(
+            crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            info.inner_rect.x,
+        ));
+        app.handle_mouse(mouse(
+            crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left),
+            info.inner_rect.x + 4,
+        ));
+
+        let context = app.current_plugin_context("selection-drag-test");
+        assert_eq!(context.selected_text.as_deref(), Some("hello"));
+
+        app.handle_mouse(mouse(
+            crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left),
+            info.inner_rect.x + 4,
+        ));
+        assert!(app.state.selection.is_none());
+        let context = app.current_plugin_context("selection-release-test");
+        assert_eq!(context.selected_text.as_deref(), Some("hello"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn prefix_plugin_action_reads_copy_mode_selection_before_exit() {
+        let root = unique_temp_path("plugin-prefix-selection");
+        let output = root.join("context.json");
+        write_manifest_content(
+            &root,
+            &format!(
+                r#"
+id = "example.prefix-selection"
+name = "Prefix selection"
+version = "0.1.0"
+min_herdr_version = "0.8.0"
+platforms = ["linux", "macos"]
+
+[[actions]]
+id = "capture"
+title = "Capture selection"
+contexts = ["selection"]
+command = ["sh", "-c", "printf '%s' \"$HERDR_PLUGIN_CONTEXT_JSON\" > '{}'"]
+"#,
+                output.display()
+            ),
+        );
+        let plugin = load_plugin_manifest(&root.display().to_string(), true).unwrap();
+        let plugin_config_dir = super::env::plugin_config_dir(&plugin.plugin_id);
+        let plugin_state_dir = super::env::plugin_state_dir(&plugin.plugin_id);
+        let mut app = test_app();
+        let workspace = crate::workspace::Workspace::test_new("plugin-prefix-selection");
+        let pane_id = workspace.tabs[0].root_pane;
+        let terminal_id = workspace.terminal_id(pane_id).cloned().unwrap();
+        let pane_infos = workspace.tabs[0]
+            .layout
+            .panes(ratatui::layout::Rect::new(26, 2, 80, 18));
+        let info = pane_infos[0].clone();
+        app.state.workspaces = vec![workspace];
+        app.state.ensure_test_terminals();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = crate::app::Mode::Copy;
+        app.state.view.pane_infos = pane_infos;
+        app.terminal_runtimes.insert(
+            terminal_id,
+            crate::terminal::TerminalRuntime::test_with_screen_bytes(
+                info.inner_rect.width,
+                info.inner_rect.height,
+                b"hello plugin\n",
+            ),
         );
         app.state.selection = Some(crate::selection::Selection::range(pane_id, 0, 0, 4, None));
+        app.state.copy_mode = Some(crate::app::state::CopyModeState {
+            pane_id,
+            cursor_row: 0,
+            cursor_col: 0,
+            entry_offset_from_bottom: 0,
+            selection: None,
+            search: crate::app::state::CopyModeSearchState::default(),
+        });
+        app.state.keybinds.custom_commands = vec![crate::config::CustomCommandKeybind {
+            bindings: crate::config::ActionKeybinds::prefix("m"),
+            label: "capture".to_string(),
+            command: "capture".to_string(),
+            action: crate::config::CustomCommandAction::PluginAction,
+            description: None,
+            width: None,
+            height: None,
+        }];
+        app.state
+            .installed_plugins
+            .insert(plugin.plugin_id.clone(), plugin);
 
-        let context = app.current_plugin_context("selection-test");
+        app.handle_copy_mode_key(crate::input::TerminalKey::new(
+            app.state.prefix_code,
+            app.state.prefix_mods,
+        ));
+        assert_eq!(app.state.mode, crate::app::Mode::Prefix);
+        app.handle_prefix_key(crate::input::TerminalKey::new(
+            crossterm::event::KeyCode::Char('m'),
+            crossterm::event::KeyModifiers::empty(),
+        ));
 
+        let context: PluginInvocationContext =
+            serde_json::from_str(&read_capture_when_ready(&output, || {})).unwrap();
         assert_eq!(context.selected_text.as_deref(), Some("hello"));
+        assert!(app.state.copy_mode.is_none());
+        assert!(app.state.selection_snapshot.is_none());
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(plugin_config_dir);
+        let _ = std::fs::remove_dir_all(plugin_state_dir);
     }
 
     #[cfg(unix)]

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -87,9 +87,14 @@ impl AppState {
             | MouseEventKind::ScrollDown
             | MouseEventKind::ScrollLeft
             | MouseEventKind::ScrollRight => {
+                self.selection_snapshot = None;
                 self.forward_pane_reported_wheel(terminal_runtimes, &info, mouse);
             }
-            MouseEventKind::Down(_) | MouseEventKind::Up(_) | MouseEventKind::Drag(_) => {
+            MouseEventKind::Down(_) => {
+                self.selection_snapshot = None;
+                self.forward_pane_mouse_button(terminal_runtimes, &info, mouse);
+            }
+            MouseEventKind::Up(_) | MouseEventKind::Drag(_) => {
                 self.forward_pane_mouse_button(terminal_runtimes, &info, mouse);
             }
             MouseEventKind::Moved => {
@@ -104,6 +109,15 @@ impl AppState {
         source_id: crate::app::InputSourceId,
         mouse: MouseEvent,
     ) -> Option<MouseAction> {
+        match mouse.kind {
+            MouseEventKind::Down(_) => self.selection_snapshot = None,
+            MouseEventKind::ScrollUp
+            | MouseEventKind::ScrollDown
+            | MouseEventKind::ScrollLeft
+            | MouseEventKind::ScrollRight => self.selection_snapshot = None,
+            _ => {}
+        }
+
         if self.mode == Mode::Onboarding {
             self.handle_onboarding_mouse(mouse);
             return None;
@@ -223,8 +237,7 @@ impl AppState {
 
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
-                self.selection = None;
-                self.selection_autoscroll = None;
+                self.clear_selection();
                 self.clear_chrome_press(source_id);
 
                 if self.mode == Mode::ConfirmClose {
@@ -638,8 +651,7 @@ impl AppState {
                     }
 
                     if self.forward_pane_mouse_button(terminal_runtimes, &info, mouse) {
-                        self.selection = None;
-                        self.selection_autoscroll = None;
+                        self.clear_selection();
                         return self.mouse_pane_focus_action(info.id);
                     }
 
@@ -679,8 +691,7 @@ impl AppState {
                 {
                     if let Some(info) = self.pane_mouse_target(mouse.column, mouse.row).cloned() {
                         if self.forward_pane_mouse_button(terminal_runtimes, &info, mouse) {
-                            self.selection = None;
-                            self.selection_autoscroll = None;
+                            self.clear_selection();
                             return None;
                         }
                     }
@@ -845,8 +856,11 @@ impl AppState {
                         // Double-click already finalized this word selection.
                     } else if self.copy_on_select {
                         self.copy_selection(terminal_runtimes);
-                    } else if let Some(selection) = self.selection.as_mut() {
-                        selection.finish();
+                    } else {
+                        if let Some(selection) = self.selection.as_mut() {
+                            selection.finish();
+                        }
+                        self.snapshot_selection_text(terminal_runtimes);
                     }
                     return None;
                 }
@@ -857,8 +871,7 @@ impl AppState {
                 {
                     if let Some(info) = self.pane_mouse_target(mouse.column, mouse.row).cloned() {
                         if self.forward_pane_mouse_button(terminal_runtimes, &info, mouse) {
-                            self.selection = None;
-                            self.selection_autoscroll = None;
+                            self.clear_selection();
                             return None;
                         }
                     }
@@ -970,8 +983,7 @@ impl AppState {
                 if !in_sidebar && self.scroll_selection_with_wheel(terminal_runtimes, mouse) => {}
 
             MouseEventKind::ScrollUp | MouseEventKind::ScrollDown if !in_sidebar => {
-                self.selection = None;
-                self.selection_autoscroll = None;
+                self.clear_selection();
                 self.handle_terminal_wheel(terminal_runtimes, mouse);
             }
 
@@ -1677,8 +1689,7 @@ impl AppState {
             return false;
         }
 
-        self.selection = None;
-        self.selection_autoscroll = None;
+        self.clear_selection();
         self.clear_chrome_press(source_id);
         self.drag = None;
         self.context_menu = None;

--- a/src/app/input/navigate.rs
+++ b/src/app/input/navigate.rs
@@ -66,6 +66,7 @@ impl App {
         }
 
         if self.state.is_prefix_key(&raw_key) {
+            self.state.selection_snapshot = None;
             if self.state.copy_mode_pane_is_focused() {
                 self.state.cancel_copy_mode(&self.terminal_runtimes);
             }
@@ -76,17 +77,36 @@ impl App {
         }
 
         if key.code == KeyCode::Esc {
+            self.state.selection_snapshot = None;
             leave_command_mode(&mut self.state);
             return;
         }
 
         match prefix_binding_for_key(&self.state, &raw_key) {
-            Some(PrefixBindingMatch::Action(action)) => self.execute_prefix_key_action(action),
-            Some(PrefixBindingMatch::Command(binding)) => {
-                self.cancel_copy_mode_if_active();
-                self.launch_custom_command(binding, ActionContext::Prefix);
+            Some(PrefixBindingMatch::Action(action)) => {
+                self.state.selection_snapshot = None;
+                self.execute_prefix_key_action(action);
             }
-            None => leave_command_mode(&mut self.state),
+            Some(PrefixBindingMatch::Command(binding)) => {
+                let selection_aware =
+                    binding.action == crate::config::CustomCommandAction::PluginAction;
+                if !selection_aware {
+                    self.state.selection_snapshot = None;
+                    self.cancel_copy_mode_if_active();
+                }
+                self.launch_custom_command(binding, ActionContext::Prefix);
+                if selection_aware {
+                    if self.state.copy_mode.is_some() {
+                        self.cancel_copy_mode_if_active();
+                    } else {
+                        self.state.clear_selection();
+                    }
+                }
+            }
+            None => {
+                self.state.selection_snapshot = None;
+                leave_command_mode(&mut self.state);
+            }
         }
     }
 

--- a/src/app/input/terminal.rs
+++ b/src/app/input/terminal.rs
@@ -43,8 +43,12 @@ impl App {
     ) -> Option<TerminalInputTarget> {
         match self.prepare_popup_key_forward(key.clone()) {
             PreparedPopupInput::NotOpen => {}
-            PreparedPopupInput::Consumed => return None,
+            PreparedPopupInput::Consumed => {
+                self.state.selection_snapshot = None;
+                return None;
+            }
             PreparedPopupInput::Bytes { target, bytes } => {
+                self.state.selection_snapshot = None;
                 let Some(runtime) = self.popup_runtime() else {
                     self.close_popup_pane();
                     return None;
@@ -70,13 +74,13 @@ impl App {
             return None;
         }
 
-        self.state.clear_selection();
         self.selection_autoscroll_deadline = None;
         self.state.update_dismissed = true;
 
         if let Some(action) =
             super::terminal_direct_non_indexed_navigation_action(&self.state, &key)
         {
+            self.state.clear_selection();
             debug!(
                 code = ?key_event.code,
                 modifiers = ?key_event.modifiers,
@@ -104,11 +108,20 @@ impl App {
                 command = %binding.label,
                 "intercepted terminal direct custom command before forwarding to pane"
             );
+            let selection_aware =
+                binding.action == crate::config::CustomCommandAction::PluginAction;
+            if !selection_aware {
+                self.state.clear_selection();
+            }
             self.launch_custom_command(binding, super::navigate::ActionContext::Direct);
+            if selection_aware {
+                self.state.clear_selection();
+            }
             return None;
         }
 
         if let Some(action) = super::terminal_direct_indexed_navigation_action(&self.state, &key) {
+            self.state.clear_selection();
             debug!(
                 code = ?key_event.code,
                 modifiers = ?key_event.modifiers,
@@ -121,10 +134,12 @@ impl App {
         }
 
         if self.state.is_prefix_key(&key) {
+            self.state.clear_selection_highlight();
             self.state.mode = Mode::Prefix;
             return None;
         }
 
+        self.state.clear_selection();
         if is_modifier_only_key(&key_event.code) {
             debug!(
                 code = ?key_event.code,
@@ -379,8 +394,12 @@ impl App {
     ) -> Option<TerminalInputTarget> {
         match self.prepare_popup_key_forward(key.clone()) {
             PreparedPopupInput::NotOpen => {}
-            PreparedPopupInput::Consumed => return None,
+            PreparedPopupInput::Consumed => {
+                self.state.selection_snapshot = None;
+                return None;
+            }
             PreparedPopupInput::Bytes { target, bytes } => {
+                self.state.selection_snapshot = None;
                 let Some(runtime) = self.popup_runtime() else {
                     self.close_popup_pane();
                     return None;
@@ -654,6 +673,7 @@ mod tests {
         app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), end_col, row));
 
         assert!(app.state.selection.is_none());
+        assert!(app.state.selection_snapshot.is_some());
     }
 
     #[tokio::test]
@@ -676,6 +696,13 @@ mod tests {
         app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), end_col, row));
         assert!(app.last_pane_click.is_none());
         assert_eq!(clipboard_write_content(&mut app), b"alpha");
+        assert_eq!(
+            app.state
+                .selection_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.text.as_str()),
+            Some("alpha")
+        );
 
         app.handle_mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
@@ -684,7 +711,32 @@ mod tests {
         ));
 
         assert!(app.last_pane_click.is_some());
+        assert!(app.state.selection_snapshot.is_none());
         assert!(app.event_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn right_click_clears_copied_selection_snapshot() {
+        let (mut app, info) = app_with_screen_bytes(b"alpha beta");
+        let row = info.inner_rect.y;
+        let start_col = info.inner_rect.x;
+        let end_col = info.inner_rect.x + 4;
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            start_col,
+            row,
+        ));
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), end_col, row));
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), end_col, row));
+        assert!(app.state.selection_snapshot.is_some());
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            start_col,
+            row,
+        ));
+
+        assert!(app.state.selection_snapshot.is_none());
     }
 
     #[tokio::test]
@@ -734,6 +786,13 @@ mod tests {
             .selection
             .as_ref()
             .is_some_and(crate::selection::Selection::is_finalized));
+        assert_eq!(
+            app.state
+                .selection_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.text.as_str()),
+            Some("alpha")
+        );
         assert!(app.state.selection_autoscroll.is_none());
         assert!(app.selection_autoscroll_deadline.is_none());
         assert!(app.selection_highlight_clear_deadline.is_none());
@@ -1306,6 +1365,13 @@ mod tests {
             .expect("highlight clear deadline");
         assert!(app.handle_scheduled_tasks(deadline + std::time::Duration::from_millis(1), false));
         assert!(app.state.selection.is_none());
+        assert_eq!(
+            app.state
+                .selection_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.text.as_str()),
+            Some("copied")
+        );
     }
 
     #[tokio::test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -625,6 +625,7 @@ impl App {
             workspace_presses: HashMap::new(),
             tab_presses: HashMap::new(),
             selection: None,
+            selection_snapshot: None,
             selection_autoscroll: None,
             context_menu: None,
             update_available,

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -412,7 +412,7 @@ impl App {
             .as_ref()
             .is_some_and(|selection| !selection.is_in_progress())
         {
-            self.state.clear_selection();
+            self.state.clear_selection_highlight();
             return true;
         }
         false

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -26,8 +26,15 @@ pub(crate) struct PopupPaneState {
 }
 
 // ---------------------------------------------------------------------------
-// Selection autoscroll types
+// Selection types
 // ---------------------------------------------------------------------------
+
+/// Stable text for server-side plugin context after the visual selection is cleared.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SelectionSnapshot {
+    pub pane_id: PaneId,
+    pub text: String,
+}
 
 /// Direction of automatic scrolling during text selection drag.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1498,6 +1505,7 @@ pub struct AppState {
         std::collections::HashMap<crate::app::InputSourceId, WorkspacePressState>,
     pub(crate) tab_presses: std::collections::HashMap<crate::app::InputSourceId, TabPressState>,
     pub selection: Option<Selection>,
+    pub(crate) selection_snapshot: Option<SelectionSnapshot>,
     pub selection_autoscroll: Option<SelectionAutoscroll>,
     pub context_menu: Option<ContextMenuState>,
     // Notifications
@@ -1896,6 +1904,7 @@ impl AppState {
             workspace_presses: std::collections::HashMap::new(),
             tab_presses: std::collections::HashMap::new(),
             selection: None,
+            selection_snapshot: None,
             selection_autoscroll: None,
             context_menu: None,
             update_available: None,
@@ -2074,6 +2083,10 @@ impl AppState {
             assert!(
                 self.selection.is_none(),
                 "empty app state must not keep text selection"
+            );
+            assert!(
+                self.selection_snapshot.is_none(),
+                "empty app state must not keep selection snapshot"
             );
             assert!(
                 self.selection_autoscroll.is_none(),
@@ -2256,6 +2269,9 @@ impl AppState {
                 self.selection_autoscroll.is_none(),
                 "selection autoscroll must not remain without an active text selection"
             );
+        }
+        if let Some(snapshot) = &self.selection_snapshot {
+            assert_live_pane(snapshot.pane_id, "selection snapshot");
         }
         if let Some(gesture) = &self.right_click_passthrough {
             assert_live_pane(gesture.pane_info.id, "right-click passthrough gesture");


### PR DESCRIPTION
## summary

- retain selected text for server-side plugin context after copy-on-select clears the highlight
- preserve existing clipboard, highlight, mouse, popup, and key behavior
- capture selection context before plugin-action keybindings clear it, including copy mode

## testing

- `just check`

refs #3353