### PR TITLE
Fix: Plugin context selected_text is empty after mouse release with copy_on

### DIFF
--- a/src/app/api/plugins/context.rs
+++ b/src/app/api/plugins/context.rs
@@ -382,7 +382,7 @@ impl App {
 
     fn selected_text_for_pane(&self, pane_id: crate::layout::PaneId) -> Option<String> {
         let selection = self.state.selection.as_ref()?;
-        if selection.pane_id != pane_id || !selection.is_visible() {
+        if selection.pane_id != pane_id {
             return None;
         }
         let terminal_id = self


### PR DESCRIPTION
This PR addresses #3353.

Plugin context selected_text is empty after mouse release with copy_on_select (default)

Generated with AI assistance and validated against the original
file before submission (syntax check + change-scope check).
Please review carefully — happy to adjust based on feedback.
