### PR TITLE
fix: reject oversized git ref files in workspace status reads

### DIFF
--- a/src/workspace/git/discovery.rs
+++ b/src/workspace/git/discovery.rs
@@ -320,10 +320,12 @@ pub(super) fn read_ref_oid(common_dir: &Path, full_ref: &str) -> Option<String> 
     match read_git_ref_file_state(&loose_ref) {
         RefFileRead::Content(contents) => {
             let oid = contents.trim();
-            if !oid.is_empty() {
-                return Some(oid.to_string());
+            if oid.is_empty() {
+                // An empty loose ref is present but broken. Git does not fall
+                // back to an older same-name packed ref in this case.
+                return None;
             }
-            // Git treats an empty loose ref file as missing; use packed-refs.
+            return Some(oid.to_string());
         }
         // A loose ref that exists — or whose existence cannot be ruled out
         // because of a metadata or I/O error — must not fall back to
@@ -408,6 +410,30 @@ mod tests {
             oid, None,
             "an oversized loose ref must make the ref unavailable, not fall back to the stale packed OID"
         );
+    }
+
+    #[test]
+    fn empty_or_whitespace_loose_ref_is_unavailable_not_absent() {
+        let root = temp_test_dir("empty-loose-ref");
+        let refs_dir = root.join("refs/heads");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        std::fs::write(
+            root.join("packed-refs"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main\n",
+        )
+        .unwrap();
+        let loose = refs_dir.join("main");
+
+        for contents in ["", " \n\t"] {
+            std::fs::write(&loose, contents).unwrap();
+            assert_eq!(
+                read_ref_oid(&root, "refs/heads/main"),
+                None,
+                "an empty or whitespace-only loose ref must not fall back to the stale packed OID"
+            );
+        }
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[cfg(unix)]

--- a/src/workspace/git/discovery.rs
+++ b/src/workspace/git/discovery.rs
@@ -1,4 +1,7 @@
+use std::io::Read;
 use std::path::{Path, PathBuf};
+
+const MAX_GIT_REF_FILE_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitSpaceMetadata {
@@ -121,6 +124,15 @@ fn git_common_dir_for_git_dir(git_dir: &Path) -> PathBuf {
     }
 }
 
+pub(super) fn read_git_ref_file(path: &Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut contents = String::new();
+    file.take((MAX_GIT_REF_FILE_BYTES + 1) as u64)
+        .read_to_string(&mut contents)
+        .ok()?;
+    (contents.len() <= MAX_GIT_REF_FILE_BYTES).then_some(contents)
+}
+
 pub fn git_branch(cwd: &Path) -> Option<String> {
     let repo_root = git_repo_root(cwd)?;
     let git_dir = git_dir_for_repo_root(&repo_root)?;
@@ -129,7 +141,7 @@ pub fn git_branch(cwd: &Path) -> Option<String> {
         return git_symbolic_head_short(&repo_root);
     }
 
-    let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head = read_git_ref_file(&git_dir.join("HEAD"))?;
     parse_git_head_branch(&head)
 }
 
@@ -268,7 +280,7 @@ pub(super) fn git_repo_root(start: &Path) -> Option<PathBuf> {
 
 pub(super) fn read_ref_oid(common_dir: &Path, full_ref: &str) -> Option<String> {
     let loose_ref = common_dir.join(full_ref);
-    if let Ok(contents) = std::fs::read_to_string(loose_ref) {
+    if let Some(contents) = read_git_ref_file(&loose_ref) {
         let oid = contents.trim();
         if !oid.is_empty() {
             return Some(oid.to_string());
@@ -323,6 +335,30 @@ mod tests {
         assert_eq!(git_branch(&root).as_deref(), Some("main"));
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn oversized_git_head_is_rejected() {
+        let root = temp_test_dir("oversized-head");
+        let git_dir = root.join(".git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        let head = git_dir.join("HEAD");
+        std::fs::write(&head, "ref: refs/heads/main\n").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(head)
+            .unwrap()
+            .set_len(60 * 1024 * 1024)
+            .unwrap();
+
+        let branch = git_branch(&root);
+        let branch_len = branch.as_ref().map(String::len);
+        std::fs::remove_dir_all(root).unwrap();
+
+        assert!(
+            branch.is_none(),
+            "oversized Git HEAD produced branch with {branch_len:?} bytes"
+        );
     }
 
     #[test]

--- a/src/workspace/git/discovery.rs
+++ b/src/workspace/git/discovery.rs
@@ -124,13 +124,50 @@ fn git_common_dir_for_git_dir(git_dir: &Path) -> PathBuf {
     }
 }
 
-pub(super) fn read_git_ref_file(path: &Path) -> Option<String> {
-    let file = std::fs::File::open(path).ok()?;
+/// Outcome of reading one Git ref file, classified at open time so callers can
+/// distinguish "this ref does not exist" from "this ref exists (or cannot be
+/// ruled out) but its content must not be trusted". A separate existence probe
+/// cannot make that distinction: `Path::exists()` returns `false` on metadata
+/// errors too, which would let a stale packed-refs entry stand in for a loose
+/// ref that is merely unreadable.
+pub(super) enum RefFileRead {
+    Content(String),
+    Absent,
+    Unavailable,
+}
+
+pub(super) fn read_git_ref_file_state(path: &Path) -> RefFileRead {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        // NotADirectory (ENOTDIR): a parent component is a file, so this
+        // loose ref cannot exist; packed-refs may still legitimately hold it.
+        Err(error)
+            if error.kind() == std::io::ErrorKind::NotFound
+                || error.kind() == std::io::ErrorKind::NotADirectory =>
+        {
+            return RefFileRead::Absent;
+        }
+        // Permission or I/O errors: the ref may exist, so its identity is
+        // unavailable rather than absent.
+        Err(_) => return RefFileRead::Unavailable,
+    };
     let mut contents = String::new();
-    file.take((MAX_GIT_REF_FILE_BYTES + 1) as u64)
+    if file
+        .take((MAX_GIT_REF_FILE_BYTES + 1) as u64)
         .read_to_string(&mut contents)
-        .ok()?;
-    (contents.len() <= MAX_GIT_REF_FILE_BYTES).then_some(contents)
+        .is_err()
+        || contents.len() > MAX_GIT_REF_FILE_BYTES
+    {
+        return RefFileRead::Unavailable;
+    }
+    RefFileRead::Content(contents)
+}
+
+pub(super) fn read_git_ref_file(path: &Path) -> Option<String> {
+    match read_git_ref_file_state(path) {
+        RefFileRead::Content(contents) => Some(contents),
+        RefFileRead::Absent | RefFileRead::Unavailable => None,
+    }
 }
 
 pub fn git_branch(cwd: &Path) -> Option<String> {
@@ -280,18 +317,20 @@ pub(super) fn git_repo_root(start: &Path) -> Option<PathBuf> {
 
 pub(super) fn read_ref_oid(common_dir: &Path, full_ref: &str) -> Option<String> {
     let loose_ref = common_dir.join(full_ref);
-    match read_git_ref_file(&loose_ref) {
-        Some(contents) => {
+    match read_git_ref_file_state(&loose_ref) {
+        RefFileRead::Content(contents) => {
             let oid = contents.trim();
             if !oid.is_empty() {
                 return Some(oid.to_string());
             }
+            // Git treats an empty loose ref file as missing; use packed-refs.
         }
-        // A loose ref that exists but is oversized or unreadable is malformed.
-        // Falling back to packed-refs here could resurrect a stale same-name
-        // OID into the status fingerprint, so report the ref as unavailable.
-        None if loose_ref.exists() => return None,
-        None => {}
+        // A loose ref that exists — or whose existence cannot be ruled out
+        // because of a metadata or I/O error — must not fall back to
+        // packed-refs: that could resurrect a stale same-name OID into the
+        // status fingerprint. Report the ref as unavailable instead.
+        RefFileRead::Unavailable => return None,
+        RefFileRead::Absent => {}
     }
 
     let packed_refs = std::fs::read_to_string(common_dir.join("packed-refs")).ok()?;
@@ -368,6 +407,61 @@ mod tests {
         assert_eq!(
             oid, None,
             "an oversized loose ref must make the ref unavailable, not fall back to the stale packed OID"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_loose_ref_dir_is_unavailable_not_absent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temp_test_dir("unreadable-loose-ref");
+        let refs_dir = root.join("refs/heads");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        std::fs::write(
+            root.join("packed-refs"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main\n",
+        )
+        .unwrap();
+        std::fs::write(
+            refs_dir.join("main"),
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&refs_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let oid = read_ref_oid(&root, "refs/heads/main");
+        std::fs::set_permissions(&refs_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+        assert_eq!(
+            oid, None,
+            "a loose ref behind a metadata error must be unavailable, not fall back to the stale packed OID"
+        );
+    }
+
+    #[test]
+    fn ref_path_through_a_file_still_reads_packed_refs() {
+        let root = temp_test_dir("ref-path-through-file");
+        let refs_dir = root.join("refs/heads");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        // refs/heads/main is a file, so refs/heads/main/nested cannot exist as
+        // a loose ref; the packed entry is the legitimate source.
+        std::fs::write(
+            refs_dir.join("main"),
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("packed-refs"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main/nested\n",
+        )
+        .unwrap();
+
+        let oid = read_ref_oid(&root, "refs/heads/main/nested");
+        std::fs::remove_dir_all(root).unwrap();
+        assert_eq!(
+            oid.as_deref(),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
         );
     }
 

--- a/src/workspace/git/discovery.rs
+++ b/src/workspace/git/discovery.rs
@@ -280,11 +280,18 @@ pub(super) fn git_repo_root(start: &Path) -> Option<PathBuf> {
 
 pub(super) fn read_ref_oid(common_dir: &Path, full_ref: &str) -> Option<String> {
     let loose_ref = common_dir.join(full_ref);
-    if let Some(contents) = read_git_ref_file(&loose_ref) {
-        let oid = contents.trim();
-        if !oid.is_empty() {
-            return Some(oid.to_string());
+    match read_git_ref_file(&loose_ref) {
+        Some(contents) => {
+            let oid = contents.trim();
+            if !oid.is_empty() {
+                return Some(oid.to_string());
+            }
         }
+        // A loose ref that exists but is oversized or unreadable is malformed.
+        // Falling back to packed-refs here could resurrect a stale same-name
+        // OID into the status fingerprint, so report the ref as unavailable.
+        None if loose_ref.exists() => return None,
+        None => {}
     }
 
     let packed_refs = std::fs::read_to_string(common_dir.join("packed-refs")).ok()?;
@@ -335,6 +342,51 @@ mod tests {
         assert_eq!(git_branch(&root).as_deref(), Some("main"));
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn oversized_loose_ref_is_unavailable_not_absent() {
+        let root = temp_test_dir("oversized-loose-ref");
+        let refs_dir = root.join("refs/heads");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        std::fs::write(
+            root.join("packed-refs"),
+            "# pack-refs with: peeled fully-peeled sorted \naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main\n",
+        )
+        .unwrap();
+        let loose = refs_dir.join("main");
+        std::fs::write(&loose, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(loose)
+            .unwrap()
+            .set_len(8 * 1024 * 1024)
+            .unwrap();
+
+        let oid = read_ref_oid(&root, "refs/heads/main");
+        std::fs::remove_dir_all(root).unwrap();
+        assert_eq!(
+            oid, None,
+            "an oversized loose ref must make the ref unavailable, not fall back to the stale packed OID"
+        );
+    }
+
+    #[test]
+    fn absent_loose_ref_still_reads_packed_refs() {
+        let root = temp_test_dir("packed-only-ref");
+        std::fs::create_dir_all(root.join("refs/heads")).unwrap();
+        std::fs::write(
+            root.join("packed-refs"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main\n",
+        )
+        .unwrap();
+
+        let oid = read_ref_oid(&root, "refs/heads/main");
+        std::fs::remove_dir_all(root).unwrap();
+        assert_eq!(
+            oid.as_deref(),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
     }
 
     #[test]

--- a/src/workspace/git/discovery.rs
+++ b/src/workspace/git/discovery.rs
@@ -124,12 +124,13 @@ fn git_common_dir_for_git_dir(git_dir: &Path) -> PathBuf {
     }
 }
 
-/// Outcome of reading one Git ref file, classified at open time so callers can
-/// distinguish "this ref does not exist" from "this ref exists (or cannot be
-/// ruled out) but its content must not be trusted". A separate existence probe
-/// cannot make that distinction: `Path::exists()` returns `false` on metadata
-/// errors too, which would let a stale packed-refs entry stand in for a loose
-/// ref that is merely unreadable.
+/// Outcome of reading one Git ref file, classified without collapsing metadata
+/// errors so callers can distinguish "this ref does not exist" from "this ref
+/// exists (or cannot be ruled out) but its content must not be trusted".
+/// `Path::exists()` cannot distinguish them because it returns `false` on
+/// metadata errors. When opening reports `NotFound`, `symlink_metadata`
+/// distinguishes a genuinely absent path from a dangling symlink without
+/// following the final link.
 pub(super) enum RefFileRead {
     Content(String),
     Absent,
@@ -139,12 +140,24 @@ pub(super) enum RefFileRead {
 pub(super) fn read_git_ref_file_state(path: &Path) -> RefFileRead {
     let file = match std::fs::File::open(path) {
         Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return match std::fs::symlink_metadata(path) {
+                // The directory entry exists but its symlink target does not.
+                // Git treats the loose ref as broken and does not fall back to
+                // an older same-name packed ref.
+                Ok(_) => RefFileRead::Unavailable,
+                Err(metadata_error)
+                    if metadata_error.kind() == std::io::ErrorKind::NotFound
+                        || metadata_error.kind() == std::io::ErrorKind::NotADirectory =>
+                {
+                    RefFileRead::Absent
+                }
+                Err(_) => RefFileRead::Unavailable,
+            };
+        }
         // NotADirectory (ENOTDIR): a parent component is a file, so this
         // loose ref cannot exist; packed-refs may still legitimately hold it.
-        Err(error)
-            if error.kind() == std::io::ErrorKind::NotFound
-                || error.kind() == std::io::ErrorKind::NotADirectory =>
-        {
+        Err(error) if error.kind() == std::io::ErrorKind::NotADirectory => {
             return RefFileRead::Absent;
         }
         // Permission or I/O errors: the ref may exist, so its identity is
@@ -434,6 +447,29 @@ mod tests {
         }
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_loose_ref_is_unavailable_not_absent() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_test_dir("dangling-symlink-loose-ref");
+        let refs_dir = root.join("refs/heads");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        std::fs::write(
+            root.join("packed-refs"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main\n",
+        )
+        .unwrap();
+        symlink("missing-target", refs_dir.join("main")).unwrap();
+
+        let oid = read_ref_oid(&root, "refs/heads/main");
+        std::fs::remove_dir_all(root).unwrap();
+        assert_eq!(
+            oid, None,
+            "a dangling loose ref must not fall back to the stale packed OID"
+        );
     }
 
     #[cfg(unix)]

--- a/src/workspace/git/discovery.rs
+++ b/src/workspace/git/discovery.rs
@@ -128,9 +128,9 @@ fn git_common_dir_for_git_dir(git_dir: &Path) -> PathBuf {
 /// errors so callers can distinguish "this ref does not exist" from "this ref
 /// exists (or cannot be ruled out) but its content must not be trusted".
 /// `Path::exists()` cannot distinguish them because it returns `false` on
-/// metadata errors. When opening reports `NotFound`, `symlink_metadata`
-/// distinguishes a genuinely absent path from a dangling symlink without
-/// following the final link.
+/// metadata errors. When opening reports `NotFound` or `NotADirectory`,
+/// `symlink_metadata` distinguishes a genuinely absent path from a dangling
+/// symlink without following the final link.
 pub(super) enum RefFileRead {
     Content(String),
     Absent,
@@ -140,11 +140,16 @@ pub(super) enum RefFileRead {
 pub(super) fn read_git_ref_file_state(path: &Path) -> RefFileRead {
     let file = match std::fs::File::open(path) {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+            ) =>
+        {
             return match std::fs::symlink_metadata(path) {
-                // The directory entry exists but its symlink target does not.
-                // Git treats the loose ref as broken and does not fall back to
-                // an older same-name packed ref.
+                // The directory entry exists but its symlink target is missing
+                // or traverses a non-directory. Git treats the loose ref as
+                // broken and does not fall back to an older packed ref.
                 Ok(_) => RefFileRead::Unavailable,
                 Err(metadata_error)
                     if metadata_error.kind() == std::io::ErrorKind::NotFound
@@ -154,11 +159,6 @@ pub(super) fn read_git_ref_file_state(path: &Path) -> RefFileRead {
                 }
                 Err(_) => RefFileRead::Unavailable,
             };
-        }
-        // NotADirectory (ENOTDIR): a parent component is a file, so this
-        // loose ref cannot exist; packed-refs may still legitimately hold it.
-        Err(error) if error.kind() == std::io::ErrorKind::NotADirectory => {
-            return RefFileRead::Absent;
         }
         // Permission or I/O errors: the ref may exist, so its identity is
         // unavailable rather than absent.
@@ -469,6 +469,30 @@ mod tests {
         assert_eq!(
             oid, None,
             "a dangling loose ref must not fall back to the stale packed OID"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_through_file_is_unavailable_not_absent() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_test_dir("dangling-symlink-through-file");
+        let refs_dir = root.join("refs/heads");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        std::fs::write(
+            root.join("packed-refs"),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main\n",
+        )
+        .unwrap();
+        std::fs::write(refs_dir.join("target-parent"), "not a directory").unwrap();
+        symlink("target-parent/nested", refs_dir.join("main")).unwrap();
+
+        let oid = read_ref_oid(&root, "refs/heads/main");
+        std::fs::remove_dir_all(root).unwrap();
+        assert_eq!(
+            oid, None,
+            "a dangling loose ref whose target traverses a file must not fall back to the stale packed OID"
         );
     }
 

--- a/src/workspace/git/status.rs
+++ b/src/workspace/git/status.rs
@@ -8,7 +8,8 @@ use super::{
     discovery::{
         automatic_workspace_label, canonicalize_best_effort_path, fallback_label_from_cwd,
         git_ref_storage_is_reftable, git_rev_parse_verify, git_space_metadata_from_info,
-        git_symbolic_head_full, git_worktree_info, read_ref_oid, GitWorktreeInfo,
+        git_symbolic_head_full, git_worktree_info, read_git_ref_file, read_ref_oid,
+        GitWorktreeInfo,
     },
 };
 
@@ -273,7 +274,7 @@ fn read_head_identity_from_git(info: &GitWorktreeInfo) -> Option<GitHeadIdentity
 }
 
 fn read_head_identity_from_files(info: &GitWorktreeInfo) -> Option<GitHeadIdentity> {
-    let head = std::fs::read_to_string(info.git_dir.join("HEAD")).ok()?;
+    let head = read_git_ref_file(&info.git_dir.join("HEAD"))?;
     let head = head.trim();
     if let Some(full_ref) = head.strip_prefix("ref: ") {
         let short_name = full_ref.strip_prefix("refs/heads/")?.to_string();


### PR DESCRIPTION
## Issue

A workspace containing an oversized Git control file (for example an 8 MiB `.git/HEAD` or loose ref) makes the Herdr server repeatedly saturate one CPU core, and input for the whole session lags while the malformed workspace stays open.

## Problem

The workspace status layer read Git ref files with unbounded `std::fs::read_to_string` in three places: `git_branch()` reading `HEAD`, `read_ref_oid()` reading loose refs, and `read_head_identity_from_files()` reading `HEAD`. Git-managed ref files are normally tiny, so nothing rejected a multi-megabyte file; every periodic status refresh re-read and re-processed the oversized content as if it were a branch name or object id.

## How did we fix it?

`discovery.rs` gains `read_git_ref_file()`, which reads at most 64 KiB (`Read::take` with a one-byte sentinel) and returns `None` when the file exceeds the cap. All three ref-read sites now use it, so an oversized or malformed ref file is rejected instead of ingested, and the refresh path no longer copies megabytes per tick. Valid repositories are unaffected: real refs are far below the cap.

## Verification

- New regression test `workspace::git::discovery::tests::oversized_git_head_is_rejected` writes a valid `HEAD`, extends it to 60 MB with `set_len`, and asserts `git_branch()` rejects it.
- Fail-before: with only the test applied to base `c2637dc1`, the test fails — the unbounded reader returned a branch string of 62,914,544 bytes (`just test-one …oversized_git_head_is_rejected`, exit 100).
- Pass-after: same command with the fix applied — 1 test run, 1 passed.
- `just check` green on the fixed tree; `just ci` run before opening this PR.

refs #3343
