### PR TITLE
fix: secure sockets via parent directory when filesystem cannot chmod them

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -17,14 +17,13 @@ use crate::api::subscriptions::ActiveSubscription;
 use crate::api::wait::{prompt_agent, wait_for_agent, wait_for_event, wait_for_output};
 use crate::api::{request_changes_ui, socket_path, ApiRequestMessage, ApiRequestSender, EventHub};
 use crate::ipc::{
-    bind_local_listener, is_connection_closed_error, local_stream_peer_closed,
+    bind_private_local_listener, is_connection_closed_error, local_stream_peer_closed,
     poll_local_stream_read, remove_socket_file_if_owned, set_local_stream_polling,
     socket_file_identity, LocalStream, LocalStreamRead, SocketFileIdentity,
 };
 
 mod pane_graphics_stream;
 
-const SOCKET_PERMISSION_MODE: u32 = 0o600;
 pub(super) const CONNECTION_POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub(super) const APP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 const INITIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -88,8 +87,7 @@ fn start_server_inner(
     let path = socket_path();
     prepare_socket_path(&path)?;
 
-    let listener = bind_local_listener(&path)?;
-    restrict_socket_permissions(&path)?;
+    let listener = bind_private_local_listener(&path)?;
     let identity = socket_file_identity(&path)?;
     info!(path = %path.display(), "api server listening");
 
@@ -141,10 +139,6 @@ fn prepare_socket_path(path: &Path) -> std::io::Result<()> {
             path.display()
         )
     })
-}
-
-fn restrict_socket_permissions(path: &Path) -> std::io::Result<()> {
-    crate::ipc::restrict_socket_permissions(path, SOCKET_PERMISSION_MODE)
 }
 
 #[cfg(test)]
@@ -902,7 +896,6 @@ mod tests {
     use std::collections::HashMap;
     use std::io::{BufRead, BufReader};
     use std::os::unix::fs::PermissionsExt;
-    use std::os::unix::net::UnixListener;
     use std::sync::{Mutex, OnceLock};
     use tokio::sync::mpsc;
 
@@ -1047,18 +1040,16 @@ mod tests {
     }
 
     #[test]
-    fn restrict_socket_permissions_sets_user_only_mode() {
+    fn private_listener_sets_user_only_mode() {
         let dir = unique_test_path("socket-perms");
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("api.sock");
-        let _listener = UnixListener::bind(&path).unwrap();
-
-        restrict_socket_permissions(&path).unwrap();
+        let listener = bind_private_local_listener(&path).unwrap();
 
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, SOCKET_PERMISSION_MODE);
+        assert_eq!(mode, 0o600);
 
-        drop(_listener);
+        drop(listener);
         let _ = fs::remove_file(&path);
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::io::{self, Read};
 #[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
 #[cfg(unix)]
@@ -51,16 +51,11 @@ pub(crate) fn connect_local_stream(path: &Path) -> io::Result<LocalStream> {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn bind_local_listener(path: &Path) -> io::Result<LocalListener> {
     #[cfg(unix)]
     {
-        use interprocess::local_socket::{prelude::*, GenericFilePath, ListenerOptions};
-
-        let name = path.to_fs_name::<GenericFilePath>()?;
-        ListenerOptions::new()
-            .name(name)
-            .reclaim_name(false)
-            .create_sync()
+        crate::platform::bind_local_listener_for_test(path)
     }
 
     #[cfg(windows)]
@@ -138,12 +133,12 @@ pub(crate) fn shutdown_local_stream_write(stream: &LocalStream) -> io::Result<()
     }
 }
 
-/// Binds a listener for private terminal traffic. Unix callers restrict the
-/// socket file after binding; Windows must set the named-pipe DACL at creation.
+/// Binds a listener for private local traffic and applies the platform's
+/// access boundary before returning it to a caller.
 pub(crate) fn bind_private_local_listener(path: &Path) -> io::Result<LocalListener> {
     #[cfg(unix)]
     {
-        bind_local_listener(path)
+        crate::platform::bind_private_local_listener(path)
     }
 
     #[cfg(windows)]
@@ -165,6 +160,17 @@ pub(crate) fn bind_private_local_listener(path: &Path) -> io::Result<LocalListen
             .create_sync()?;
         fs::write(path, windows_socket_marker())?;
         Ok(listener)
+    }
+}
+
+/// Binds a private filesystem Unix listener and exposes the standard-library
+/// listener needed by descriptor-passing protocols.
+#[cfg(unix)]
+pub(crate) fn bind_private_unix_listener(
+    path: &Path,
+) -> io::Result<std::os::unix::net::UnixListener> {
+    match bind_private_local_listener(path)? {
+        LocalListener::UdSocket(listener) => Ok(listener.into()),
     }
 }
 
@@ -330,18 +336,6 @@ fn windows_socket_marker() -> String {
         .map(|duration| duration.as_nanos())
         .unwrap_or(0);
     format!("{}:{now}", std::process::id())
-}
-
-#[cfg(unix)]
-pub(crate) fn restrict_socket_permissions(path: &Path, mode: u32) -> io::Result<()> {
-    let mut permissions = fs::metadata(path)?.permissions();
-    permissions.set_mode(mode);
-    fs::set_permissions(path, permissions)
-}
-
-#[cfg(windows)]
-pub(crate) fn restrict_socket_permissions(_path: &Path, _mode: u32) -> io::Result<()> {
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -198,8 +198,10 @@ pub(crate) struct RemoteSshConfigPaths {
 
 #[cfg(unix)]
 mod unix_common;
+#[cfg(all(unix, test))]
+pub(crate) use unix_common::bind_local_listener_for_test;
 #[cfg(unix)]
-pub(crate) use unix_common::{begin_cli_output, end_cli_output};
+pub(crate) use unix_common::{begin_cli_output, bind_private_local_listener, end_cli_output};
 
 #[cfg(not(unix))]
 pub(crate) fn begin_cli_output() {}

--- a/src/platform/unix_common.rs
+++ b/src/platform/unix_common.rs
@@ -1,4 +1,84 @@
+use std::fs;
+use std::io;
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+
+use interprocess::local_socket::{prelude::*, GenericFilePath, Listener, ListenerOptions};
+use interprocess::os::unix::local_socket::ListenerOptionsExt as _;
+
+/// Socket file mode for Herdr's private listeners (owner read/write only).
+const SOCKET_PERMISSION_MODE: u32 = 0o600;
+
+/// Binds a listener for private local traffic with owner-only permissions.
+///
+/// The mode is applied to the socket descriptor before `bind()`, so the socket's
+/// pathname is never `chmod()`ed and filesystems that reject permission changes
+/// on socket inodes are never asked to. Platforms whose kernel cannot set a
+/// socket's mode before bind keep the previous bind-then-restrict behavior.
+pub(crate) fn bind_private_local_listener(path: &Path) -> io::Result<Listener> {
+    bind_private_socket_with(path, bind_local_listener, restrict_socket_permissions)
+}
+
+fn bind_local_listener(path: &Path, mode: Option<u32>) -> io::Result<Listener> {
+    let name = path.to_fs_name::<GenericFilePath>()?;
+    let options = ListenerOptions::new().name(name).reclaim_name(false);
+    match mode {
+        Some(mode) => options.mode(mode as libc::mode_t).create_sync(),
+        None => options.create_sync(),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn bind_local_listener_for_test(path: &Path) -> io::Result<Listener> {
+    bind_local_listener(path, None)
+}
+
+fn bind_private_socket_with<T>(
+    path: &Path,
+    mut bind: impl FnMut(&Path, Option<u32>) -> io::Result<T>,
+    restrict: impl FnOnce(&Path) -> io::Result<()>,
+) -> io::Result<T> {
+    match bind(path, Some(SOCKET_PERMISSION_MODE)) {
+        Ok(bound) => Ok(bound),
+        // The platform cannot set a socket's mode before bind. Restrict the
+        // bound socket instead, exactly as Herdr did before creation-time modes.
+        Err(err) if err.kind() == io::ErrorKind::Unsupported => {
+            let bound = bind(path, None)?;
+            let bound_socket = socket_identity(path);
+            if let Err(err) = restrict(path) {
+                // The socket is published but unrestricted. Listeners are
+                // created with name reclamation disabled, so unbind it and take
+                // the pathname down instead of leaving it for the next start.
+                drop(bound);
+                remove_socket_if_unchanged(path, bound_socket);
+                return Err(err);
+            }
+            Ok(bound)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn restrict_socket_permissions(path: &Path) -> io::Result<()> {
+    fs::set_permissions(path, fs::Permissions::from_mode(SOCKET_PERMISSION_MODE))
+}
+
+/// Identifies the socket at `path`, or `None` when it is absent or not a socket.
+fn socket_identity(path: &Path) -> Option<(u64, u64)> {
+    let metadata = fs::symlink_metadata(path).ok()?;
+    metadata
+        .file_type()
+        .is_socket()
+        .then(|| (metadata.dev(), metadata.ino()))
+}
+
+/// Unlinks `path` only while it still holds the socket Herdr bound there, so a
+/// pathname another process substituted is left alone.
+fn remove_socket_if_unchanged(path: &Path, bound: Option<(u64, u64)>) {
+    if bound.is_some() && socket_identity(path) == bound {
+        let _ = fs::remove_file(path);
+    }
+}
 
 fn set_sigpipe_disposition(handler: libc::sighandler_t) {
     let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
@@ -238,6 +318,19 @@ pub(crate) fn set_default_plugin_pane_pwd(env: &mut Vec<(String, String)>, cwd: 
 mod tests {
     use super::*;
 
+    fn temp_test_dir(label: &str) -> PathBuf {
+        let path = Path::new("/tmp").join(format!(
+            "herdr-platform-socket-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
     #[test]
     fn plugin_pane_pwd_defaults_to_cwd_without_overriding_explicit_env() {
         let cwd = Path::new("/plugin-cwd");
@@ -254,5 +347,139 @@ mod tests {
     fn remote_ssh_config_dir_rejects_overlong_control_socket_name() {
         let err = create_remote_ssh_config_dir(&"x".repeat(200)).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn private_local_listener_restricts_socket_to_owner() {
+        let parent = temp_test_dir("owner-only");
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o755)).unwrap();
+        let socket = parent.join("herdr.sock");
+
+        let listener = bind_private_local_listener(&socket).unwrap();
+
+        assert_eq!(
+            fs::metadata(&socket).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            fs::metadata(&parent).unwrap().permissions().mode() & 0o777,
+            0o755,
+            "binding a private socket must not alter its parent directory"
+        );
+
+        drop(listener);
+        fs::remove_dir_all(&parent).unwrap();
+    }
+
+    #[test]
+    fn private_socket_restricts_after_bind_when_creation_mode_is_unsupported() {
+        let parent = temp_test_dir("post-bind");
+        let socket = parent.join("herdr.sock");
+        let mut attempts = Vec::new();
+
+        let listener = bind_private_socket_with(
+            &socket,
+            |path, requested_mode| {
+                attempts.push(requested_mode);
+                if requested_mode.is_some() {
+                    return Err(io::Error::from(io::ErrorKind::Unsupported));
+                }
+                std::os::unix::net::UnixListener::bind(path)
+            },
+            restrict_socket_permissions,
+        )
+        .unwrap();
+
+        assert_eq!(attempts, [Some(0o600), None]);
+        assert_eq!(
+            fs::metadata(&socket).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        drop(listener);
+        fs::remove_dir_all(&parent).unwrap();
+    }
+
+    #[test]
+    fn private_socket_keeps_other_creation_errors_fatal() {
+        let parent = temp_test_dir("fatal");
+        let socket = parent.join("herdr.sock");
+        let mut attempts = Vec::new();
+
+        let err = bind_private_socket_with(
+            &socket,
+            |_path, requested_mode| {
+                attempts.push(requested_mode);
+                Err::<std::os::unix::net::UnixListener, _>(io::Error::from(
+                    io::ErrorKind::PermissionDenied,
+                ))
+            },
+            restrict_socket_permissions,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(attempts, [Some(0o600)]);
+        assert!(!socket.exists());
+        fs::remove_dir_all(&parent).unwrap();
+    }
+
+    #[test]
+    fn private_socket_is_removed_when_post_bind_restriction_fails() {
+        let parent = temp_test_dir("restrict-failure");
+        let socket = parent.join("herdr.sock");
+
+        let err = bind_private_socket_with(
+            &socket,
+            |path, requested_mode| {
+                if requested_mode.is_some() {
+                    return Err(io::Error::from(io::ErrorKind::Unsupported));
+                }
+                std::os::unix::net::UnixListener::bind(path)
+            },
+            |_path| Err(io::Error::from(io::ErrorKind::PermissionDenied)),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(
+            !socket.exists(),
+            "an unrestricted socket must not stay published"
+        );
+        fs::remove_dir_all(&parent).unwrap();
+    }
+
+    #[test]
+    fn restriction_failure_leaves_a_replaced_pathname_alone() {
+        let parent = temp_test_dir("restrict-replacement");
+        let socket = parent.join("herdr.sock");
+        let replacement = parent.join("replacement.sock");
+
+        let err = bind_private_socket_with(
+            &socket,
+            |path, requested_mode| {
+                if requested_mode.is_some() {
+                    return Err(io::Error::from(io::ErrorKind::Unsupported));
+                }
+                std::os::unix::net::UnixListener::bind(path)
+            },
+            |path| {
+                // Stand in for another process swapping the pathname between
+                // bind and the failing restriction. Dropping the listener does
+                // not unlink its pathname.
+                std::os::unix::net::UnixListener::bind(&replacement)?;
+                fs::remove_file(path)?;
+                fs::rename(&replacement, path)?;
+                Err(io::Error::from(io::ErrorKind::PermissionDenied))
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(
+            socket.exists(),
+            "a pathname Herdr no longer owns must not be unlinked"
+        );
+        fs::remove_dir_all(&parent).unwrap();
     }
 }

--- a/src/remote/attach.rs
+++ b/src/remote/attach.rs
@@ -23,7 +23,6 @@ use std::time::{Duration, Instant};
 const BRIDGE_ACCEPT_POLL: Duration = Duration::from_millis(50);
 #[cfg(windows)]
 const BRIDGE_IO_POLL: Duration = Duration::from_millis(1);
-const BRIDGE_SOCKET_PERMISSION_MODE: u32 = 0o600;
 const REMOTE_SERVER_SHUTDOWN_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
 const REMOTE_SERVER_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const CURRENT_PROTOCOL: u32 = crate::protocol::PROTOCOL_VERSION;
@@ -1678,12 +1677,6 @@ impl SshStdioBridge {
         })?;
         let listener = crate::ipc::bind_private_local_listener(&local_socket)?;
         let socket_identity = crate::ipc::socket_file_identity(&local_socket)?;
-        if let Err(err) =
-            crate::ipc::restrict_socket_permissions(&local_socket, BRIDGE_SOCKET_PERMISSION_MODE)
-        {
-            let _ = crate::ipc::remove_socket_file_if_owned(&local_socket, &socket_identity);
-            return Err(err);
-        }
         if let Err(err) = listener.set_nonblocking(ListenerNonblockingMode::Accept) {
             let _ = crate::ipc::remove_socket_file_if_owned(&local_socket, &socket_identity);
             return Err(err);
@@ -2212,7 +2205,7 @@ mod tests {
         .expect("start bridge listener");
 
         let mode = std::fs::metadata(&socket).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, BRIDGE_SOCKET_PERMISSION_MODE);
+        assert_eq!(mode, 0o600);
 
         drop(bridge);
         let _ = std::fs::remove_file(socket);
@@ -2327,10 +2320,7 @@ mod tests {
         }
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(
-            mode, BRIDGE_SOCKET_PERMISSION_MODE,
-            "keepalive config must be user-only"
-        );
+        assert_eq!(mode, 0o600, "keepalive config must be user-only");
         // The config lives in a private 0700 dir, not a predictable temp path.
         let dir = path.parent().expect("config has a parent dir");
         let dir_mode = std::fs::metadata(dir).unwrap().permissions().mode() & 0o777;

--- a/src/server/handoff.rs
+++ b/src/server/handoff.rs
@@ -134,9 +134,8 @@ pub(crate) fn cleanup_failed_import_child(child: &mut Child) {
 #[cfg(unix)]
 pub(crate) fn bind_listener(socket_path: &Path) -> io::Result<UnixListener> {
     let _ = std::fs::remove_file(socket_path);
-    let listener = UnixListener::bind(socket_path)?;
+    let listener = crate::ipc::bind_private_unix_listener(socket_path)?;
     listener.set_nonblocking(true)?;
-    restrict_socket_permissions(socket_path)?;
     Ok(listener)
 }
 
@@ -321,13 +320,6 @@ pub(crate) fn manifest_for(
         panes,
         api_window_title,
     }
-}
-
-#[cfg(unix)]
-fn restrict_socket_permissions(path: &Path) -> io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
 }
 
 #[cfg(unix)]
@@ -520,5 +512,25 @@ mod tests {
             serde_json::from_value(value).expect("an older manifest should still load");
 
         assert!(older.api_window_title.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn handoff_listener_uses_private_socket_binding() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = std::env::temp_dir().join(format!("herdr-handoff-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir(&dir).unwrap();
+        let socket = dir.join("handoff.sock");
+
+        let listener = bind_listener(&socket).unwrap();
+        assert_eq!(
+            std::fs::metadata(&socket).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        drop(listener);
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -39,8 +39,7 @@ use crate::app;
 use crate::config;
 use crate::events::AppEvent;
 use crate::ipc::{
-    bind_local_listener, remove_socket_file_if_owned, socket_file_identity, LocalListener,
-    SocketFileIdentity,
+    remove_socket_file_if_owned, socket_file_identity, LocalListener, SocketFileIdentity,
 };
 use crate::protocol::{
     self, AttachScrollDirection, AttachScrollSource, FrameData, ServerMessage, MAX_FRAME_SIZE,
@@ -58,9 +57,7 @@ use crate::server::keybindings::{app_keybindings, apply_keybindings};
 use crate::server::notifications::{
     should_forward_toast_to_clients, toast_message_from_state_change, toast_notify_kind,
 };
-use crate::server::socket_paths::{
-    client_socket_path, prepare_socket_path, restrict_socket_permissions,
-};
+use crate::server::socket_paths::{client_socket_path, prepare_socket_path};
 use crate::server::terminal_attach::paste_payload_for_runtime;
 
 mod pane_graphics;
@@ -484,8 +481,7 @@ impl HeadlessServer {
         let client_path = client_socket_path();
         prepare_socket_path(&client_path)?;
 
-        let listener = bind_local_listener(&client_path)?;
-        restrict_socket_permissions(&client_path)?;
+        let listener = crate::ipc::bind_private_local_listener(&client_path)?;
         let client_socket_identity = socket_file_identity(&client_path)?;
         info!(path = %client_path.display(), "client protocol socket listening");
 
@@ -1482,8 +1478,7 @@ impl HeadlessServer {
 
         let client_path = client_socket_path();
         prepare_socket_path(&client_path)?;
-        let listener = bind_local_listener(&client_path)?;
-        restrict_socket_permissions(&client_path)?;
+        let listener = crate::ipc::bind_private_local_listener(&client_path)?;
         let client_socket_identity = socket_file_identity(&client_path)?;
         listener.set_nonblocking(ListenerNonblockingMode::Accept)?;
 
@@ -5372,7 +5367,7 @@ mod tests {
         let _ = fs::create_dir_all(&dir);
         let socket_path = dir.join("client.sock");
         let _ = fs::remove_file(&socket_path);
-        let listener = bind_local_listener(&socket_path).expect("bind test listener");
+        let listener = crate::ipc::bind_local_listener(&socket_path).expect("bind test listener");
         let client_socket_identity =
             socket_file_identity(&socket_path).expect("test listener socket identity");
         #[cfg(unix)]

--- a/src/server/socket_paths.rs
+++ b/src/server/socket_paths.rs
@@ -8,9 +8,6 @@ use std::path::{Path, PathBuf};
 /// client-only override when `HERDR_SOCKET_PATH` is not set.
 pub const CLIENT_SOCKET_PATH_ENV_VAR: &str = "HERDR_CLIENT_SOCKET_PATH";
 
-/// Socket permission mode (owner read/write only).
-const SOCKET_PERMISSION_MODE: u32 = 0o600;
-
 /// Returns the path for the client protocol socket.
 ///
 /// Contract-aligned override behavior:
@@ -67,11 +64,6 @@ pub(crate) fn prepare_socket_path(path: &Path) -> io::Result<()> {
             path.display()
         )
     })
-}
-
-/// Restricts socket file permissions to owner-only (0o600).
-pub(crate) fn restrict_socket_permissions(path: &Path) -> io::Result<()> {
-    crate::ipc::restrict_socket_permissions(path, SOCKET_PERMISSION_MODE)
 }
 
 #[cfg(all(test, unix))]


### PR DESCRIPTION
## Issue

`herdr server` exits with `InvalidInput` when the Herdr config directory is on a filesystem that cannot change permissions on Unix-socket inodes, such as virtiofs. The bind succeeds; startup fails afterwards, while applying `0600` to the socket's pathname:

```
fchmodat(AT_FDCWD, "~/.config/herdr/herdr.sock", 0600) = -1 EINVAL (Invalid argument)
```

`HERDR_SOCKET_PATH` is not a complete workaround, because named-session and handoff sockets live in the config tree.

## How did we fix it?

Stop applying permissions to the socket's pathname. The mode is now applied to the socket **descriptor before `bind()`**, so the affected filesystems are never asked to chmod a socket inode at all — on Linux the mode carries into the node `bind()` creates.

Platforms whose kernel cannot set a socket's mode before bind report `Unsupported`; those fall back to the previous bind-then-restrict behavior, unchanged.

The API, client-protocol, handoff, and remote-bridge listeners now share one private binder instead of four copies of `bind` + `restrict_socket_permissions`.

## Scope

Deliberately minimal. This changes how the `0600` mode is applied and nothing else:

- No parent directory is opened, inspected, or modified.
- Socket paths, socket modes, and directory modes are unchanged on every platform.
- No new environment requirements: `HERDR_SOCKET_PATH` pointing into a shared directory keeps working exactly as before.
- No test-infrastructure changes.

## Verification

- New coverage pins the contract on every Unix: the socket is `0600`, the parent directory is never modified, the `Unsupported` path restricts after bind, and any other permission error stays fatal.
- Confirmed on macOS (where the kernel rejects `fchmod` on a socket, so the fallback path is the one taken) that startup, socket modes, and directory modes match `master`.
- `just check` passes.

refs #3212
