### PR TITLE
fix: detect claude mcp elicitation dialogs as blocked

### DIFF
--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -747,6 +747,30 @@ fn claude_blocker_screen_outranks_osc_idle_title() {
 }
 
 #[test]
+fn claude_mcp_elicitation_is_blocked() {
+    // Regression for issue #3283: an MCP elicitation dialog has Accept/Decline
+    // controls and an "Esc to cancel" footer but no Enter hint, so no blocked
+    // rule matched and the static OSC title reported idle.
+    // Live capture uses curly quotes around the server name; the issue report
+    // transcribed straight quotes. Both must classify as blocked.
+    for screen in [
+        "MCP server \u{201c}my-server\u{201d} requests your input\n\nGrant temporary access to the demo gateway for 15 minutes?\n\n\u{276f} Accept    Decline\n\nEsc to cancel \u{b7} \u{2191}/\u{2193} to navigate\n",
+        "MCP server \"my-server\" requests your input\n\nserver-supplied message\n\n\u{276f} Accept    Decline\n\nEsc to cancel \u{b7} \u{2191}/\u{2193} to navigate\n",
+    ] {
+        let result = with_manifest_dirs("claude-mcp-elicitation", || {
+            osc_explain(Agent::Claude, screen, "\u{2733} Claude Code", "")
+        });
+        assert_eq!(result.state, AgentState::Blocked, "{result:#?}");
+        assert!(result.visible_blocker, "{result:#?}");
+        assert_eq!(
+            result.matched_rule.as_ref().map(|r| r.id.as_str()),
+            Some("mcp_elicitation_prompt"),
+            "{result:#?}"
+        );
+    }
+}
+
+#[test]
 fn claude_empty_osc_empty_screen_is_idle_fallback() {
     // No OSC data, no matching screen rule → fallback idle (unchanged V3 behavior)
     let result = osc_explain(Agent::Claude, "", "", "");

--- a/src/detect/manifests/claude.toml
+++ b/src/detect/manifests/claude.toml
@@ -1,7 +1,7 @@
 id = "claude"
-version = "2026.08.21.1"
+version = "2026.08.29.1"
 min_engine_version = 2
-updated_at = "2026-08-21T00:00:00Z"
+updated_at = "2026-08-29T00:00:00Z"
 aliases = ["claude-code"]
 
 [[rules]]
@@ -109,6 +109,25 @@ priority = 980
 region = "whole_recent"
 visible_blocker = true
 contains = ["run a dynamic workflow?", "esc to cancel"]
+
+[[rules]]
+id = "mcp_elicitation_prompt"
+state = "blocked"
+priority = 980
+region = "whole_recent"
+visible_blocker = true
+# MCP elicitation dialogs (elicitation/create) show Accept/Decline controls
+# with an "Esc to cancel" footer but no Enter hint, so live_blocked_form
+# cannot see them (issue #3283). Gate on the invariant header line, the
+# Accept/Decline control line, and the cancel footer.
+contains = ["esc to cancel"]
+line_regex = ['(?i)^\s*MCP server ["\x{201C}].+["\x{201D}] requests your input\s*$']
+all = [
+  { any = [
+    { line_regex = ['^\s*\x{276F}?\s*Accept\b'] },
+    { line_regex = ['^\s*\x{276F}?\s*Decline\b'] },
+  ] },
+]
 
 [[rules]]
 id = "live_prompt_box"

--- a/website/agent-detection/claude.toml
+++ b/website/agent-detection/claude.toml
@@ -1,7 +1,7 @@
 id = "claude"
-version = "2026.08.21.1"
+version = "2026.08.29.1"
 min_engine_version = 2
-updated_at = "2026-08-21T00:00:00Z"
+updated_at = "2026-08-29T00:00:00Z"
 aliases = ["claude-code"]
 
 [[rules]]
@@ -109,6 +109,25 @@ priority = 980
 region = "whole_recent"
 visible_blocker = true
 contains = ["run a dynamic workflow?", "esc to cancel"]
+
+[[rules]]
+id = "mcp_elicitation_prompt"
+state = "blocked"
+priority = 980
+region = "whole_recent"
+visible_blocker = true
+# MCP elicitation dialogs (elicitation/create) show Accept/Decline controls
+# with an "Esc to cancel" footer but no Enter hint, so live_blocked_form
+# cannot see them (issue #3283). Gate on the invariant header line, the
+# Accept/Decline control line, and the cancel footer.
+contains = ["esc to cancel"]
+line_regex = ['(?i)^\s*MCP server ["\x{201C}].+["\x{201D}] requests your input\s*$']
+all = [
+  { any = [
+    { line_regex = ['^\s*\x{276F}?\s*Accept\b'] },
+    { line_regex = ['^\s*\x{276F}?\s*Decline\b'] },
+  ] },
+]
 
 [[rules]]
 id = "live_prompt_box"


### PR DESCRIPTION
## Issue

A Claude Code pane showing an MCP elicitation dialog (`elicitation/create`) reports `idle`. The Agents sidebar shows it as parked, no notification fires, and `herdr agent wait --until blocked` does not return while the dialog waits for input.

refs #3283

## Problem

The elicitation dialog renders Accept/Decline controls with an `Esc to cancel · ↑/↓ to navigate` footer but no `Enter to confirm`/`Enter to select` hint, so `live_blocked_form` cannot match it. No other blocked rule covers this form, so lower-priority idle evidence wins. Live capture shows two wrong states, not just the reported one: while Claude's spinner line is visible during the pending tool call, `live_turn_working` (970) reports `working`; once it settles, `live_prompt_box` (950) or `osc_title_idle` (250, as in the report) reports `idle`.

One detail the report transcribed away: the live dialog header uses typographic quotes (`MCP server “my-server” requests your input`, U+201C/U+201D), not straight quotes.

## How did we fix it?

Added an `mcp_elicitation_prompt` blocked rule (priority 980, `whole_recent`) to the Claude manifest, gated on three invariant visible controls: the header line (accepting both straight and typographic quotes), the `❯ Accept / Decline` control line, and the `esc to cancel` footer. Priority 980 outranks both wrong-state rules. Bundled and website manifest copies updated together, version `2026.08.29.1`.

## Verification

- Characterization test `claude_mcp_elicitation_is_blocked` covers both the live-captured curly-quote screen and the reported straight-quote screen, and asserts the new rule is the match. Fails on the base manifest (`Idle` via `osc_title_idle`), passes with the fix.
- Live evidence loop per the repo's detection policy: drove a real elicitation dialog (throwaway named session + minimal stdio MCP server using `elicitation/create`). Stock manifest: `idle`. With the fix hot-reloaded: `state: blocked`, `matched_rule: mcp_elicitation_prompt`, `visible_blocker: true`, and `herdr agent wait --until blocked` returns.
- Verified independently twice (two separate agent sessions ran their own live loops and reached identical results).
- 108/108 `detect::` tests, manifest parity/schema checks, fmt + clippy, and full `just ci 'not binary(live_handoff)'` green (the `live_handoff` exclusions reproduce on untouched master on this host and are unrelated).
