### PR TITLE
fix: keep codex detection manifest compatible with pre-engine-3 clients

### DIFF
--- a/scripts/test_agent_detection_manifest_check.py
+++ b/scripts/test_agent_detection_manifest_check.py
@@ -151,6 +151,10 @@ class AgentDetectionManifestCheckTests(unittest.TestCase):
             with self.assertRaisesRegex(check.CheckError, "exceeds engine"):
                 check.load_manifest_dir(bundled, engine_version=1)
 
+    def test_codex_manifests_use_engine_two_compatible_regions(self):
+        check.validate_manifest(check.DEFAULT_BUNDLED_DIR / "codex.toml", engine_version=2)
+        check.validate_manifest(check.DEFAULT_WEBSITE_DIR / "codex.toml", engine_version=2)
+
     def test_rejects_top_non_empty_lines_below_engine_three(self):
         with tempfile.TemporaryDirectory() as tmp:
             bundled = Path(tmp) / "bundled"

--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -795,7 +795,7 @@ fn codex_osc_title_plain_is_idle() {
 }
 
 #[test]
-fn codex_trust_directory_requires_live_top_region() {
+fn codex_trust_directory_requires_live_screen_prefix() {
     let screen = "> You are in C:\\Users\\user\\project\n\n\
         Do you trust the contents of this\n\
         directory? Working with untrusted\n\
@@ -812,6 +812,13 @@ fn codex_trust_directory_requires_live_top_region() {
     assert_eq!(
         result.matched_rule.as_ref().map(|rule| rule.id.as_str()),
         Some("trust_directory")
+    );
+    assert_eq!(
+        result
+            .matched_rule
+            .as_ref()
+            .map(|rule| rule.region.as_str()),
+        Some("whole_recent")
     );
     assert!(result.visible_blocker);
 

--- a/src/detect/manifests/codex.toml
+++ b/src/detect/manifests/codex.toml
@@ -1,7 +1,7 @@
 id = "codex"
-version = "2026.08.28.1"
-min_engine_version = 3
-updated_at = "2026-08-28T00:00:00Z"
+version = "2026.08.29.1"
+min_engine_version = 2
+updated_at = "2026-08-29T00:00:00Z"
 
 [[rules]]
 id = "osc_title_blocked"
@@ -35,7 +35,7 @@ any = [
 id = "trust_directory"
 state = "blocked"
 priority = 950
-region = "top_non_empty_lines(20)"
+region = "whole_recent"
 visible_blocker = true
 all = [
   { regex = ['\A> You are in [^\r\n]+(?:\r?\n|$)'] },

--- a/website/agent-detection/codex.toml
+++ b/website/agent-detection/codex.toml
@@ -1,7 +1,7 @@
 id = "codex"
-version = "2026.08.28.1"
-min_engine_version = 3
-updated_at = "2026-08-28T00:00:00Z"
+version = "2026.08.29.1"
+min_engine_version = 2
+updated_at = "2026-08-29T00:00:00Z"
 
 [[rules]]
 id = "osc_title_blocked"
@@ -35,7 +35,7 @@ any = [
 id = "trust_directory"
 state = "blocked"
 priority = 950
-region = "top_non_empty_lines(20)"
+region = "whole_recent"
 visible_blocker = true
 all = [
   { regex = ['\A> You are in [^\r\n]+(?:\r?\n|$)'] },


### PR DESCRIPTION
## Problem

Since 2026-08-28, every herdr client that predates the engine-3 detection grammar fails its remote manifest update for codex with:

```
WARN herdr::detect::manifest_update: agent detection manifest update failed for agent="codex" error=rule trust_directory uses invalid region: top_non_empty_lines(20)
```

Observed on a long-lived Termux build (Android aarch64): **835 occurrences** in `~/.config/herdr/herdr-server.log` between `2026-08-28T06:13Z` and `2026-08-28T10:43Z` (until the binary was updated locally). Net effect on such clients: the codex remote manifest update voids, codex detection is unavailable, and the manifest never heals until the client binary is upgraded. Other agent kinds on the same client keep working — a single bad manifest publish disables a whole agent kind on older clients.

## Root cause

Manifest `codex.toml` v`2026.08.28.1` set `min_engine_version = 3` and used `region = "top_non_empty_lines(20)"` in the `trust_directory` rule. Pre-engine-3 clients (where `MANIFEST_ENGINE_VERSION < 3`) reject the region as invalid **at manifest-load time**, before the `min_engine_version` gate can skip it, so the whole manifest fails to load rather than being treated as not-applicable.

## Fix

Publish the codex manifest in a form pre-engine-3 clients can load:

- `trust_directory` region: `top_non_empty_lines(20)` → `whole_recent` (already used by this manifest's other rules), keeping both regex gates unchanged (including the `\A> You are in ...` live-screen anchor, so transcript text still can't false-match).
- `min_engine_version`: 3 → 2.
- `version` bump to `2026.08.29.1`, `updated_at` bump.

Both copies updated (`src/detect/manifests/codex.toml` and `website/agent-detection/codex.toml` — they remain byte-identical; `website/agent-detection/index.toml` pins `codex.toml`).

## Tests

- `scripts/test_agent_detection_manifest_check.py`: new `test_codex_manifests_use_engine_two_compatible_regions` asserts both codex copies validate at engine version 2. All 11 tests pass.
- `src/detect/manifest/tests.rs`: `codex_trust_directory_requires_live_top_region` → renamed `codex_trust_directory_requires_live_screen_prefix`, now also asserts the matched region is `whole_recent`; the transcript-false-match negative case retained.

`cargo build`/`cargo test` could not run on the aarch64-linux-android (Termux) host used to prepare this PR (`build.rs` rejects the target for a **libghostty-vt** — unrelated to the changed files, which are data + tests; `cargo fmt --check` passes and the Python manifest-check suite passes).

## Verification against installed 0.8.2

With the patched manifest in an isolated XDG config dir:

- `herdr agent explain --file <trust-prompt-screen> --agent codex --format json` → `state: blocked`, matched `trust_directory` via `whole_recent`, no warnings, `remote_update_status: current`.

## Observations (not part of this PR)

Two things I noticed while reproducing, in case they're useful to maintainers:

1. On herdr 0.8.2 (aarch64-linux-android), `agent explain` against the **v2026.08.28.1** remote manifest now succeeds (trust-prompt screen → blocked), yet `herdr agent start --kind codex` still times out with the TUI fully ready: the agent stays `launch_pending`/`agent_status: unknown` with `state_change_seq: 0` — no server-side detection event ever records for codex. pi/hermes register fine in the same setup. Possibly related to OSC evidence handling rather than the manifest itself.
2. The screen_working_fallback rule's `bottom_non_empty_lines(3)` parses on pre-engine-3 clients while `top_non_empty_lines(N)` does not — worth confirming intentional.

Happy to add a DCO sign-off if required, or follow up with pi/hermes detection traces from the same host.