### PR TITLE
fix: report the foreground group leader's cwd, not a descendant's

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -3013,12 +3013,12 @@ impl PaneRuntime {
                 .or_else(|| crate::platform::foreground_process_group_id(pid));
             let leader_cwd = foreground_pgid.and_then(absolute_process_cwd);
 
-            if leader_cwd.as_ref() == shell_cwd.as_ref() {
-                foreground_member_cwd_different_from_shell(pid, shell_cwd.as_ref()).or(leader_cwd)
-            } else {
-                leader_cwd
-                    .or_else(|| foreground_member_cwd_different_from_shell(pid, shell_cwd.as_ref()))
-            }
+            // The group leader's cwd is authoritative (issue #3270): a helper
+            // process that chdirs elsewhere inside the same foreground group
+            // must not override it. Scan other members only when the leader's
+            // cwd cannot be read at all.
+            leader_cwd
+                .or_else(|| foreground_member_cwd_different_from_shell(pid, shell_cwd.as_ref()))
         }
 
         #[cfg(not(unix))]

--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -969,9 +969,11 @@ fn new_terminal_cwd_follow_ignores_nonleader_group_member_cwd() {
         ),
     );
     assert_eq!(pane["result"]["pane"]["cwd"], base.display().to_string());
+    // Regression for issue #3270: the foreground group leader's cwd is
+    // authoritative; the backgrounded helper's chdir must not override it.
     assert_eq!(
         pane["result"]["pane"]["foreground_cwd"],
-        helper_cwd.display().to_string()
+        base.display().to_string()
     );
 
     let split = send_request(


### PR DESCRIPTION
## Issue

When a pane's foreground process group spans more than one directory, `foreground_cwd` reports a descendant's cwd rather than the group leader's, so `cwd` and `foreground_cwd` disagree and API clients/plugins act in the wrong directory. This is the common case for coding-agent panes, whose MCP servers and language servers sit in the same foreground group after chdiring elsewhere.

refs #3270

## Problem

`PaneRuntime::foreground_cwd()` reads the PTY foreground pgid and the leader's cwd correctly, but when the leader's cwd equals the shell's cwd it prefers `foreground_member_cwd_different_from_shell()` — the first group member whose cwd differs from the shell's, with no requirement that the member is the leader. A backgrounded helper that chdir'd elsewhere therefore overrides a perfectly valid leader cwd. The heuristic dates to the original foreground-cwd feature (issue #345); `follow_cwd()` was later fixed to leader-only for #1472, but the API path kept the member scan, and the Linux integration test asserted the helper's directory.

## How did we fix it?

The group leader's cwd is now authoritative: `foreground_cwd()` returns it whenever it is readable, and falls back to the member scan only when the leader's cwd cannot be read at all (keeping graceful degradation on platforms where per-process cwd reads can fail). The regression test `new_terminal_cwd_follow_ignores_nonleader_group_member_cwd` now asserts the leader's directory for `foreground_cwd` as well.

## Verification

- Updated Linux integration test on the unfixed base fails exactly as reported (`foreground_cwd` returns the helper's directory, exit 100); with the fix it passes (verified on Ubuntu 24.04, glibc 2.39).
- Live reproduction of the issue's exact script on macOS: stable 0.8.2 reports `cwd=…/a`, `foreground_cwd=…/b` with the fully formed four-process group captured via `pane process-info`; the fixed build reports `…/a` for both, with the group re-verified as formed at read time (ruling out the issue's noted early-read race).
- Full local `just ci 'not binary(live_handoff)'` green (the excluded `live_handoff` tests are pre-existing failures on this host, unrelated to the change).
