### PR TITLE
fix: keep live agents registered through false process-exit observations

### DIFF
--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -73,7 +73,7 @@ pub fn normalize_session_start_source(value: Option<String>) -> Option<String> {
     match value.as_deref().map(str::trim) {
         Some(
             source @ ("startup" | "resume" | "clear" | "compact" | "branch" | "new" | "fork"
-            | "select"),
+            | "select" | "reload"),
         ) => Some(source.to_string()),
         _ => None,
     }
@@ -636,6 +636,10 @@ mod tests {
         assert_eq!(
             normalize_session_start_source(Some("select".into())),
             Some("select".into())
+        );
+        assert_eq!(
+            normalize_session_start_source(Some("reload".into())),
+            Some("reload".into())
         );
         assert_eq!(
             normalize_session_start_source(Some(" resume ".into())),

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -2046,6 +2046,111 @@ mod tests {
     }
 
     #[test]
+    fn reload_after_a_false_process_exit_republishes_agent_registration() {
+        // refs #3225: a false exit releases a live agent, and the reload that the
+        // agent sends next must reach event subscribers as a re-registration, not
+        // only restore the label for direct `agent list` polling. The sequence
+        // mirrors what the pi integration emits on reload: session report first,
+        // then the state report.
+        let event_hub = crate::api::EventHub::default();
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            &crate::config::Config::default(),
+            true,
+            None,
+            api_rx,
+            event_hub.clone(),
+        );
+        let workspace = crate::workspace::Workspace::test_new("false-exit-reload");
+        let pane_id = workspace.tabs[0].root_pane;
+        let terminal_id = workspace.terminal_id(pane_id).cloned().unwrap();
+        app.state.workspaces = vec![workspace];
+        app.state.ensure_test_terminals();
+        let observed_at = std::time::Instant::now();
+        let session_ref = crate::agent_resume::AgentSessionRef::id("issue-3225-pi").unwrap();
+        let terminal = app.state.terminals.get_mut(&terminal_id).unwrap();
+        terminal.set_detected_state(Some(Agent::Pi), AgentState::Idle);
+        terminal
+            .set_agent_session_ref_for_session_start(
+                "herdr:pi".into(),
+                "pi".into(),
+                Some(session_ref.clone()),
+                Some(20),
+                Some("new".into()),
+            )
+            .unwrap();
+        terminal
+            .set_hook_authority_at(
+                "herdr:pi".into(),
+                "pi".into(),
+                AgentState::Working,
+                None,
+                Some(session_ref.clone()),
+                Some(21),
+                observed_at,
+            )
+            .unwrap();
+
+        app.handle_internal_event(AppEvent::StateChanged {
+            pane_id,
+            agent: Some(Agent::Pi),
+            state: AgentState::Idle,
+            visible_blocker: false,
+            visible_working: false,
+            process_exited: true,
+            observed_at: observed_at + std::time::Duration::from_secs(1),
+        });
+
+        let released = event_hub.events_after(0);
+        assert!(released.iter().any(|(_, event)| matches!(
+            event.data,
+            crate::api::schema::EventData::PaneAgentDetected { released: true, .. }
+        )));
+        let after_release = released.last().map(|(sequence, _)| *sequence).unwrap_or(0);
+
+        app.handle_internal_event(AppEvent::AgentSessionReported {
+            pane_id,
+            source: "herdr:pi".into(),
+            agent_label: "pi".into(),
+            seq: Some(22),
+            session_ref: Some(session_ref.clone()),
+            session_start_source: crate::agent_resume::normalize_session_start_source(Some(
+                "reload".into(),
+            )),
+        });
+
+        assert!(
+            event_hub
+                .events_after(after_release)
+                .iter()
+                .any(|(_, event)| matches!(
+                    &event.data,
+                    crate::api::schema::EventData::PaneAgentDetected {
+                        agent: Some(agent),
+                        released: false,
+                        ..
+                    } if agent == "pi"
+                )),
+            "subscribers told the agent was released must be told it came back"
+        );
+
+        app.handle_internal_event(AppEvent::HookStateReported {
+            pane_id,
+            source: "herdr:pi".into(),
+            agent_label: "pi".into(),
+            state: AgentState::Working,
+            message: None,
+            seq: Some(23),
+            session_ref: Some(session_ref),
+        });
+
+        let terminal = &app.state.terminals[&terminal_id];
+        assert!(terminal.is_agent_terminal());
+        assert_eq!(terminal.state, AgentState::Working);
+        assert!(terminal.full_lifecycle_hook_authority_active());
+    }
+
+    #[test]
     fn overlay_exit_layout_updated_uses_restored_zoom_state() {
         let event_hub = crate::api::EventHub::default();
         let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -4062,6 +4062,10 @@ mod tests {
                 pending_foreground_shell_clear: true,
                 ..quiet
             },
+            ProcessProbeInput {
+                pending_shell_exit_confirmation: true,
+                ..quiet
+            },
         ] {
             assert!(observe(false, false, std::time::Duration::ZERO, immediate));
         }
@@ -4145,6 +4149,81 @@ mod tests {
             pending_restore_probe: true,
             ..process_probe_input()
         }));
+    }
+
+    #[test]
+    fn pending_shell_exit_confirmation_forces_a_fast_recheck() {
+        // refs #3225: a pending confirmation must be resolved by the next ~300ms
+        // probe. If it fell back to PROCESS_RECHECK_IDENTIFIED or was skipped
+        // under lifecycle authority, a genuine exit would be reported seconds late.
+        let pending = ProcessProbeInput {
+            current_agent: Some(Agent::Pi),
+            pending_shell_exit_confirmation: true,
+            elapsed_since_process_check: std::time::Duration::ZERO,
+            ..process_probe_input()
+        };
+        let settled = ProcessProbeInput {
+            pending_shell_exit_confirmation: false,
+            ..pending
+        };
+
+        assert!(should_probe_foreground_job(pending));
+        assert!(!should_probe_foreground_job(settled));
+        assert!(!should_skip_process_probe_for_lifecycle_authority(
+            true, pending
+        ));
+        assert!(should_skip_process_probe_for_lifecycle_authority(
+            true,
+            ProcessProbeInput {
+                elapsed_since_process_check: PROCESS_RECHECK_IDENTIFIED,
+                ..settled
+            }
+        ));
+    }
+
+    #[test]
+    fn shell_exit_confirmation_costs_at_most_one_extra_probe_tick() {
+        // refs #3225: the streak resolves on the next observation, so the forced
+        // recheck above cannot persist across ticks or scale with pane count.
+        let mut presence = AgentDetectionPresence::from_agent(Some(Agent::Pi));
+        let mut pending_clear = false;
+        let mut exit_reported = false;
+        let mut streak = 0u8;
+
+        let first =
+            foreground_shell_agent_action(Some(Agent::Pi), None, true, exit_reported, streak);
+        assert_eq!(first, ForegroundShellAgentAction::ConfirmShellObservation);
+        apply_foreground_shell_agent_action(
+            &mut presence,
+            first,
+            Some(Agent::Pi),
+            None,
+            &mut pending_clear,
+            &mut exit_reported,
+            &mut streak,
+        );
+        assert_eq!(streak, 1);
+
+        let second =
+            foreground_shell_agent_action(Some(Agent::Pi), None, true, exit_reported, streak);
+        assert_eq!(second, ForegroundShellAgentAction::ReportProcessExit);
+        apply_foreground_shell_agent_action(
+            &mut presence,
+            second,
+            Some(Agent::Pi),
+            None,
+            &mut pending_clear,
+            &mut exit_reported,
+            &mut streak,
+        );
+        assert_eq!(
+            streak, 0,
+            "the confirmation must stop forcing probes once it resolves"
+        );
+        assert!(
+            pending_clear,
+            "the exit still hands off to the existing pending-clear probe"
+        );
     }
 
     #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -289,6 +289,12 @@ async fn apply_agent_detection_publish_update(
 }
 
 const AGENT_MISS_CONFIRMATION_ATTEMPTS: u8 = 6;
+/// Consecutive pane-shell foreground observations required before a
+/// previously detected agent is reported as exited. One observation can be a
+/// transient probe glitch (a sampled process snapshot briefly missing the
+/// agent), and a false exit releases a still-live agent's registration
+/// (refs #3225).
+const FOREGROUND_SHELL_EXIT_CONFIRMATION_OBSERVATIONS: u8 = 2;
 const PROCESS_RECHECK_IDENTIFIED: std::time::Duration = std::time::Duration::from_secs(5);
 const PROCESS_RECHECK_MISSING_FOREGROUND_GROUP: std::time::Duration =
     std::time::Duration::from_secs(30);
@@ -340,6 +346,9 @@ enum ForegroundShellAgentAction {
     ReportProcessExit,
     ReportReplacementProcess,
     ClearAgent,
+    /// The pane shell was observed in the foreground, but not often enough in
+    /// a row to publish a process exit yet.
+    ConfirmShellObservation,
 }
 
 fn foreground_shell_agent_action(
@@ -347,6 +356,7 @@ fn foreground_shell_agent_action(
     new_agent: Option<Agent>,
     foreground_is_pane_shell: bool,
     process_exit_reported: bool,
+    shell_observation_streak: u8,
 ) -> ForegroundShellAgentAction {
     let Some(previous_agent) = previous_agent else {
         return ForegroundShellAgentAction::ObserveProbe;
@@ -365,6 +375,11 @@ fn foreground_shell_agent_action(
     }
 
     if foreground_is_pane_shell {
+        if shell_observation_streak.saturating_add(1)
+            < FOREGROUND_SHELL_EXIT_CONFIRMATION_OBSERVATIONS
+        {
+            return ForegroundShellAgentAction::ConfirmShellObservation;
+        }
         // Do not clear identity immediately. First publish an idle process-exit
         // transition for the previous agent so notifications and wait-agent callers
         // observe completion before the pane becomes unknown.
@@ -390,7 +405,11 @@ fn apply_foreground_shell_agent_action(
     new_agent: Option<Agent>,
     pending_foreground_shell_clear: &mut bool,
     foreground_shell_exit_reported: &mut bool,
+    shell_observation_streak: &mut u8,
 ) -> bool {
+    if action != ForegroundShellAgentAction::ConfirmShellObservation {
+        *shell_observation_streak = 0;
+    }
     match action {
         ForegroundShellAgentAction::ReportReplacementProcess => {
             *pending_foreground_shell_clear = false;
@@ -412,6 +431,10 @@ fn apply_foreground_shell_agent_action(
             *foreground_shell_exit_reported = false;
             agent_presence.observe_process_probe(new_agent)
         }
+        ForegroundShellAgentAction::ConfirmShellObservation => {
+            *shell_observation_streak = shell_observation_streak.saturating_add(1);
+            false
+        }
     }
 }
 
@@ -424,6 +447,7 @@ struct ProcessProbeInput {
     has_process_probe: bool,
     acquisition_age: Option<std::time::Duration>,
     pending_foreground_shell_clear: bool,
+    pending_shell_exit_confirmation: bool,
     pending_restore_probe: bool,
     elapsed_since_process_check: std::time::Duration,
 }
@@ -453,6 +477,7 @@ fn should_skip_process_probe_for_lifecycle_authority(
     full_lifecycle_authority_active
         && input.foreground_pgid.is_some()
         && !input.pending_foreground_shell_clear
+        && !input.pending_shell_exit_confirmation
         && input.suppressed_agent.is_none()
         && input.has_process_probe
         && !foreground_group_changed(input.foreground_pgid, input.last_foreground_pgid)
@@ -469,6 +494,7 @@ fn should_observe_foreground_process_group(
         || input.current_agent.is_none()
         || input.suppressed_agent.is_some()
         || input.pending_foreground_shell_clear
+        || input.pending_shell_exit_confirmation
         || input.pending_restore_probe
         || content_changed
         || (lifecycle_authority && elapsed >= PROCESS_RECHECK_IDENTIFIED)
@@ -476,7 +502,10 @@ fn should_observe_foreground_process_group(
 }
 
 fn should_probe_foreground_job(input: ProcessProbeInput) -> bool {
-    if input.pending_foreground_shell_clear || input.pending_restore_probe {
+    if input.pending_foreground_shell_clear
+        || input.pending_shell_exit_confirmation
+        || input.pending_restore_probe
+    {
         return true;
     }
 
@@ -717,6 +746,7 @@ fn spawn_basic_detection_task(
         let mut last_content_change_at = None;
         let mut pending_foreground_shell_clear = false;
         let mut foreground_shell_exit_reported = false;
+        let mut foreground_shell_observation_streak: u8 = 0;
         let mut release_was_active = false;
         let mut last_detection_text = String::new();
         let mut last_screen_scan_detection_content_seq = None;
@@ -745,6 +775,7 @@ fn spawn_basic_detection_task(
                     last_content_change_at = None;
                     pending_foreground_shell_clear = false;
                     foreground_shell_exit_reported = false;
+                    foreground_shell_observation_streak = 0;
                     release_was_active = false;
                     last_detection_text.clear();
                     last_screen_scan_detection_content_seq = None;
@@ -781,6 +812,7 @@ fn spawn_basic_detection_task(
                     acquisition_age: acquisition_started_at
                         .map(|started| now.duration_since(started)),
                     pending_foreground_shell_clear,
+                    pending_shell_exit_confirmation: foreground_shell_observation_streak > 0,
                     pending_restore_probe: false,
                     elapsed_since_process_check: now.duration_since(last_process_check),
                 };
@@ -813,6 +845,7 @@ fn spawn_basic_detection_task(
                     new_agent,
                     foreground_is_pane_shell,
                     foreground_shell_exit_reported,
+                    foreground_shell_observation_streak,
                 );
                 let changed = apply_foreground_shell_agent_action(
                     &mut agent_presence,
@@ -821,6 +854,7 @@ fn spawn_basic_detection_task(
                     new_agent,
                     &mut pending_foreground_shell_clear,
                     &mut foreground_shell_exit_reported,
+                    &mut foreground_shell_observation_streak,
                 );
                 last_foreground_pgid = tracked_process_group_id;
                 if new_agent.is_some() {
@@ -2200,6 +2234,7 @@ impl PaneRuntime {
                 let mut last_content_change_at = None;
                 let mut pending_foreground_shell_clear = false;
                 let mut foreground_shell_exit_reported = false;
+                let mut foreground_shell_observation_streak: u8 = 0;
                 let mut release_was_active = false;
                 let mut pending_restore_probe = initial_state.detected_agent.is_some();
                 let mut last_visible_blocker = false;
@@ -2238,6 +2273,7 @@ impl PaneRuntime {
                             last_content_change_at = None;
                             pending_foreground_shell_clear = false;
                             foreground_shell_exit_reported = false;
+                            foreground_shell_observation_streak = 0;
                             release_was_active = false;
                             pending_restore_probe = false;
                             last_visible_blocker = false;
@@ -2271,6 +2307,7 @@ impl PaneRuntime {
                         acquisition_age: acquisition_started_at
                             .map(|started| now.duration_since(started)),
                         pending_foreground_shell_clear,
+                        pending_shell_exit_confirmation: foreground_shell_observation_streak > 0,
                         pending_restore_probe,
                         elapsed_since_process_check: now.duration_since(last_process_check),
                     };
@@ -2345,6 +2382,7 @@ impl PaneRuntime {
                                 new_agent,
                                 foreground_is_pane_shell,
                                 foreground_shell_exit_reported,
+                                foreground_shell_observation_streak,
                             );
                             let changed = apply_foreground_shell_agent_action(
                                 &mut agent_presence,
@@ -2353,6 +2391,7 @@ impl PaneRuntime {
                                 new_agent,
                                 &mut pending_foreground_shell_clear,
                                 &mut foreground_shell_exit_reported,
+                                &mut foreground_shell_observation_streak,
                             );
                             last_foreground_pgid = tracked_process_group_id;
                             if new_agent.is_some() {
@@ -3722,19 +3761,61 @@ mod tests {
     #[test]
     fn foreground_shell_reports_process_exit_before_clearing_agent() {
         assert_eq!(
-            foreground_shell_agent_action(Some(Agent::Codex), None, true, false),
+            foreground_shell_agent_action(Some(Agent::Codex), None, true, false, 1),
             ForegroundShellAgentAction::ReportProcessExit
         );
         assert_eq!(
-            foreground_shell_agent_action(Some(Agent::Codex), None, true, true),
+            foreground_shell_agent_action(Some(Agent::Codex), None, true, true, 1),
             ForegroundShellAgentAction::ClearAgent
         );
     }
 
     #[test]
+    fn first_shell_observation_requires_confirmation_before_process_exit() {
+        // refs #3225: a single sampled snapshot without the agent must not
+        // release a live agent's registration.
+        assert_eq!(
+            foreground_shell_agent_action(Some(Agent::Pi), None, true, false, 0),
+            ForegroundShellAgentAction::ConfirmShellObservation
+        );
+        let mut presence = AgentDetectionPresence::from_agent(Some(Agent::Pi));
+        let mut pending_clear = false;
+        let mut exit_reported = false;
+        let mut streak = 0u8;
+        let changed = apply_foreground_shell_agent_action(
+            &mut presence,
+            ForegroundShellAgentAction::ConfirmShellObservation,
+            Some(Agent::Pi),
+            None,
+            &mut pending_clear,
+            &mut exit_reported,
+            &mut streak,
+        );
+        assert!(!changed);
+        assert!(!pending_clear);
+        assert_eq!(streak, 1);
+        assert_eq!(presence.current_agent(), Some(Agent::Pi));
+        assert_eq!(
+            foreground_shell_agent_action(Some(Agent::Pi), None, true, false, streak),
+            ForegroundShellAgentAction::ReportProcessExit
+        );
+        // A recovered agent observation resets the confirmation streak.
+        apply_foreground_shell_agent_action(
+            &mut presence,
+            ForegroundShellAgentAction::ObserveProbe,
+            Some(Agent::Pi),
+            Some(Agent::Pi),
+            &mut pending_clear,
+            &mut exit_reported,
+            &mut streak,
+        );
+        assert_eq!(streak, 0);
+    }
+
+    #[test]
     fn same_agent_after_reported_exit_is_a_replacement_process() {
         assert_eq!(
-            foreground_shell_agent_action(Some(Agent::Pi), Some(Agent::Pi), false, true),
+            foreground_shell_agent_action(Some(Agent::Pi), Some(Agent::Pi), false, true, 0),
             ForegroundShellAgentAction::ReportReplacementProcess
         );
     }
@@ -3742,7 +3823,7 @@ mod tests {
     #[test]
     fn unknown_non_shell_foreground_job_is_not_immediate_clear_signal() {
         assert_eq!(
-            foreground_shell_agent_action(Some(Agent::Claude), None, false, false),
+            foreground_shell_agent_action(Some(Agent::Claude), None, false, false, 0),
             ForegroundShellAgentAction::ObserveProbe
         );
     }
@@ -3764,7 +3845,7 @@ mod tests {
     #[test]
     fn reported_process_exit_clears_before_unknown_foreground_probe() {
         assert_eq!(
-            foreground_shell_agent_action(Some(Agent::Claude), None, false, true),
+            foreground_shell_agent_action(Some(Agent::Claude), None, false, true, 0),
             ForegroundShellAgentAction::ClearAgent
         );
     }
@@ -3772,7 +3853,13 @@ mod tests {
     #[test]
     fn foreground_agent_job_is_not_clear_signal() {
         assert_eq!(
-            foreground_shell_agent_action(Some(Agent::Claude), Some(Agent::OpenCode), true, false,),
+            foreground_shell_agent_action(
+                Some(Agent::Claude),
+                Some(Agent::OpenCode),
+                true,
+                false,
+                0,
+            ),
             ForegroundShellAgentAction::ObserveProbe
         );
     }
@@ -3911,6 +3998,7 @@ mod tests {
             has_process_probe: true,
             acquisition_age: None,
             pending_foreground_shell_clear: false,
+            pending_shell_exit_confirmation: false,
             pending_restore_probe: false,
             elapsed_since_process_check: std::time::Duration::from_secs(1),
         }

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -1346,7 +1346,7 @@ impl TerminalState {
     fn session_start_source_is_recognized(session_start_source: Option<&str>) -> bool {
         matches!(
             session_start_source,
-            Some("startup" | "clear" | "resume" | "compact" | "new" | "fork" | "select")
+            Some("startup" | "clear" | "resume" | "compact" | "new" | "fork" | "select" | "reload")
         )
     }
 
@@ -1489,6 +1489,19 @@ impl TerminalState {
                 suppressed.replacement_session_ref = Some(session_ref);
             }
             self.hook_report_sequences.insert(source.clone(), seq);
+            // A `reload` session start is a live process re-anchoring its
+            // existing session, so a recorded process exit for the same
+            // detected agent was a false observation. Drop it so the live
+            // agent's effective label (and its `agent list` registration) is
+            // restored (refs #3225). Other session-start reasons (such as
+            // `startup`) can follow a genuine exit and keep the existing
+            // replay-on-process-evidence flow.
+            if session_start_source.as_deref() == Some("reload")
+                && known_agent.is_some()
+                && self.detected_agent == known_agent
+            {
+                self.recent_agent_process_exit = None;
+            }
 
             if process_present {
                 self.clear_full_lifecycle_hook_suppression_for_detected_agent(None, known_agent);
@@ -2863,6 +2876,79 @@ mod tests {
         assert!(late.is_none());
         assert!(terminal.hook_authority.is_none());
         assert_eq!(terminal.state, AgentState::Idle);
+    }
+
+    #[test]
+    fn issue_3225_false_exit_loses_live_pi_registration() {
+        let now = Instant::now();
+        let mut terminal = test_terminal();
+        let session_ref =
+            crate::agent_resume::AgentSessionRef::path(test_session_path("issue-3225-pi.jsonl"))
+                .expect("test session path should be valid");
+        terminal.set_detected_state(Some(Agent::Pi), AgentState::Idle);
+        terminal
+            .set_agent_session_ref_for_session_start(
+                "herdr:pi".into(),
+                "pi".into(),
+                Some(session_ref.clone()),
+                Some(20),
+                Some("new".into()),
+            )
+            .expect("initial Pi session should be accepted");
+        terminal
+            .set_hook_authority_at(
+                "herdr:pi".into(),
+                "pi".into(),
+                AgentState::Working,
+                None,
+                Some(session_ref.clone()),
+                Some(21),
+                now,
+            )
+            .expect("initial Pi state should be accepted");
+        terminal.set_agent_name("reviewer".into());
+
+        let exit = terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Pi),
+            AgentState::Idle,
+            false,
+            false,
+            false,
+            true,
+            now + Duration::from_secs(1),
+        );
+
+        assert!(exit.agent_released);
+        assert!(exit.session_ref_changed);
+        assert!(terminal.hook_authority.is_none());
+        assert!(terminal.persisted_agent_session.is_none());
+        assert!(terminal.agent_name.is_none());
+
+        let reload = terminal.set_agent_session_ref_for_session_start(
+            "herdr:pi".into(),
+            "pi".into(),
+            Some(session_ref.clone()),
+            Some(22),
+            Some("reload".into()),
+        );
+        let working = terminal.set_hook_authority_at(
+            "herdr:pi".into(),
+            "pi".into(),
+            AgentState::Working,
+            None,
+            Some(session_ref),
+            Some(23),
+            now + Duration::from_secs(2),
+        );
+
+        assert!(reload.is_none());
+        assert!(working.is_none());
+        assert!(terminal.hook_authority.is_none());
+        assert!(terminal.persisted_agent_session.is_none());
+        assert!(
+            terminal.is_agent_terminal(),
+            "a live Pi should re-register after a false process-exit observation"
+        );
     }
 
     #[test]

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -1346,7 +1346,7 @@ impl TerminalState {
     fn session_start_source_is_recognized(session_start_source: Option<&str>) -> bool {
         matches!(
             session_start_source,
-            Some("startup" | "clear" | "resume" | "compact" | "new" | "fork" | "select" | "reload")
+            Some("startup" | "clear" | "resume" | "compact" | "new" | "fork" | "select")
         )
     }
 
@@ -1390,6 +1390,16 @@ impl TerminalState {
         let process_present = known_agent.is_some()
             && self.detected_agent == known_agent
             && self.recent_agent_process_exit.is_none();
+        // A `reload` session start is a live process re-anchoring its existing
+        // session, so a recorded process exit for the same detected agent was a
+        // false observation (refs #3225). Only this recovery accepts `reload`;
+        // `session_start_source_is_recognized` stays narrow so reload cannot
+        // widen generic session-owner arbitration.
+        let reload_confirms_live_process = session_start_source.as_deref() == Some("reload")
+            && self.detected_agent == known_agent
+            && self
+                .recent_agent_process_exit
+                .is_some_and(|exit| Some(exit.agent) == known_agent);
         let full_lifecycle_source =
             crate::detect::full_lifecycle_hook_authority(&source, &agent_label);
         let generation_gated = self
@@ -1446,7 +1456,9 @@ impl TerminalState {
             && !selection_can_reconcile
             && (!process_present || generation_gated || !session_anchored)
         {
-            if !Self::session_start_source_is_recognized(session_start_source.as_deref()) {
+            if !Self::session_start_source_is_recognized(session_start_source.as_deref())
+                && !reload_confirms_live_process
+            {
                 return None;
             }
             let seq = seq?;
@@ -1489,21 +1501,17 @@ impl TerminalState {
                 suppressed.replacement_session_ref = Some(session_ref);
             }
             self.hook_report_sequences.insert(source.clone(), seq);
-            // A `reload` session start is a live process re-anchoring its
-            // existing session, so a recorded process exit for the same
-            // detected agent was a false observation. Drop it so the live
-            // agent's effective label (and its `agent list` registration) is
-            // restored (refs #3225). Other session-start reasons (such as
+            // Drop the false exit so the live agent's effective label (and its
+            // `agent list` registration) is restored, then take the process-present
+            // path below so the transition is published as a mutation instead of
+            // mutating state behind a `None`. Other session-start reasons (such as
             // `startup`) can follow a genuine exit and keep the existing
             // replay-on-process-evidence flow.
-            if session_start_source.as_deref() == Some("reload")
-                && known_agent.is_some()
-                && self.detected_agent == known_agent
-            {
+            if reload_confirms_live_process {
                 self.recent_agent_process_exit = None;
             }
 
-            if process_present {
+            if process_present || reload_confirms_live_process {
                 self.clear_full_lifecycle_hook_suppression_for_detected_agent(None, known_agent);
                 let current_session = self.current_session_identity_for_persistence();
                 return Some(TerminalStateMutation {
@@ -2879,7 +2887,7 @@ mod tests {
     }
 
     #[test]
-    fn issue_3225_false_exit_loses_live_pi_registration() {
+    fn issue_3225_reload_restores_live_pi_registration_after_false_exit() {
         let now = Instant::now();
         let mut terminal = test_terminal();
         let session_ref =
@@ -2933,6 +2941,23 @@ mod tests {
             // if `reload` stops surviving the API path, not just the arbitration.
             crate::agent_resume::normalize_session_start_source(Some("reload".into())),
         );
+        let reload = reload.expect("a reload from a live Pi should publish a mutation");
+        assert!(
+            reload.effective_state_change.is_some(),
+            "the restored Pi label must reach clients as an effective state change"
+        );
+        assert!(reload.session_ref_changed);
+        assert!(!reload.agent_released);
+        assert_eq!(
+            terminal
+                .persisted_agent_session
+                .as_ref()
+                .map(|session| (session.source.as_str(), session.agent.as_str())),
+            Some(("herdr:pi", "pi")),
+            "the reload must restore the session the false exit dropped"
+        );
+        assert!(terminal.is_agent_terminal());
+
         let working = terminal.set_hook_authority_at(
             "herdr:pi".into(),
             "pi".into(),
@@ -2943,14 +2968,68 @@ mod tests {
             now + Duration::from_secs(2),
         );
 
-        assert!(reload.is_none());
-        assert!(working.is_none());
-        assert!(terminal.hook_authority.is_none());
-        assert!(terminal.persisted_agent_session.is_none());
+        assert!(
+            working.is_some(),
+            "the next working report must be accepted once the false exit is cleared"
+        );
+        assert_eq!(
+            terminal
+                .hook_authority
+                .as_ref()
+                .map(|authority| (authority.agent_label.as_str(), authority.state)),
+            Some(("pi", AgentState::Working)),
+            "lifecycle authority must be live again, not buffered behind the exit"
+        );
+        assert_eq!(terminal.state, AgentState::Working);
         assert!(
             terminal.is_agent_terminal(),
             "a live Pi should re-register after a false process-exit observation"
         );
+    }
+
+    #[test]
+    fn reload_does_not_take_over_a_different_session_owner() {
+        // refs #3225: `reload` exists here only to recover a false process exit
+        // for the already detected agent. It must not widen generic session-owner
+        // arbitration, which `session_report_allows_session_replacement`
+        // deliberately denies it. `startup` still takes over, so this pins the
+        // narrowing rather than the takeover path itself.
+        for (start_source, expected_owner) in [
+            (Some("reload"), ("herdr:codex", "codex")),
+            (Some("startup"), ("herdr:hermes", "hermes")),
+        ] {
+            let mut terminal = test_terminal();
+            terminal.set_detected_state(Some(Agent::Hermes), AgentState::Idle);
+            terminal.set_persisted_agent_session(crate::agent_resume::PersistedAgentSession {
+                source: "herdr:codex".into(),
+                agent: "codex".into(),
+                session_ref: crate::agent_resume::AgentSessionRef::id("codex-root")
+                    .expect("test session id should be valid"),
+            });
+
+            let report = terminal.set_agent_session_ref_for_session_start(
+                "herdr:hermes".into(),
+                "hermes".into(),
+                crate::agent_resume::AgentSessionRef::id("hermes-root"),
+                Some(11),
+                crate::agent_resume::normalize_session_start_source(
+                    start_source.map(str::to_string),
+                ),
+            );
+
+            assert_eq!(
+                report.is_some(),
+                start_source == Some("startup"),
+                "{start_source:?} must not decide session ownership like a recognized start"
+            );
+            assert_eq!(
+                terminal
+                    .persisted_agent_session
+                    .as_ref()
+                    .map(|session| (session.source.as_str(), session.agent.as_str())),
+                Some(expected_owner)
+            );
+        }
     }
 
     #[test]

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -2929,7 +2929,9 @@ mod tests {
             "pi".into(),
             Some(session_ref.clone()),
             Some(22),
-            Some("reload".into()),
+            // Route the reason through the public normalizer so this test fails
+            // if `reload` stops surviving the API path, not just the arbitration.
+            crate::agent_resume::normalize_session_start_source(Some("reload".into())),
         );
         let working = terminal.set_hook_authority_at(
             "herdr:pi".into(),


### PR DESCRIPTION
## Issue

A running agent (Pi on Windows, an assigned AGY name on macOS) abruptly disappears from `agent list` while its process is still alive, and its registration never comes back. API clients and plugins that target the pane's agent get `agent_not_found` from that moment on.

refs #3225

## Problem

Two mechanisms compound.

**One observation is enough to publish a false exit.** The foreground-process probe maps a previously detected agent plus a single observation of the pane shell to `ReportProcessExit` immediately (`src/pane.rs`), while the normal unidentified-job path requires six consecutive misses (`AGENT_MISS_CONFIRMATION_ATTEMPTS`). So one transient probe glitch — a sampled Windows process snapshot briefly missing the agent descendant, or a momentary foreground transition on macOS — publishes a process exit for a live agent.

**A false exit can then deadlock into permanent deregistration.** The exit sets `recent_agent_process_exit`, which masks `detected_agent` out of `effective_agent_label()` — the sole basis of `is_agent_terminal()`. The pane can reach a state no runtime path leaves on its own:

- Terminal state holds `detected_agent = Some(pi)` together with `recent_agent_process_exit = Some(pi)`, so the pane resolves to `agent_not_found`.
- The detection loop still holds `Some(pi)` in `agent_presence` while its local exit flag is `false`, so every probe that re-finds Pi observes the same value. `observe_process_probe` reports no change, no detection update is published, and `set_detected_state_with_screen_signals_at` — the only writer that clears `recent_agent_process_exit` — is never reached.
- The agent's own state reports are dropped behind the recorded exit, so lifecycle authority never returns, so `set_full_lifecycle_authority_active(true)` never fires the detection reset that would re-seed `agent_presence`.

Every other post-exit shape self-heals: a probe that observes a *changed* presence value (`ReportReplacementProcess`, or a fresh `None → Some` acquisition) publishes a detection update, and that clears the marker. The deadlock needs the loop-local exit flag and the terminal-side marker to desync — for example when a detection task starts from restored state with `detected_agent` already set (`AgentDetectionPresence::from_agent(initial_state.detected_agent)`) while the exit flag starts `false`.

Because the process probe cannot break that state, a session-start report from the live process is the only signal left.

## How did we fix it?

The shell-observation path now requires two consecutive confirmations before publishing a process exit (`FOREGROUND_SHELL_EXIT_CONFIRMATION_OBSERVATIONS`), with the pending confirmation driving the same fast probe recheck as a pending shell clear, so genuine exits are still reported within one extra ~300ms probe tick. This removes a single-tick probe glitch as a way into the deadlock; it does not make a sustained probe failure impossible.

On the recovery side, a `reload` session start — a live process re-anchoring its existing session, which only a running agent can send — clears a recorded process exit for the same detected agent. The clear then takes the process-present path: the suppressed lifecycle report is reconciled, the session the false exit dropped is restored, and the transition is returned as a `TerminalStateMutation`. `pane.agent_detected` is republished with `released: false`, and the agent's next state report is accepted rather than buffered, so registration recovers for direct queries and event subscribers on the same reload.

The unmasking is deliberately narrow. `reload` is not added to `session_start_source_is_recognized`, so generic session-owner arbitration is unchanged and a reload cannot replace a different persisted session owner. Recovery additionally requires the reported agent to match the detected agent and a recorded process exit for that same agent. Other session-start reasons such as `startup` can follow a genuine exit and keep the existing replay-on-process-evidence flow, and a late same-session hook report still does not silently reacquire authority after an exit.

## Known limitations

**An assigned agent name is not restored.** The false exit runs `clear_agent_name()`, which drops the pane's name, its name owner, and `managed_agent`. The reload restores the agent label, the session, and lifecycle authority, so pane-target lookups (`agent list`, `agent explain <pane>`) recover — but a name assigned with `agent rename` does not come back, and name-based lookup still needs a manual rename. Requiring two observations before an exit is what keeps named panes out of this state to begin with; restoring an already-released name is a separate change.

**The recovery is agent-specific by construction.** It is driven by the session-start report Pi emits on `/reload`. An agent that never re-anchors its session cannot break the deadlock this way, and would need a recovery driven by process evidence instead.

## Performance

The confirmation adds at most one extra foreground probe per exit candidate per pane, bounded to a single ~300ms tick: the streak resets on any other action, and a published exit already forces the same probe on the following tick through `pending_foreground_shell_clear`. On a false exit it removes the release and re-registration work entirely. `shell_exit_confirmation_costs_at_most_one_extra_probe_tick` pins that bound.

## Verification

- `issue_3225_reload_restores_live_pi_registration_after_false_exit`: after a false process-exit observation, a live Pi's `reload` restores the dropped session, publishes the effective-state change, and the following working report is accepted with live hook authority.
- `reload_after_a_false_process_exit_republishes_agent_registration`: at the App/API level the release emits `pane.agent_detected` with `released: true`, and the reload emits `pane.agent_detected` for `pi` with `released: false` — in the report order the pi integration emits, session report first and state report second.
- `reload_does_not_take_over_a_different_session_owner`: a `reload` does not decide session ownership when a different owner holds the session, while `startup` still does.
- `first_shell_observation_requires_confirmation_before_process_exit` and `shell_exit_confirmation_costs_at_most_one_extra_probe_tick`: a single shell observation cannot publish an exit, and the confirmation streak resets once it resolves.
- `pending_shell_exit_confirmation_forces_a_fast_recheck` and the extended `windows_foreground_observation_schedule_preserves_lifecycle_checks`: a pending confirmation forces the foreground observation and the full probe, and is not skipped under lifecycle authority.
- Existing process-exit arbitration tests pass unchanged, including `late_full_lifecycle_hook_with_same_session_after_process_exit_does_not_reacquire_authority` and `rapid_restart_replays_reports_that_arrive_before_process_evidence`.

## Platform note

On Windows the pi integration can report a session ref only through the session id: `herdr-agent-state.ts` accepts a session file path only when it starts with `/`, so a Windows path is rejected. Any session-start recovery, including this one, depends on that id being present in the reload report.
