### PR TITLE
fix: stop silently truncating oversized canonical pty input on macos

### DIFF
--- a/docs/next/website/src/content/docs/troubleshooting.mdx
+++ b/docs/next/website/src/content/docs/troubleshooting.mdx
@@ -103,7 +103,10 @@ takes over the terminal
 
 This affects `herdr agent start ... -- <long args>`, `herdr pane run`, and
 pasted text — anything that composes a single line over 1024 bytes. The cap is
-per line, not per write, so multi-line input of any total size is unaffected.
+per line, not per write: multi-line input is delivered whatever its total size,
+as long as every line in it fits. Text already typed into the pane and not yet
+read counts toward the line being composed, so a short injection appended to a
+long unread line can still be cut.
 
 Interactive agents such as Claude Code put the terminal in raw mode and are not
 subject to the cap, so the usual remedy is to retry once the agent has taken

--- a/docs/next/website/src/content/docs/troubleshooting.mdx
+++ b/docs/next/website/src/content/docs/troubleshooting.mdx
@@ -87,6 +87,29 @@ herdr
 
 Stopping the server exits its pane processes. Herdr panes inherit the long-lived server's macOS launch context, so a server started through SSH or a background job may not have access to interactive Keychain services. See [Herdr issue #966](https://github.com/herdrdev/herdr/issues/966) for details.
 
+## Long input is refused on macOS with `agent_start_input_failed`
+
+macOS caps a terminal input line at 1024 bytes, including its newline, while
+the foreground program is reading in canonical mode — a fresh pane before the
+shell finishes starting, or a shell busy running a command. The kernel keeps
+the first 1024 bytes of a longer line and silently discards the rest, so Herdr
+refuses the write instead of delivering a truncated command:
+
+```
+pane's foreground program is reading in canonical mode, which truncates input
+lines longer than 1024 bytes; send shorter lines or retry once the program
+takes over the terminal
+```
+
+This affects `herdr agent start ... -- <long args>`, `herdr pane run`, and
+pasted text — anything that composes a single line over 1024 bytes. The cap is
+per line, not per write, so multi-line input of any total size is unaffected.
+
+Interactive agents such as Claude Code put the terminal in raw mode and are not
+subject to the cap, so the usual remedy is to retry once the agent has taken
+over the pane. For a shell that stays in canonical mode, write long arguments
+to a script and run that instead of typing them.
+
 ## The `herdr` command is not found
 
 Restart the terminal so it reloads its environment, then confirm the Herdr install directory is on `PATH`. For package-manager installs, use that package manager to update Herdr and expose it on `PATH`. See [Install Herdr](/docs/install/#verify).

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -21,7 +21,9 @@ use tracing::{error, info, warn};
 use crate::detect::{Agent, AgentState};
 use crate::events::AppEvent;
 use crate::layout::PaneId;
-use crate::pty::actor::{PtyIoActor, PtyIoActorConfig, PtyIoActorHandle, PtyReadResult};
+use crate::pty::actor::{
+    PtyIoActor, PtyIoActorConfig, PtyIoActorHandle, PtyReadResult, PtyWriteError,
+};
 use crate::render_signal::RenderSignal;
 
 mod agent_detection;
@@ -1175,19 +1177,24 @@ impl PaneRuntimeIo {
         }
     }
 
-    async fn send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::SendError<Bytes>> {
+    async fn send_bytes(&self, bytes: Bytes) -> Result<(), PtyWriteError> {
         match self {
             PaneRuntimeIo::Actor(actor) => actor.write_user_input(bytes).await,
             #[cfg(test)]
-            PaneRuntimeIo::TestChannel { sender, .. } => sender.send(bytes).await,
+            PaneRuntimeIo::TestChannel { sender, .. } => sender
+                .send(bytes)
+                .await
+                .map_err(|_| PtyWriteError::Unavailable),
         }
     }
 
-    fn try_send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+    fn try_send_bytes(&self, bytes: Bytes) -> Result<(), PtyWriteError> {
         match self {
             PaneRuntimeIo::Actor(actor) => actor.try_write_user_input(bytes),
             #[cfg(test)]
-            PaneRuntimeIo::TestChannel { sender, .. } => sender.try_send(bytes),
+            PaneRuntimeIo::TestChannel { sender, .. } => sender
+                .try_send(bytes)
+                .map_err(|_| PtyWriteError::Unavailable),
         }
     }
 
@@ -2849,11 +2856,11 @@ impl PaneRuntime {
             .encode_terminal_key(key, self.keyboard_protocol())
     }
 
-    pub async fn send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::SendError<Bytes>> {
+    pub async fn send_bytes(&self, bytes: Bytes) -> Result<(), PtyWriteError> {
         self.io.send_bytes(bytes).await
     }
 
-    pub fn try_send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+    pub fn try_send_bytes(&self, bytes: Bytes) -> Result<(), PtyWriteError> {
         self.io.try_send_bytes(bytes)
     }
 
@@ -2861,11 +2868,11 @@ impl PaneRuntime {
         self.io.send_bytes_after(bytes, delay);
     }
 
-    pub async fn send_paste(&self, text: String) -> Result<(), mpsc::error::SendError<Bytes>> {
+    pub async fn send_paste(&self, text: String) -> Result<(), PtyWriteError> {
         self.send_bytes(self.paste_payload(text)).await
     }
 
-    pub fn try_send_paste(&self, text: String) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+    pub fn try_send_paste(&self, text: String) -> Result<(), PtyWriteError> {
         self.try_send_bytes(self.paste_payload(text))
     }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -995,6 +995,121 @@ pub fn process_exists(pid: u32) -> bool {
     }
 }
 
+/// Capacity of Darwin's canonical input queue (`MAX_INPUT`/`MAX_CANON`).
+///
+/// The limit is per line and counts the terminator, so a 1024-byte line ending
+/// in a newline is delivered whole. A longer line is not rejected by the
+/// kernel: it keeps a byte-exact 1024-byte prefix, silently discards the rest,
+/// and still reports the whole `write()` as successful. That stranded prefix
+/// is the truncated fragment users report — a command cut mid-string with its
+/// closing quote lost (refs #2862).
+const DARWIN_MAX_CANONICAL_INPUT: usize = 1024;
+
+/// The bytes that end a canonical line under the discipline installed now.
+///
+/// Only the translations that can *lengthen* the line we measure are modelled,
+/// because only those produce a false "would truncate" verdict and refuse a
+/// write the kernel would have accepted. A translation we miss leaves the
+/// pre-existing behaviour untouched rather than losing data, so the exotic
+/// remainder of the discipline (`ISTRIP`, `PARMRK`, erase and kill processing)
+/// is deliberately not modelled here.
+struct CanonicalTerminators {
+    /// `IGNCR`: a carriage return is discarded before anything else sees it,
+    /// so it neither ends a line nor costs a byte. Takes precedence over
+    /// `ICRNL`.
+    ignore_cr: bool,
+    /// `ICRNL`: a carriage return arrives as a newline and ends the line.
+    cr_ends_line: bool,
+    /// `INLCR` rewrites a newline as a carriage return, which is not fed back
+    /// through `ICRNL`, so under it a newline stops ending lines.
+    nl_ends_line: bool,
+    /// `VEOL`, `VEOL2` and `VEOF` each end a line when not `_POSIX_VDISABLE`.
+    /// Darwin honours `VEOL2` regardless of `IEXTEN`.
+    eol: Option<u8>,
+    eol2: Option<u8>,
+    eof: Option<u8>,
+}
+
+impl CanonicalTerminators {
+    /// The terminators in force on `fd`, or `None` when input is not canonical.
+    /// The master and slave share one termios on Darwin, so the master fd
+    /// answers for the foreground program.
+    fn installed_on(fd: RawFd) -> Option<Self> {
+        let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+        // SAFETY: tcgetattr fills one termios for a valid fd. A failed read is
+        // reported as non-canonical, which keeps the write behaviour herdr had
+        // before this check existed.
+        let termios = unsafe {
+            if libc::tcgetattr(fd, termios.as_mut_ptr()) != 0 {
+                return None;
+            }
+            termios.assume_init()
+        };
+        if termios.c_lflag & libc::ICANON == 0 {
+            return None;
+        }
+        let control = |index: usize| match termios.c_cc[index] {
+            libc::_POSIX_VDISABLE => None,
+            byte => Some(byte),
+        };
+        Some(Self {
+            ignore_cr: termios.c_iflag & libc::IGNCR != 0,
+            cr_ends_line: termios.c_iflag & libc::ICRNL != 0,
+            nl_ends_line: termios.c_iflag & libc::INLCR == 0,
+            eol: control(libc::VEOL),
+            eol2: control(libc::VEOL2),
+            eof: control(libc::VEOF),
+        })
+    }
+
+    fn ends_line(&self, byte: u8) -> bool {
+        match byte {
+            b'\n' => self.nl_ends_line,
+            b'\r' => !self.ignore_cr && self.cr_ends_line,
+            byte => self.eol == Some(byte) || self.eol2 == Some(byte) || self.eof == Some(byte),
+        }
+    }
+
+    /// Whether any line in `bytes` outgrows the queue. A line left unterminated
+    /// at the end of the payload still counts: the queue fills as the bytes
+    /// arrive, not when the line is completed.
+    fn would_truncate(&self, bytes: &[u8]) -> bool {
+        let mut line = 0usize;
+        for &byte in bytes {
+            if byte == b'\r' && self.ignore_cr {
+                continue;
+            }
+            line += 1;
+            if line > DARWIN_MAX_CANONICAL_INPUT {
+                return true;
+            }
+            if self.ends_line(byte) {
+                line = 0;
+            }
+        }
+        false
+    }
+}
+
+/// Whether `bytes` is even large enough for the canonical queue to truncate
+/// it, answered without a descriptor. This is the shape of essentially every
+/// PTY write — a keystroke, a mouse report, a terminal response — so answering
+/// it first keeps the discipline read off that path entirely.
+pub(crate) fn may_exceed_canonical_queue(bytes: &[u8]) -> bool {
+    bytes.len() > DARWIN_MAX_CANONICAL_INPUT
+}
+
+/// The per-line byte cap the discipline installed on `fd` would silently
+/// enforce on `bytes`, or `None` when the write survives intact (refs #2862).
+pub(crate) fn canonical_truncation_limit(fd: RawFd, bytes: &[u8]) -> Option<usize> {
+    if !may_exceed_canonical_queue(bytes) {
+        return None;
+    }
+    CanonicalTerminators::installed_on(fd)
+        .filter(|terminators| terminators.would_truncate(bytes))
+        .map(|_| DARWIN_MAX_CANONICAL_INPUT)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1214,5 +1329,109 @@ printf '%s\n' "$@" > "$HERDR_NOTIFY_ARGS"
         assert_eq!(argv[1], "-c");
         assert!(argv[2].contains("EDITOR:-vi"));
         assert!(argv[2].contains("/tmp/herdr scrollback.txt"));
+    }
+
+    impl CanonicalTerminators {
+        /// Darwin's defaults for an interactive shell: ICRNL on, VEOF at
+        /// ^D, VEOL and VEOL2 left at `_POSIX_VDISABLE`.
+        fn test_defaults() -> Self {
+            Self {
+                ignore_cr: false,
+                cr_ends_line: true,
+                nl_ends_line: true,
+                eol: None,
+                eol2: None,
+                eof: Some(0x04),
+            }
+        }
+    }
+
+    fn line_of(len: usize) -> Vec<u8> {
+        vec![b'a'; len]
+    }
+
+    /// refs #2862: the cap is per line and counts the terminator. Verified
+    /// against XNU: a 1024-byte line arrives whole, a 1025-byte one strands a
+    /// 1024-byte prefix and loses the rest.
+    #[test]
+    fn canonical_line_budget_matches_the_kernel_boundary() {
+        let terminators = CanonicalTerminators::test_defaults();
+
+        let fits = [line_of(1023), vec![b'\n']].concat();
+        assert!(!terminators.would_truncate(&fits));
+        let over = [line_of(1024), vec![b'\n']].concat();
+        assert!(terminators.would_truncate(&over));
+
+        // The queue fills as bytes arrive, so an unterminated line counts too.
+        // This is the reported shape: a composed command typed before Enter.
+        assert!(!terminators.would_truncate(&line_of(1024)));
+        assert!(terminators.would_truncate(&line_of(1025)));
+    }
+
+    /// refs #2862: total size must not decide the verdict. Ordinary multi-line
+    /// input is far larger than the queue and the kernel accepts every byte of
+    /// it, so refusing on size alone would break normal pastes.
+    #[test]
+    fn total_size_does_not_decide_the_verdict() {
+        let terminators = CanonicalTerminators::test_defaults();
+        let many_short_lines: Vec<u8> = (0..10)
+            .flat_map(|_| [line_of(499), vec![b'\n']].concat())
+            .collect();
+        assert_eq!(many_short_lines.len(), 5000);
+        assert!(!terminators.would_truncate(&many_short_lines));
+    }
+
+    /// refs #2862: which byte ends a line follows the active termios, and only
+    /// a missed terminator can refuse a write the kernel would have taken.
+    #[test]
+    fn line_terminators_follow_the_active_termios() {
+        let split_by =
+            |separator: u8| [line_of(1000), vec![separator], line_of(1000), vec![b'\n']].concat();
+
+        // ICRNL decides whether a carriage return ends a line.
+        let mut terminators = CanonicalTerminators::test_defaults();
+        assert!(!terminators.would_truncate(&split_by(b'\r')));
+        terminators.cr_ends_line = false;
+        assert!(terminators.would_truncate(&split_by(b'\r')));
+
+        // IGNCR discards the carriage return before ICRNL sees it, so it ends
+        // nothing — but it costs no queue byte either.
+        let mut terminators = CanonicalTerminators::test_defaults();
+        terminators.ignore_cr = true;
+        assert!(terminators.would_truncate(&split_by(b'\r')));
+        assert!(!terminators.would_truncate(&[line_of(1024), vec![b'\r'; 64]].concat()));
+
+        // INLCR rewrites a newline as a carriage return and does not feed it
+        // back through ICRNL, so newlines stop ending lines.
+        let short_lines: Vec<u8> = (0..6)
+            .flat_map(|_| [line_of(499), vec![b'\n']].concat())
+            .collect();
+        assert!(!CanonicalTerminators::test_defaults().would_truncate(&short_lines));
+        let mut terminators = CanonicalTerminators::test_defaults();
+        terminators.nl_ends_line = false;
+        assert!(terminators.would_truncate(&short_lines));
+
+        // VEOL, VEOL2 and VEOF each end a line when enabled; Darwin honours
+        // VEOL2 without IEXTEN. A control left disabled ends nothing.
+        assert!(!CanonicalTerminators::test_defaults().would_truncate(&split_by(0x04)));
+        assert!(CanonicalTerminators::test_defaults().would_truncate(&split_by(0x02)));
+        for assign in [
+            |t: &mut CanonicalTerminators| t.eol = Some(0x02),
+            |t: &mut CanonicalTerminators| t.eol2 = Some(0x02),
+        ] {
+            let mut terminators = CanonicalTerminators::test_defaults();
+            assign(&mut terminators);
+            assert!(!terminators.would_truncate(&split_by(0x02)));
+        }
+    }
+
+    /// refs #2862: a payload that cannot outgrow the queue is cleared without
+    /// reading the discipline at all, which keeps the check off the path every
+    /// keystroke and terminal response takes.
+    #[test]
+    fn writes_within_the_queue_skip_the_discipline_read() {
+        // An invalid fd would fail tcgetattr, so reaching it changes nothing
+        // here; the point is that a short write is answered before that.
+        assert_eq!(canonical_truncation_limit(-1, &line_of(1024)), None);
     }
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -132,6 +132,26 @@ pub(crate) fn take_terminal_resize_signal() -> bool {
     false
 }
 
+/// The per-line byte cap that the line discipline installed on `fd` would
+/// silently enforce on `bytes`, or `None` when the write survives intact.
+///
+/// Only Darwin's canonical discipline truncates silently: it caps a line at
+/// 1024 bytes including its terminator, keeps that prefix, discards the rest,
+/// and still reports the whole `write()` as successful (refs #2862). Every
+/// other Unix delivers the write intact.
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) fn canonical_truncation_limit(_fd: std::os::fd::RawFd, _bytes: &[u8]) -> Option<usize> {
+    None
+}
+
+/// Whether `bytes` is even large enough for a line discipline to truncate it,
+/// answered without a descriptor so a caller can skip asking about the
+/// overwhelming majority of writes. Only Darwin has such a cap.
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) fn may_exceed_canonical_queue(_bytes: &[u8]) -> bool {
+    false
+}
+
 #[cfg(unix)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClipboardCommand {

--- a/src/pty/actor.rs
+++ b/src/pty/actor.rs
@@ -13,6 +13,11 @@ pub(crate) enum PtyWriteError {
     /// no such discipline, so Windows never reports this.
     #[cfg(unix)]
     LineExceedsCanonicalQueue { limit: usize },
+    /// The pane could not say whether its line discipline would truncate the
+    /// write. Reporting the refusal is the only truthful answer left: writing
+    /// anyway is what silently truncated input before this check existed.
+    #[cfg(unix)]
+    DisciplineUnknown,
 }
 
 impl std::fmt::Display for PtyWriteError {
@@ -25,6 +30,12 @@ impl std::fmt::Display for PtyWriteError {
                 "pane's foreground program is reading in canonical mode, which truncates \
                  input lines longer than {limit} bytes; send shorter lines or retry once \
                  the program takes over the terminal"
+            ),
+            #[cfg(unix)]
+            Self::DisciplineUnknown => write!(
+                f,
+                "pane did not report whether its terminal would truncate this input in time; \
+                 retry"
             ),
         }
     }

--- a/src/pty/actor.rs
+++ b/src/pty/actor.rs
@@ -1,3 +1,37 @@
+/// Why a pane refused input.
+///
+/// Herdr reports a refusal instead of half-delivering a write, so a caller
+/// that is told its input was accepted can rely on that (refs #2862).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PtyWriteError {
+    /// The pane is not accepting input: it was released, it is quiesced for a
+    /// handoff, or the actor's command queue is full.
+    Unavailable,
+    /// The foreground program is reading in canonical mode, whose input queue
+    /// caps a line at `limit` bytes and silently discards the rest. Delivering
+    /// the write would truncate it, so the pane refused it whole. ConPTY has
+    /// no such discipline, so Windows never reports this.
+    #[cfg(unix)]
+    LineExceedsCanonicalQueue { limit: usize },
+}
+
+impl std::fmt::Display for PtyWriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unavailable => write!(f, "pane is not accepting input"),
+            #[cfg(unix)]
+            Self::LineExceedsCanonicalQueue { limit } => write!(
+                f,
+                "pane's foreground program is reading in canonical mode, which truncates \
+                 input lines longer than {limit} bytes; send shorter lines or retry once \
+                 the program takes over the terminal"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PtyWriteError {}
+
 #[cfg(unix)]
 mod unix;
 
@@ -58,32 +92,39 @@ mod windows {
     }
 
     impl PtyIoActorHandle {
+        /// ConPTY has no canonical line discipline of its own, so a write is
+        /// either accepted or refused outright (refs #2862).
         pub(crate) async fn write_user_input(
             &self,
             bytes: Bytes,
-        ) -> Result<(), mpsc::error::SendError<Bytes>> {
+        ) -> Result<(), super::PtyWriteError> {
             if !*self
                 .accepting
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
             {
-                return Err(mpsc::error::SendError(bytes));
+                return Err(super::PtyWriteError::Unavailable);
             }
-            self.data_tx.send(bytes).await
+            self.data_tx
+                .send(bytes)
+                .await
+                .map_err(|_| super::PtyWriteError::Unavailable)
         }
 
         pub(crate) fn try_write_user_input(
             &self,
             bytes: Bytes,
-        ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        ) -> Result<(), super::PtyWriteError> {
             if !*self
                 .accepting
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
             {
-                return Err(mpsc::error::TrySendError::Closed(bytes));
+                return Err(super::PtyWriteError::Unavailable);
             }
-            self.data_tx.try_send(bytes)
+            self.data_tx
+                .try_send(bytes)
+                .map_err(|_| super::PtyWriteError::Unavailable)
         }
 
         pub(crate) fn write_terminal_response(&self, response: impl FnOnce() -> Option<Bytes>) {

--- a/src/pty/actor/unix.rs
+++ b/src/pty/actor/unix.rs
@@ -12,12 +12,22 @@ use tracing::{debug, warn};
 
 use crate::pty::fd;
 
+use super::PtyWriteError;
+
 // Actor handle methods must call wake_actor() after queuing work. The idle
 // timeout is only a fallback for missed wakes; PTY and wake readiness drive
 // normal responsiveness.
 const ACTOR_IDLE_POLL_MS: i32 = 1000;
 const ACTOR_COMMAND_BUFFER: usize = 1024;
 const HANDOFF_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+/// How long a submission waits for the runner's line-discipline verdict before
+/// being written unchecked (refs #2862).
+///
+/// The runner is a dedicated thread that answers on its next loop pass, so this
+/// normally costs microseconds and only a submission too large to be a
+/// keystroke ever waits at all. The bound exists so a runner buried in output
+/// cannot stall the caller, which may be a runtime worker.
+const CANONICAL_VERDICT_TIMEOUT: Duration = Duration::from_millis(100);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ActorState {
@@ -77,6 +87,12 @@ enum PtyIoDataCommand {
 
 enum PtyIoControlCommand {
     BeginHandoff(std_mpsc::Sender<std::io::Result<()>>),
+    /// Ask the runner, which holds the pane's only master fd, whether the line
+    /// discipline installed right now would truncate this submission.
+    CanonicalTruncationLimit {
+        bytes: Bytes,
+        reply: std_mpsc::Sender<Option<usize>>,
+    },
     DuplicateForHandoff(std_mpsc::Sender<std::io::Result<RawFd>>),
     ForegroundProcessGroup(std_mpsc::Sender<Option<u32>>),
     RollbackHandoff(std_mpsc::Sender<std::io::Result<()>>),
@@ -100,23 +116,61 @@ struct UserWriteGate {
 }
 
 impl PtyIoActorHandle {
-    pub(crate) async fn write_user_input(
-        &self,
-        bytes: Bytes,
-    ) -> Result<(), mpsc::error::SendError<Bytes>> {
+    /// Refuse input the line discipline installed right now would silently
+    /// truncate, so the caller learns the write did not land instead of being
+    /// told it succeeded (refs #2862).
+    ///
+    /// The runner holds the pane's only master fd — handoff depends on that —
+    /// so the verdict is asked of the runner rather than read here. The
+    /// question is only worth asking for a submission large enough to be
+    /// truncated at all, which excludes every keystroke, mouse report and
+    /// terminal response, so the common write never pays for this.
+    ///
+    /// The discipline can change between the verdict and the write. That race
+    /// costs a refusal the kernel would have accepted, which the caller can
+    /// retry; it never costs delivered bytes.
+    fn reject_if_discipline_would_truncate(&self, bytes: &Bytes) -> Result<(), PtyWriteError> {
+        if !crate::platform::may_exceed_canonical_queue(bytes) {
+            return Ok(());
+        }
+        let (reply, verdict) = std_mpsc::channel();
+        if self
+            .control_tx
+            .send(PtyIoControlCommand::CanonicalTruncationLimit {
+                bytes: bytes.clone(),
+                reply,
+            })
+            .is_err()
+        {
+            return Err(PtyWriteError::Unavailable);
+        }
+        self.wake_actor();
+        // A runner too busy to answer leaves the write to the behaviour it had
+        // before this check existed rather than refusing on a guess. The gate
+        // above is already closed during a handoff drain, which is the only
+        // place the runner stays away from its control channel for long.
+        match verdict.recv_timeout(CANONICAL_VERDICT_TIMEOUT) {
+            Ok(Some(limit)) => Err(PtyWriteError::LineExceedsCanonicalQueue { limit }),
+            Ok(None) => Ok(()),
+            Err(_) => Ok(()),
+        }
+    }
+
+    pub(crate) async fn write_user_input(&self, bytes: Bytes) -> Result<(), PtyWriteError> {
         {
             let user_writes = self
                 .user_writes
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             if !user_writes.accepting {
-                return Err(mpsc::error::SendError(bytes));
+                return Err(PtyWriteError::Unavailable);
             }
         }
+        self.reject_if_discipline_would_truncate(&bytes)?;
 
         let permit = match self.data_tx.reserve().await {
             Ok(permit) => permit,
-            Err(_) => return Err(mpsc::error::SendError(bytes)),
+            Err(_) => return Err(PtyWriteError::Unavailable),
         };
 
         let user_writes = self
@@ -124,24 +178,22 @@ impl PtyIoActorHandle {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if !user_writes.accepting {
-            return Err(mpsc::error::SendError(bytes));
+            return Err(PtyWriteError::Unavailable);
         }
         permit.send(PtyIoDataCommand::WriteUserInput(bytes));
         self.wake_actor();
         Ok(())
     }
 
-    pub(crate) fn try_write_user_input(
-        &self,
-        bytes: Bytes,
-    ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+    pub(crate) fn try_write_user_input(&self, bytes: Bytes) -> Result<(), PtyWriteError> {
         let user_writes = self
             .user_writes
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if !user_writes.accepting {
-            return Err(mpsc::error::TrySendError::Closed(bytes));
+            return Err(PtyWriteError::Unavailable);
         }
+        self.reject_if_discipline_would_truncate(&bytes)?;
         match self
             .data_tx
             .try_send(PtyIoDataCommand::WriteUserInput(bytes))
@@ -150,12 +202,7 @@ impl PtyIoActorHandle {
                 self.wake_actor();
                 Ok(())
             }
-            Err(mpsc::error::TrySendError::Full(PtyIoDataCommand::WriteUserInput(bytes))) => {
-                Err(mpsc::error::TrySendError::Full(bytes))
-            }
-            Err(mpsc::error::TrySendError::Closed(PtyIoDataCommand::WriteUserInput(bytes))) => {
-                Err(mpsc::error::TrySendError::Closed(bytes))
-            }
+            Err(_) => Err(PtyWriteError::Unavailable),
         }
     }
 
@@ -361,7 +408,6 @@ impl PtyIoActor {
     ) -> std::io::Result<PtyIoActorHandle> {
         fd::set_cloexec(config.master_fd.as_raw_fd())?;
         fd::set_nonblocking(config.master_fd.as_raw_fd())?;
-
         let (data_tx, data_rx) = mpsc::channel(ACTOR_COMMAND_BUFFER);
         let (control_tx, control_rx) = std_mpsc::channel();
         let wake_pipe = fd::create_wake_pipe()?;
@@ -557,6 +603,12 @@ impl PtyIoActorRunner {
             PtyIoControlCommand::BeginHandoff(reply) => {
                 let result = self.begin_handoff();
                 let _ = reply.send(result);
+            }
+            PtyIoControlCommand::CanonicalTruncationLimit { bytes, reply } => {
+                let _ = reply.send(crate::platform::canonical_truncation_limit(
+                    self.file.as_raw_fd(),
+                    &bytes,
+                ));
             }
             PtyIoControlCommand::DuplicateForHandoff(reply) => {
                 let result = if self.state == ActorState::Quiesced {
@@ -1365,7 +1417,7 @@ mod tests {
         let err = write.await.expect("write task joins").expect_err(
             "write waiting for capacity must be rejected after handoff closes the input gate",
         );
-        assert_eq!(err.0, Bytes::from_static(b"after-handoff-start"));
+        assert_eq!(err, PtyWriteError::Unavailable);
         match tokio::time::timeout(Duration::from_millis(50), data_rx.recv()).await {
             Err(_) | Ok(None) => {}
             Ok(Some(_)) => panic!("rejected write must not be queued"),
@@ -1459,5 +1511,199 @@ mod tests {
 
         let _ = peer.write_all(b"ignored");
         assert!(read_rx.recv_timeout(Duration::from_millis(150)).is_err());
+    }
+
+    /// A PTY whose slave is in canonical mode with echo off, the shape a shell
+    /// leaves behind while a foreground program reads a line.
+    #[cfg(target_os = "macos")]
+    fn canonical_test_pty() -> (OwnedFd, OwnedFd, libc::termios) {
+        let mut master_fd = 0;
+        let mut slave_fd = 0;
+        // SAFETY: openpty fills both descriptors or reports failure; the
+        // remaining arguments are optional and left null.
+        let opened = unsafe {
+            libc::openpty(
+                &mut master_fd,
+                &mut slave_fd,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(opened, 0, "open PTY: {}", std::io::Error::last_os_error());
+        // SAFETY: openpty just handed us both descriptors and kept no copy.
+        let master_fd = unsafe { <OwnedFd as std::os::fd::FromRawFd>::from_raw_fd(master_fd) };
+        // SAFETY: as above.
+        let slave_fd = unsafe { <OwnedFd as std::os::fd::FromRawFd>::from_raw_fd(slave_fd) };
+
+        let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+        // SAFETY: tcgetattr fills one termios for the slave we just opened.
+        let read = unsafe { libc::tcgetattr(slave_fd.as_raw_fd(), termios.as_mut_ptr()) };
+        assert_eq!(
+            read,
+            0,
+            "read PTY settings: {}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: tcgetattr reported success, so the value is initialized.
+        let mut termios = unsafe { termios.assume_init() };
+        termios.c_lflag |= libc::ICANON;
+        termios.c_lflag &= !libc::ECHO;
+        // SAFETY: writes the termios we just read back to the same fd.
+        let written = unsafe { libc::tcsetattr(slave_fd.as_raw_fd(), libc::TCSANOW, &termios) };
+        assert_eq!(
+            written,
+            0,
+            "set canonical mode: {}",
+            std::io::Error::last_os_error()
+        );
+        (master_fd, slave_fd, termios)
+    }
+
+    /// Take the slave out of canonical mode, the way a program does when it
+    /// takes over the terminal, and drain what the actor delivered.
+    #[cfg(target_os = "macos")]
+    fn leave_canonical_and_drain(
+        slave_fd: OwnedFd,
+        termios: &mut libc::termios,
+        expected_len: usize,
+        patience: Duration,
+    ) -> Vec<u8> {
+        termios.c_lflag &= !libc::ICANON;
+        termios.c_cc[libc::VMIN] = 0;
+        termios.c_cc[libc::VTIME] = 1;
+        // SAFETY: writes a termios read from this same fd back to it.
+        let written = unsafe { libc::tcsetattr(slave_fd.as_raw_fd(), libc::TCSANOW, termios) };
+        assert_eq!(
+            written,
+            0,
+            "set raw read mode: {}",
+            std::io::Error::last_os_error()
+        );
+        let mut slave = std::fs::File::from(slave_fd);
+        let mut received = Vec::new();
+        let deadline = Instant::now() + patience;
+        while received.len() < expected_len && Instant::now() < deadline {
+            let mut chunk = [0u8; 4096];
+            match slave.read(&mut chunk) {
+                Ok(0) => {}
+                Ok(read) => received.extend_from_slice(&chunk[..read]),
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(err) => panic!("read slave: {err}"),
+            }
+        }
+        received
+    }
+
+    #[cfg(target_os = "macos")]
+    fn spawn_actor_on(master_fd: OwnedFd) -> PtyIoActorHandle {
+        PtyIoActor::spawn(PtyIoActorConfig {
+            pane_id: 1,
+            master_fd,
+            initially_quiesced: false,
+            on_read: Box::new(|_| PtyReadResult::empty()),
+            on_reader_exit: None,
+        })
+        .expect("actor spawn")
+    }
+
+    /// refs #2862: the reported failure. A composed command longer than the
+    /// canonical queue used to be accepted, truncated at 1024 bytes by the
+    /// kernel, and reported as delivered. It is now refused, and the refusal
+    /// names the cap so `agent start` can surface it.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn oversized_canonical_line_is_refused_instead_of_truncated() {
+        let (master_fd, slave_fd, mut termios) = canonical_test_pty();
+        let handle = spawn_actor_on(master_fd);
+
+        let submitted = vec![b'A'; 1400];
+        let err = handle
+            .try_write_user_input(Bytes::copy_from_slice(&submitted))
+            .expect_err("input the canonical queue would truncate must be refused");
+        assert_eq!(
+            err,
+            PtyWriteError::LineExceedsCanonicalQueue { limit: 1024 }
+        );
+
+        // Nothing may reach the slave: a refusal that still delivered a
+        // truncated prefix would leave the shell at a `quote>` continuation,
+        // which is the symptom this refusal exists to prevent.
+        // Nothing is expected, so wait only long enough for a delivery the
+        // actor would have made immediately.
+        let leaked =
+            leave_canonical_and_drain(slave_fd, &mut termios, 1, Duration::from_millis(250));
+        handle.shutdown();
+        assert!(
+            leaked.is_empty(),
+            "refused input must not be partially delivered, got {} bytes",
+            leaked.len()
+        );
+    }
+
+    /// refs #2862: the refusal is about the discipline installed now, not the
+    /// payload, so the same input is delivered whole once the foreground
+    /// program takes over the terminal. Retrying is the documented remedy.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn the_same_input_is_accepted_once_the_program_leaves_canonical_mode() {
+        let (master_fd, slave_fd, mut termios) = canonical_test_pty();
+        let handle = spawn_actor_on(master_fd);
+
+        let submitted = vec![b'A'; 1400];
+        handle
+            .try_write_user_input(Bytes::copy_from_slice(&submitted))
+            .expect_err("refused while canonical");
+
+        termios.c_lflag &= !libc::ICANON;
+        // SAFETY: writes a termios read from this same fd back to it.
+        let written = unsafe { libc::tcsetattr(slave_fd.as_raw_fd(), libc::TCSANOW, &termios) };
+        assert_eq!(
+            written,
+            0,
+            "leave canonical mode: {}",
+            std::io::Error::last_os_error()
+        );
+
+        handle
+            .try_write_user_input(Bytes::copy_from_slice(&submitted))
+            .expect("a raw-mode program accepts input of any length");
+
+        let received = leave_canonical_and_drain(
+            slave_fd,
+            &mut termios,
+            submitted.len(),
+            Duration::from_secs(3),
+        );
+        handle.shutdown();
+        assert_eq!(received, submitted, "the retried input must arrive whole");
+    }
+
+    /// refs #2862: only an over-long *line* is refused. Ordinary multi-line
+    /// input dwarfs the queue and the kernel takes every byte, so refusing on
+    /// total size would break normal pastes into a canonical reader.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn short_lined_input_larger_than_the_queue_is_accepted_while_canonical() {
+        let (master_fd, slave_fd, mut termios) = canonical_test_pty();
+        let handle = spawn_actor_on(master_fd);
+
+        let submitted: Vec<u8> = (0..6)
+            .flat_map(|_| [vec![b'A'; 499], vec![b'\n']].concat())
+            .collect();
+        assert_eq!(submitted.len(), 3000, "payload far exceeds the 1024 queue");
+        handle
+            .try_write_user_input(Bytes::copy_from_slice(&submitted))
+            .expect("short-lined input must not be refused");
+
+        let received = leave_canonical_and_drain(
+            slave_fd,
+            &mut termios,
+            submitted.len(),
+            Duration::from_secs(3),
+        );
+        handle.shutdown();
+        assert_eq!(received, submitted, "every line must be delivered");
     }
 }

--- a/src/pty/actor/unix.rs
+++ b/src/pty/actor/unix.rs
@@ -26,8 +26,9 @@ const HANDOFF_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 /// The runner is a dedicated thread that answers on its next loop pass, so this
 /// normally costs microseconds and only a submission too large to be a
 /// keystroke ever waits at all. The bound exists so a runner buried in output
-/// cannot stall the caller, which may be a runtime worker.
-const CANONICAL_VERDICT_TIMEOUT: Duration = Duration::from_millis(100);
+/// cannot stall the caller, which may be a runtime worker; expiring it refuses
+/// the write, so it is set well past a healthy answer to keep that refusal rare.
+const CANONICAL_VERDICT_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ActorState {
@@ -126,9 +127,11 @@ impl PtyIoActorHandle {
     /// truncated at all, which excludes every keystroke, mouse report and
     /// terminal response, so the common write never pays for this.
     ///
-    /// The discipline can change between the verdict and the write. That race
-    /// costs a refusal the kernel would have accepted, which the caller can
-    /// retry; it never costs delivered bytes.
+    /// Every uncertain answer refuses. The discipline can change between the
+    /// verdict and the write, and a runner may not answer in time; both cost a
+    /// refusal the kernel would have accepted, which the caller can retry.
+    /// Neither costs delivered bytes, and neither reports a write that did not
+    /// land as successful.
     fn reject_if_discipline_would_truncate(&self, bytes: &Bytes) -> Result<(), PtyWriteError> {
         if !crate::platform::may_exceed_canonical_queue(bytes) {
             return Ok(());
@@ -145,14 +148,17 @@ impl PtyIoActorHandle {
             return Err(PtyWriteError::Unavailable);
         }
         self.wake_actor();
-        // A runner too busy to answer leaves the write to the behaviour it had
-        // before this check existed rather than refusing on a guess. The gate
-        // above is already closed during a handoff drain, which is the only
-        // place the runner stays away from its control channel for long.
+        // Writing without a verdict would restore the silent truncation this
+        // check exists to remove: the runner would drop the late reply and
+        // then write the bytes unchecked while the caller was told they
+        // landed. An unanswered question is refused instead, which the caller
+        // can retry. The gate above is already closed during a handoff drain,
+        // the only place the runner stays away from its control channel long
+        // enough for this to be reachable.
         match verdict.recv_timeout(CANONICAL_VERDICT_TIMEOUT) {
             Ok(Some(limit)) => Err(PtyWriteError::LineExceedsCanonicalQueue { limit }),
             Ok(None) => Ok(()),
-            Err(_) => Ok(()),
+            Err(_) => Err(PtyWriteError::DisciplineUnknown),
         }
     }
 
@@ -1705,5 +1711,40 @@ mod tests {
         );
         handle.shutdown();
         assert_eq!(received, submitted, "every line must be delivered");
+    }
+
+    /// refs #2862: an unanswered discipline question must refuse rather than
+    /// write. A runner that never services its control channel used to let the
+    /// submission through unchecked, which is the silent truncation this whole
+    /// check exists to remove.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_submission_is_refused_when_the_runner_cannot_report_its_discipline() {
+        let (data_tx, mut data_rx) = mpsc::channel(ACTOR_COMMAND_BUFFER);
+        // Held, never drained: the runner is busy elsewhere.
+        let (control_tx, _control_rx) = std_mpsc::channel();
+        let (wake, _wake_read_fd) = test_wake_pair();
+        let handle = PtyIoActorHandle {
+            data_tx,
+            control_tx,
+            wake,
+            user_writes: Arc::new(Mutex::new(UserWriteGate { accepting: true })),
+            controls: Arc::new(Mutex::new(SharedPtyControls::default())),
+            response_order: Arc::new(Mutex::new(())),
+        };
+
+        let err = handle
+            .try_write_user_input(Bytes::from(vec![b'A'; 1400]))
+            .expect_err("a submission with no verdict must be refused");
+        assert_eq!(err, PtyWriteError::DisciplineUnknown);
+        assert!(
+            data_rx.try_recv().is_err(),
+            "a refused submission must never reach the write queue"
+        );
+
+        // A submission the queue cannot truncate is unaffected: it never asks.
+        handle
+            .try_write_user_input(Bytes::from(vec![b'A'; 1024]))
+            .expect("input within the cap must not wait on a verdict");
     }
 }

--- a/src/terminal/runtime.rs
+++ b/src/terminal/runtime.rs
@@ -8,6 +8,7 @@ use tokio::sync::{mpsc, Notify};
 
 use crate::events::AppEvent;
 use crate::layout::PaneId;
+use crate::pty::actor::PtyWriteError;
 
 /// Live runtime for a server-owned terminal.
 ///
@@ -450,11 +451,11 @@ impl TerminalRuntime {
         self.0.encode_terminal_key(key)
     }
 
-    pub async fn send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::SendError<Bytes>> {
+    pub async fn send_bytes(&self, bytes: Bytes) -> Result<(), PtyWriteError> {
         self.0.send_bytes(bytes).await
     }
 
-    pub fn try_send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+    pub fn try_send_bytes(&self, bytes: Bytes) -> Result<(), PtyWriteError> {
         self.0.try_send_bytes(bytes)
     }
 
@@ -462,11 +463,11 @@ impl TerminalRuntime {
         self.0.send_bytes_after(bytes, delay);
     }
 
-    pub async fn send_paste(&self, text: String) -> Result<(), mpsc::error::SendError<Bytes>> {
+    pub async fn send_paste(&self, text: String) -> Result<(), PtyWriteError> {
         self.0.send_paste(text).await
     }
 
-    pub fn try_send_paste(&self, text: String) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+    pub fn try_send_paste(&self, text: String) -> Result<(), PtyWriteError> {
         self.0.try_send_paste(text)
     }
 


### PR DESCRIPTION
## Issue

On macOS, injecting a command longer than 1024 bytes into a pane whose foreground process holds the terminal in canonical mode — a fresh pane before the shell finishes starting, or a shell busy running a command — is silently truncated at exactly 1024 bytes. The closing quote is lost, the shell drops into a `quote>` continuation, and Herdr reports the injection as delivered.

refs #2862

## Problem

XNU caps a canonical input line at `MAX_CANON`/`MAX_INPUT` = 1024 bytes, including its terminator. A longer line is not rejected: the kernel keeps a byte-exact 1024-byte prefix, silently discards the rest, and still returns the full count from `write()`. Standalone probes confirmed there is no reliable kernel signal for how much the discipline actually kept — `TIOCOUTQ` on the master mixes echo and application output with stranded input, and `FIONREAD` reports zero even with readable data — so the "chunk the write and verify delivery" option in the issue is not implementable.

`PtyIoActorRunner::flush_pending_writes_once` trusted the `write()` return value, so the actor advanced past bytes the kernel had discarded. The damage is not the truncation itself but the silence: `agent start` returned `ok`, so a launcher built on it reported a healthy start for an agent that never launched.

## How did we fix it?

Refuse the write instead of half-delivering it, which is the "reject with a loud error" option the issue asks for.

Before queueing a submission large enough to be truncated at all, the handle asks the PTY runner — which holds the pane's only master fd — whether the line discipline installed right now would cut it, and returns `PtyWriteError::LineExceedsCanonicalQueue` when it would. The existing error paths carry it the rest of the way with no new plumbing:

- `agent start` → `agent_start_input_failed`, and the same branch already calls `clear_agent_name()`, so no phantom agent is left behind
- `pane run` / send-text → `pane_send_failed`
- agent send-keys → `agent_send_keys_failed`; terminal attach → its existing `Result<(), String>`

Every uncertain answer refuses. A discipline that changes between the verdict and the write, or a runner that does not answer within 250ms (`PtyWriteError::DisciplineUnknown`), costs a retryable refusal — never delivered bytes, and never a success report for a write that did not land.

Design notes:

- **The cap is per line, not per submission.** Ordinary multi-line input larger than the queue is delivered whatever its total size; only a line the model proves over-long is refused.
- **The verdict is asked of the runner, not read from a duplicated fd.** An earlier revision duplicated the master fd into the handle; `live_server_holds_one_pty_master_fd_per_pane` correctly rejected it, since handoff depends on the server holding exactly one ptmx fd per pane.
- **The common write pays nothing.** A submission at or under 1024 bytes is cleared by a length comparison alone — no syscall, no channel, no wait — so keystrokes, mouse reports and terminal responses never touch this path. Non-Darwin targets compile it to a constant `false`.
- **Only translations that can lengthen the measured line are modelled** (`ICANON`, `ICRNL`, `IGNCR`, `INLCR`, plus `VEOL`/`VEOL2`/`VEOF`). Under a reject design only those can refuse a write the kernel would have accepted; a translation the model misses leaves the pre-existing behaviour untouched rather than losing data. That trade-off is documented on the type.

An earlier revision of this branch held oversized submissions and dropped them after a 750ms hold. It was discarded: the drop reached the caller only as a `warn!` in the server log, so its end state for the reported case was still a silent loss — the same defect, with the truncated fragment traded for total loss. Both bot findings on that design (Greptile's "canonical programs stall input" and "timed hold discards input") are resolved by removing the mechanism rather than tuning it.

## Verification

- `cargo nextest run --no-fail-fast`: 3398/3398 pass. `just check`, `just windows-lint`, `cargo fmt --check` clean. Cross-checked `--target x86_64-unknown-linux-gnu`.
- New tests:
  - `canonical_line_budget_matches_the_kernel_boundary` — 1023+`\n` fits, 1024+`\n` does not, and an unterminated line counts too, matching the boundary measured against XNU.
  - `total_size_does_not_decide_the_verdict` and `line_terminators_follow_the_active_termios` — per-line sizing, and `ICRNL`/`IGNCR`/`INLCR`/`VEOL`/`VEOL2`/`VEOF` each changing where a line ends.
  - `writes_within_the_queue_skip_the_discipline_read` — the fast path never reads termios.
  - `oversized_canonical_line_is_refused_instead_of_truncated` — a real canonical PTY refuses a 1400-byte line and delivers **zero** bytes, not a truncated prefix.
  - `the_same_input_is_accepted_once_the_program_leaves_canonical_mode` — the identical payload arrives whole after the program takes over the terminal, so retry is a real remedy.
  - `short_lined_input_larger_than_the_queue_is_accepted_while_canonical` — 3000 bytes of short lines into a canonical, unread PTY arrive intact.
  - `a_submission_is_refused_when_the_runner_cannot_report_its_discipline` — an unanswered verdict refuses and never enqueues.

## Known limitation

Text already typed into a pane and not yet read counts toward the line the discipline is composing, and the model measures each submission from zero. A short injection appended to a long unread line can therefore still be cut. This is documented in the troubleshooting page; the reported class — a single composed line over the cap — is fully covered.
