### PR TITLE
fix: detect copilot background agents as working

### DIFF
--- a/src/detect/manifests/github-copilot.toml
+++ b/src/detect/manifests/github-copilot.toml
@@ -1,7 +1,7 @@
 id = "copilot"
-version = "2026.07.07.1"
+version = "2026.08.29.1"
 min_engine_version = 1
-updated_at = "2026-07-07T14:15:00Z"
+updated_at = "2026-08-29T00:00:00Z"
 aliases = ["github-copilot", "ghcs"]
 
 [[rules]]
@@ -22,6 +22,14 @@ all = [
     { contains = ["enter accept"] },
   ] },
 ]
+
+[[rules]]
+id = "background_agents_working"
+state = "working"
+priority = 110
+region = "bottom_non_empty_lines(6)"
+visible_working = true
+line_regex = ['^\s*◎\s+Waiting for background agents(?:\s|·|$)']
 
 [[rules]]
 id = "working_cancel_hint"

--- a/website/agent-detection/github-copilot.toml
+++ b/website/agent-detection/github-copilot.toml
@@ -1,7 +1,7 @@
 id = "copilot"
-version = "2026.07.07.1"
+version = "2026.08.29.1"
 min_engine_version = 1
-updated_at = "2026-07-07T14:15:00Z"
+updated_at = "2026-08-29T00:00:00Z"
 aliases = ["github-copilot", "ghcs"]
 
 [[rules]]
@@ -22,6 +22,14 @@ all = [
     { contains = ["enter accept"] },
   ] },
 ]
+
+[[rules]]
+id = "background_agents_working"
+state = "working"
+priority = 110
+region = "bottom_non_empty_lines(6)"
+visible_working = true
+line_regex = ['^\s*◎\s+Waiting for background agents(?:\s|·|$)']
 
 [[rules]]
 id = "working_cancel_hint"


### PR DESCRIPTION
## Issue

Refs #3291

## Problem

When GitHub Copilot CLI is waiting for background agents, Herdr recognizes the pane as Copilot but falls through to the known-agent idle fallback even though work is still in progress.

## How did we fix it?

- Add a high-priority working-state rule for Copilot's anchored `Waiting for background agents` status line.
- Limit the match to the bottom six non-empty detection-buffer lines so matching is based on the live status area rather than incidental pane content.
- Keep the bundled and website-distributed Copilot manifests in sync.

## Verification

- Reproduced the idle fallback from the detection snapshot attached to #3291.
- Hot-reloaded the updated manifest and confirmed the pane reports `working` at normal and narrow widths.
- Confirmed the same phrase in prompt content remains idle and Copilot's blocker state remains blocked.
- `python3 -m unittest scripts.test_agent_detection_manifest_check`
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- Full `just check` was attempted locally; four unchanged API/cross-area integration tests consistently timed out or missed runtime transitions before the manifest checks. The scoped manifest validator passes.
