### PR TITLE
fix(cli): align agent read/wait/prompt/start with the CLI error contract

### DIFF
--- a/docs/next/website/src/content/docs/agent-automation.mdx
+++ b/docs/next/website/src/content/docs/agent-automation.mdx
@@ -105,6 +105,8 @@ herdr agent prompt reviewer "Review the current diff" --wait --timeout 120000
 herdr agent read reviewer --source recent-unwrapped --lines 120
 ```
 
+Without `--timeout`, `agent wait` and `agent prompt --wait` wait indefinitely after the stall check; always pass `--timeout` when calling from an agent.
+
 Wait for an agent to ask for input, inspect it, and interact with its UI:
 
 ```bash

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -291,10 +291,17 @@ fn agent_start(args: &[String]) -> std::io::Result<i32> {
         eprintln!("usage: herdr agent start <name> --kind KIND --pane ID [--timeout MS] [-- <agent-args...>]");
         return Ok(2);
     };
-    let separator = args
-        .iter()
-        .position(|arg| arg == "--")
-        .unwrap_or(args.len());
+    // Expand `--flag=value` only before the `--` separator so pass-through
+    // agent arguments keep their exact shape.
+    let (own_args, agent_args) = args.split_at(
+        args.iter()
+            .position(|arg| arg == "--")
+            .unwrap_or(args.len()),
+    );
+    let mut expanded = super::expand_equals_args(own_args, &["--kind", "--pane", "--timeout"]);
+    let separator = expanded.len();
+    expanded.extend_from_slice(agent_args);
+    let args = &expanded[..];
     let mut kind = None;
     let mut pane_id = None;
     let mut timeout_ms = None;
@@ -508,6 +515,7 @@ fn agent_wait(args: &[String]) -> std::io::Result<i32> {
         eprintln!("usage: herdr agent wait <target> [--until STATUS]... [--timeout MS]");
         return Ok(2);
     };
+    let args = super::expand_equals_args(args, &["--until", "--timeout"]);
     let mut until = Vec::new();
     let mut timeout_ms = None;
     let mut index = 1;
@@ -779,6 +787,7 @@ fn agent_prompt(args: &[String]) -> std::io::Result<i32> {
         eprintln!("agent prompt requires text");
         return Ok(2);
     };
+    let args = super::expand_equals_args(args, &["--until", "--timeout"]);
     let mut wait = false;
     let mut until = Vec::new();
     let mut timeout_ms = None;
@@ -855,42 +864,59 @@ fn agent_send_keys(args: &[String]) -> std::io::Result<i32> {
     })?)
 }
 
+const AGENT_READ_USAGE: &str = "usage: herdr agent read <target> [--source visible|recent|recent-unwrapped|detection] [--lines N] [--format text|ansi] [--ansi]";
+
 fn agent_read(args: &[String]) -> std::io::Result<i32> {
     let Some(target) = args.first() else {
-        eprintln!("usage: herdr agent read <target> [--source visible|recent|recent-unwrapped] [--lines N] [--format text|ansi] [--ansi]");
+        eprintln!("{AGENT_READ_USAGE}");
         return Ok(2);
     };
+    let params = match parse_agent_read_args(target, &args[1..]) {
+        Ok(params) => params,
+        Err(err) => {
+            eprintln!("{err}");
+            eprintln!("{AGENT_READ_USAGE}");
+            return Ok(2);
+        }
+    };
 
+    let response = super::send_request(&Request {
+        id: "cli:agent:read".into(),
+        method: Method::AgentRead(params),
+    })?;
+    super::print_read_response(&response)
+}
+
+fn parse_agent_read_args(target: &str, args: &[String]) -> Result<AgentReadParams, String> {
+    let args = super::expand_equals_args(args, &["--source", "--lines", "--format"]);
     let mut source = ReadSource::Recent;
     let mut lines = None;
     let mut format = ReadFormat::Text;
     let mut strip_ansi = true;
 
-    let mut index = 1;
+    let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
             "--source" => {
                 let Some(value) = args.get(index + 1) else {
-                    eprintln!("missing value for --source");
-                    return Ok(2);
+                    return Err("missing value for --source".into());
                 };
-                source = super::parse_read_source(value)?;
+                source = super::parse_read_source(value).map_err(|err| err.to_string())?;
                 index += 2;
             }
             "--lines" => {
                 let Some(value) = args.get(index + 1) else {
-                    eprintln!("missing value for --lines");
-                    return Ok(2);
+                    return Err("missing value for --lines".into());
                 };
-                lines = Some(super::parse_u32_flag("--lines", value)?);
+                lines =
+                    Some(super::parse_u32_flag("--lines", value).map_err(|err| err.to_string())?);
                 index += 2;
             }
             "--format" => {
                 let Some(value) = args.get(index + 1) else {
-                    eprintln!("missing value for --format");
-                    return Ok(2);
+                    return Err("missing value for --format".into());
                 };
-                format = super::parse_read_format(value)?;
+                format = super::parse_read_format(value).map_err(|err| err.to_string())?;
                 strip_ansi = !matches!(format, ReadFormat::Ansi);
                 index += 2;
             }
@@ -899,24 +925,17 @@ fn agent_read(args: &[String]) -> std::io::Result<i32> {
                 strip_ansi = false;
                 index += 1;
             }
-            other => {
-                eprintln!("unknown option: {other}");
-                return Ok(2);
-            }
+            other => return Err(format!("unknown option: {other}")),
         }
     }
 
-    let response = super::send_request(&Request {
-        id: "cli:agent:read".into(),
-        method: Method::AgentRead(AgentReadParams {
-            target: target.clone(),
-            source,
-            lines,
-            format,
-            strip_ansi,
-        }),
-    })?;
-    super::print_read_response(&response)
+    Ok(AgentReadParams {
+        target: target.to_owned(),
+        source,
+        lines,
+        format,
+        strip_ansi,
+    })
 }
 
 fn print_agent_help() {

--- a/tests/cli/agents.rs
+++ b/tests/cli/agents.rs
@@ -1469,3 +1469,101 @@ fn agent_wait_ignores_other_panes_and_errors_when_its_pane_closes() {
 
     cleanup_spawned_herdr(herdr, base);
 }
+
+#[test]
+fn agent_read_reports_usage_errors_with_exit_status_2() {
+    for (args, expected) in [
+        (
+            &["agent", "read", "reviewer", "--lines", "abc"][..],
+            "invalid value for --lines: abc",
+        ),
+        (
+            &["agent", "read", "reviewer", "--source", "bogus"][..],
+            "invalid read source: bogus",
+        ),
+        (
+            &["agent", "read", "reviewer", "--format", "bogus"][..],
+            "invalid read format: bogus",
+        ),
+    ] {
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_herdr"))
+            .args(args)
+            .env("HERDR_SOCKET_PATH", "/nonexistent/herdr.sock")
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "herdr {}: {stderr}",
+            args.join(" ")
+        );
+        assert!(
+            stderr.contains(expected),
+            "herdr {}: {stderr}",
+            args.join(" ")
+        );
+        assert!(
+            !stderr.contains("Custom {"),
+            "herdr {}: {stderr}",
+            args.join(" ")
+        );
+        assert!(stderr.contains("usage: herdr agent read"), "{stderr}");
+    }
+}
+
+#[test]
+fn agent_commands_accept_flag_equals_value_form() {
+    for args in [
+        &[
+            "agent",
+            "read",
+            "reviewer",
+            "--lines=120",
+            "--source=detection",
+        ][..],
+        &[
+            "agent",
+            "wait",
+            "reviewer",
+            "--until=blocked",
+            "--timeout=5",
+        ][..],
+        &[
+            "agent",
+            "prompt",
+            "reviewer",
+            "work",
+            "--wait",
+            "--timeout=5",
+        ][..],
+        &[
+            "agent",
+            "start",
+            "reviewer",
+            "--kind=pi",
+            "--pane=w1:p1",
+            "--timeout=5000",
+            "--",
+            "--timeout=5",
+        ][..],
+    ] {
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_herdr"))
+            .args(args)
+            .env("HERDR_SOCKET_PATH", "/nonexistent/herdr.sock")
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_ne!(
+            output.status.code(),
+            Some(2),
+            "herdr {}: {stderr}",
+            args.join(" ")
+        );
+        assert!(
+            !stderr.contains("unknown option"),
+            "herdr {}: {stderr}",
+            args.join(" ")
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`herdr agent read <id> --lines abc` (and a bad `--source` or `--format`) propagated an `io::Error` up to `main`, so the user saw `Error: Custom { kind: Other, error: "invalid value for --lines: abc" }` and exit status 1. The agent skill documents syntax errors as exit 2 with a plain message, and `pane read` already behaves that way.

Separately, `agent read/wait/prompt/start` rejected the `--flag=value` form that `pane read` accepts.

## Change

- `agent read` parses through `parse_agent_read_args`, which maps parser failures to the message plus usage line and exit 2, mirroring `parse_pane_read_args`. The usage line also lists the `detection` source the command already accepted.
- `agent read`, `wait`, `prompt`, and `start` run `expand_equals_args`; `start` expands only the arguments before `--` so pass-through agent arguments keep their exact shape.
- One sentence in `docs/next` agent automation notes that `agent wait` and `agent prompt --wait` block indefinitely without `--timeout`.

## Tests

Two new cli tests: `agent_read_reports_usage_errors_with_exit_status_2` and `agent_commands_accept_flag_equals_value_form` (including `-- --timeout=5` pass-through on `start`). Both fail without the fix. `just ci` equivalent run locally: 3554 nextest tests pass, lint clean.