### PR TITLE
fix(pi): report blocked for native ui prompts and re-queue unacknowledged state reports

### DIFF
--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -109,6 +109,8 @@ Herdr writes the bundled extension to:
 
 If `PI_CODING_AGENT_DIR` is set, Herdr writes to `$PI_CODING_AGENT_DIR/extensions/herdr-agent-state.ts` instead. Herdr creates the extensions directory when the Pi agent directory already exists. Uninstall removes only that extension file.
 
+The extension reports `blocked` while Pi shows a native select, confirm, input, editor, or custom prompt. That requires Pi `0.84.4` or newer, which emits `ui_prompt_start` and `ui_prompt_end`; older Pi releases still report `idle` and `working` and can raise `blocked` only through a `herdr:blocked` bus event from another extension.
+
 ## OMP
 
 Install the OMP integration:

--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -315,6 +315,81 @@ test("Pi settlement preserves explicit blocked-state precedence", async () => {
   expect(requestStates(requests)).toEqual(["idle", "working", "blocked", "idle"]);
 });
 
+test("Pi reports blocked for native ui_prompt events with title or kind label", async () => {
+  const requests = await startRecordingServer("pi-ui-prompt");
+  const { handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  let idle = true;
+  const context = piContext(() => idle);
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+  idle = false;
+  handlers.get("agent_start")?.({}, context);
+  await waitFor(() => requestStates(requests).length === 2);
+
+  handlers.get("ui_prompt_start")?.({ kind: "select", title: "Pick a branch" }, context);
+  await waitFor(() => requestStates(requests).length === 3);
+  expect(requestStates(requests)).toEqual(["idle", "working", "blocked"]);
+  expect(requestMessages(requests)[2]).toBe("Pick a branch");
+
+  handlers.get("ui_prompt_end")?.({ kind: "select" }, context);
+  await waitFor(() => requestStates(requests).length === 4);
+  expect(requestStates(requests)[3]).toBe("working");
+
+  handlers.get("ui_prompt_start")?.({ kind: "confirm" }, context);
+  await waitFor(() => requestStates(requests).length === 5);
+  expect(requestStates(requests)[4]).toBe("blocked");
+  expect(requestMessages(requests)[4]).toBe("Confirm");
+
+  idle = true;
+  handlers.get("agent_settled")?.({}, context);
+  await Bun.sleep(25);
+  expect(requestStates(requests).length).toBe(5);
+
+  handlers.get("ui_prompt_end")?.({ kind: "confirm" }, context);
+  await waitFor(() => requestStates(requests).length === 6);
+  expect(requestStates(requests)[5]).toBe("idle");
+});
+
+test("Pi ignores ui_prompt events outside the root TUI session", async () => {
+  const requests = await startRecordingServer("pi-ui-prompt-rpc");
+  const { handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  const context = { ...piContext(() => true), mode: "rpc" };
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  handlers.get("ui_prompt_start")?.({ kind: "select" }, context);
+  handlers.get("ui_prompt_end")?.({ kind: "select" }, context);
+  await Bun.sleep(25);
+
+  expect(requests).toEqual([]);
+});
+
+test("Pi re-queues a state report that Herdr never acknowledged", async () => {
+  const { attemptedRequests, deliveredRequests } =
+    await startUnansweredConnectionsServer("pi-requeue", 2);
+  const { handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  let idle = false;
+  const context = piContext(() => idle);
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(deliveredRequests).length === 1, 5_000);
+  expect(requestStates(deliveredRequests)).toEqual(["working"]);
+
+  // Both socket attempts for the idle report go unanswered; the report must
+  // be retried after backoff rather than dropped.
+  idle = true;
+  handlers.get("agent_settled")?.({}, context);
+  await waitFor(() => requestStates(deliveredRequests).length === 2, 5_000);
+  expect(requestStates(deliveredRequests)).toEqual(["working", "idle"]);
+  expect(requestStates(attemptedRequests).filter((state) => state === "idle").length).toBe(3);
+});
+
 test("Pi reports the session replacement source", async () => {
   const requests = await startRecordingServer("pi-session-source");
   const { handlers, pi } = createExtensionHarness();
@@ -425,6 +500,46 @@ test("Pi waits for a replacement session report before publishing state", async 
     "pane.report_agent",
   ]);
 });
+
+async function startUnansweredConnectionsServer(name: string, unansweredAfterFirst: number) {
+  const recordingSocketPath = join(tmpdir(), `herdr-${name}-${process.pid}.sock`);
+  socketPath = recordingSocketPath;
+  await rm(recordingSocketPath, { force: true });
+
+  let connectionCount = 0;
+  const attemptedRequests: unknown[] = [];
+  const deliveredRequests: unknown[] = [];
+  const recordingServer = createServer((socket) => {
+    connectionCount += 1;
+    const connectionNumber = connectionCount;
+    let input = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      input += chunk;
+      const newline = input.indexOf("\n");
+      if (newline === -1) {
+        return;
+      }
+      const request = JSON.parse(input.slice(0, newline));
+      attemptedRequests.push(request);
+      // Answer the first connection, then leave the next N unanswered so the
+      // client exhausts both immediate attempts for one report.
+      if (connectionNumber > 1 && connectionNumber <= 1 + unansweredAfterFirst) {
+        return;
+      }
+      deliveredRequests.push(request);
+      socket.end("{}\n");
+    });
+  });
+  server = recordingServer;
+  await new Promise<void>((resolve, reject) => {
+    recordingServer.once("error", reject);
+    recordingServer.listen(recordingSocketPath, resolve);
+  });
+
+  configureIntegrationEnvironment(recordingSocketPath);
+  return { attemptedRequests, deliveredRequests };
+}
 
 async function startDroppedFirstResponseServer(name: string) {
   const recordingSocketPath = join(tmpdir(), `herdr-${name}-${process.pid}.sock`);
@@ -608,6 +723,12 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<voi
     await Bun.sleep(5);
   }
   expect(predicate()).toBe(true);
+}
+
+function requestMessages(requests: unknown[]): unknown[] {
+  return requests
+    .filter((request) => isRecord(request) && request.method === "pane.report_agent")
+    .map((request) => (isRecord(request) && isRecord(request.params) ? request.params.message : undefined));
 }
 
 function requestState(request: unknown): unknown {

--- a/src/integration/assets/pi/herdr-agent-state.ts
+++ b/src/integration/assets/pi/herdr-agent-state.ts
@@ -2,7 +2,7 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=pi
-// HERDR_INTEGRATION_VERSION=8
+// HERDR_INTEGRATION_VERSION=9
 // @ts-nocheck
 
 import net from "node:net";
@@ -46,11 +46,11 @@ function sendRequestAttempt(request: unknown, timeoutMs: number): Promise<boolea
   });
 }
 
-async function sendRequest(request: unknown): Promise<void> {
+async function sendRequest(request: unknown): Promise<boolean> {
   if (await sendRequestAttempt(request, 500)) {
-    return;
+    return true;
   }
-  await sendRequestAttempt(request, 1500);
+  return sendRequestAttempt(request, 1500);
 }
 
 type AgentState = "working" | "blocked" | "idle";
@@ -107,13 +107,13 @@ function currentSessionRef(): Record<string, unknown> | undefined {
   return undefined;
 }
 
-function reportSession(sessionStartSource?: string): Promise<void> {
+async function reportSession(sessionStartSource?: string): Promise<void> {
   const sessionRef = currentSessionRef();
   if (!sessionRef) {
-    return Promise.resolve();
+    return;
   }
 
-  return sendRequest({
+  await sendRequest({
     id: `${source}:session:${Date.now()}:${Math.random().toString(36).slice(2)}`,
     method: "pane.report_agent_session",
     params: {
@@ -127,7 +127,7 @@ function reportSession(sessionStartSource?: string): Promise<void> {
   });
 }
 
-function sendState(state: AgentState, message?: string, seq = nextReportSeq()): Promise<void> {
+function sendState(state: AgentState, message?: string, seq = nextReportSeq()): Promise<boolean> {
   return sendRequest({
     id: `${source}:${Date.now()}:${Math.random().toString(36).slice(2)}`,
     method: "pane.report_agent",
@@ -144,12 +144,33 @@ function sendState(state: AgentState, message?: string, seq = nextReportSeq()): 
 
 let sendInFlight = false;
 let queuedState: QueuedState | undefined;
+let retryDelayMs = 0;
+let wakeRetry: (() => void) | undefined;
+
+const RETRY_INITIAL_DELAY_MS = 1_000;
+const RETRY_MAX_DELAY_MS = 30_000;
 
 function queueState(state: AgentState, message?: string): void {
   queuedState = { state, message, seq: nextReportSeq() };
+  // A newer state supersedes any pending retry; wake the drain loop so it
+  // sends the latest state instead of waiting out the backoff.
+  wakeRetry?.();
   if (!sendInFlight) {
     void drainStateQueue();
   }
+}
+
+function retryPause(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(finish, delayMs);
+    timer.unref?.();
+    function finish() {
+      clearTimeout(timer);
+      wakeRetry = undefined;
+      resolve();
+    }
+    wakeRetry = finish;
+  });
 }
 
 async function drainStateQueue(): Promise<void> {
@@ -162,7 +183,20 @@ async function drainStateQueue(): Promise<void> {
     while (queuedState) {
       const next = queuedState;
       queuedState = undefined;
-      await sendState(next.state, next.message, next.seq);
+      if (await sendState(next.state, next.message, next.seq)) {
+        retryDelayMs = 0;
+        continue;
+      }
+      // Herdr did not acknowledge the report. Never drop it: a lost idle or
+      // blocked report would leave the pane on its previous state until the
+      // next agent_start, which can be hours for a pane waiting on the user.
+      // Re-queue unless a newer state already replaced it, then back off.
+      queuedState ??= next;
+      retryDelayMs =
+        retryDelayMs === 0
+          ? RETRY_INITIAL_DELAY_MS
+          : Math.min(retryDelayMs * 2, RETRY_MAX_DELAY_MS);
+      await retryPause(retryDelayMs);
     }
   } finally {
     sendInFlight = false;
@@ -170,6 +204,23 @@ async function drainStateQueue(): Promise<void> {
       void drainStateQueue();
     }
   }
+}
+
+const UI_PROMPT_KIND_LABELS: Record<string, string> = {
+  select: "Select",
+  confirm: "Confirm",
+  input: "Input",
+  editor: "Editor",
+  custom: "Custom prompt",
+};
+
+function uiPromptLabel(event: any): string {
+  const title = event?.title;
+  if (typeof title === "string" && title.trim().length > 0) {
+    return title;
+  }
+  const kind = event?.kind;
+  return (typeof kind === "string" && UI_PROMPT_KIND_LABELS[kind]) || "Prompt";
 }
 
 export default function (pi) {
@@ -204,22 +255,47 @@ export default function (pi) {
     queueState(next.state, next.message);
   }
 
+  function activateBlocked(message: string | undefined) {
+    blockedCount += 1;
+    blockedMessage = message;
+    publishState();
+  }
+
+  function deactivateBlocked() {
+    blockedCount = Math.max(0, blockedCount - 1);
+    if (blockedCount === 0) {
+      blockedMessage = undefined;
+    }
+    publishState();
+  }
+
   pi.events.on("herdr:blocked", (data) => {
     if (!rootSession) {
       return;
     }
     if (!data?.active) {
-      blockedCount = Math.max(0, blockedCount - 1);
-      if (blockedCount === 0) {
-        blockedMessage = undefined;
-      }
-      publishState();
+      deactivateBlocked();
       return;
     }
 
-    blockedCount += 1;
-    blockedMessage = data.label;
-    publishState();
+    activateBlocked(data.label);
+  });
+
+  // Pi >= 0.84.4 emits ui_prompt_start/ui_prompt_end around ctx.ui select,
+  // confirm, input, editor, and custom prompts. Older Pi never emits them, so
+  // these handlers are inert there and blocked stays opt-in via herdr:blocked.
+  pi.on("ui_prompt_start", (event) => {
+    if (!rootSession) {
+      return;
+    }
+    activateBlocked(uiPromptLabel(event));
+  });
+
+  pi.on("ui_prompt_end", () => {
+    if (!rootSession) {
+      return;
+    }
+    deactivateBlocked();
   });
 
   pi.on("session_start", async (event, ctx) => {

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use types::{IntegrationRecommendation, IntegrationStatus, Integration
 
 const PI_EXTENSION_INSTALL_NAME: &str = "herdr-agent-state.ts";
 const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
-const PI_INTEGRATION_VERSION: u32 = 8;
+const PI_INTEGRATION_VERSION: u32 = 9;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
 const OMP_INTEGRATION_VERSION: u32 = 9;

--- a/tests/cli/sessions.rs
+++ b/tests/cli/sessions.rs
@@ -293,7 +293,7 @@ fn integration_commands_run_locally_when_server_is_missing() {
         .unwrap();
     assert_eq!(integration_status.status.code(), Some(0));
     let status_stdout = String::from_utf8_lossy(&integration_status.stdout);
-    assert!(status_stdout.contains("pi: current (v8)"));
+    assert!(status_stdout.contains("pi: current (v9)"));
     assert!(status_stdout.contains("claude: not installed"));
 
     let integration_uninstall = Command::new(env!("CARGO_BIN_EXE_herdr"))


### PR DESCRIPTION
## Problem

The shipped Pi extension only enters `blocked` through a custom `herdr:blocked` bus event, and nothing herdr ships emits it. Every native Pi select, confirm, input or editor prompt therefore shows the pane as `working`. Pi 0.84.4 emits `ui_prompt_start` / `ui_prompt_end` for those prompts, and the OMP asset already maps its equivalent native events.

Separately, `sendRequest` gave up after two socket attempts without signalling failure while `drainStateQueue` had already cleared the queued state, so a lost `idle` after `working` left the pane on `working` until the next `agent_start`. Because herdr treats the extension as full-lifecycle authority and skips screen scans while it is active, that can persist for hours on a pane waiting for a human.

## Change

- Map `ui_prompt_start` to `blocked` (title, or a kind label such as Select/Confirm/Input) and `ui_prompt_end` back, gated on the root session like the existing handlers. Older Pi releases never emit these events, so the handlers are inert there. Asset and `PI_INTEGRATION_VERSION` bumped to 9.
- `sendRequest` returns delivery success; `drainStateQueue` re-queues a failed report unless a newer state superseded it and retries with 1s..30s backoff, woken early by any newer state.
- `docs/next` integrations page notes the Pi 0.84.4 requirement for prompt-blocked reporting.

## Tests

New cases in `src/integration/assets/herdr-agent-state.test.ts` cover prompt start/end, the older-Pi path, and re-queue on socket failure (30 bun tests pass). `tests/cli/sessions.rs` updated for v9. `just ci` equivalent run locally: 3552 nextest tests pass, lint clean.