### PR TITLE
test: make workspace id handle test independent of global counter

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1534,11 +1534,25 @@ mod tests {
         assert!(first.starts_with('w'));
         assert!(second.starts_with('w'));
         assert_ne!(first, second);
-        assert!(first.len() <= 3, "unexpectedly long workspace id: {first}");
+
+        // The counter is process-global, so other tests in the same binary may
+        // have advanced it. Assert on the encoding and ordering instead of on
+        // the absolute length of the handle.
+        let first_number = decode_public_number(&first[1..]).expect("first id decodes");
+        let second_number = decode_public_number(&second[1..]).expect("second id decodes");
         assert!(
-            second.len() <= 3,
-            "unexpectedly long workspace id: {second}"
+            second_number > first_number,
+            "workspace ids must be monotonic: {first} then {second}"
         );
+
+        for value in 1..=1056 {
+            let encoded = encode_public_number(value);
+            assert!(
+                encoded.len() <= 2,
+                "unexpectedly long public number {value}: {encoded}"
+            );
+        }
+        assert_eq!(encode_public_number(1057).len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`generated_workspace_ids_are_short_base32_handles` asserts an absolute handle length, but `generate_workspace_id` reads a process-global `NEXT_WORKSPACE_ID` counter. Once other tests in the same process have generated more than 1056 ids the handle becomes 4 characters and the test fails, so it passes alone and fails under a full `cargo test` run depending on scheduling.

## Change

The test now checks the `w` prefix, that both ids decode and the second is strictly greater than the first, and exercises `encode_public_number` directly for the length boundaries (1..=1056 yields at most 2 characters, 1057 yields 3). No production code changed.

## Tests

`just ci` equivalent run locally: 3552 nextest tests pass, lint clean.