### PR TITLE
fix: read detection snapshots row-wise instead of per-cell scrollback traversal

### DIFF
--- a/src/ghostty/mod.rs
+++ b/src/ghostty/mod.rs
@@ -1140,7 +1140,10 @@ impl Terminal {
             let Some(y) = u32::try_from(y).ok() else {
                 break;
             };
-            let mut grid_ref = self.grid_ref(ghostty_screen_point(0, y))?;
+            // Resolve at the widest column we will read: `pin` rejects a page left
+            // narrower than the terminal by an incomplete reflow, so this validates the
+            // whole row before we walk `x` across it in place.
+            let mut grid_ref = self.grid_ref(ghostty_screen_point(cols.saturating_sub(1), y))?;
             let (soft_wrapped, wrap_continuation) = grid_ref_wrap_state(&grid_ref)?;
             let mut cells = Vec::with_capacity(usize::from(cols));
             for x in 0..cols {

--- a/src/ghostty/mod.rs
+++ b/src/ghostty/mod.rs
@@ -1115,6 +1115,8 @@ impl Terminal {
         (result == ffi::GhosttyResult_GHOSTTY_SUCCESS).then_some(point.y as usize)
     }
 
+    /// Resolves one screen coordinate, which can traverse the whole scrollback;
+    /// read several cells with `screen_text_rows_range` instead (refs #2592).
     pub fn screen_cell(&self, x: u16, y: u32) -> Result<(CellWide, Vec<u32>), Error> {
         let grid_ref = self.grid_ref(ghostty_screen_point(x, y))?;
         let wide = grid_ref_wide(&grid_ref)?;

--- a/src/ghostty/mod.rs
+++ b/src/ghostty/mod.rs
@@ -438,6 +438,21 @@ pub enum CellWide {
     SpacerHead,
 }
 
+#[cfg(test)]
+std::thread_local! {
+    /// Counts `ghostty_terminal_grid_ref` resolutions; each one can traverse
+    /// scrollback through `PageList.pin` (refs #2592).
+    static SCREEN_COORDINATE_RESOLUTIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
+/// Returns and resets the number of screen-coordinate resolutions performed
+/// on this thread.
+#[cfg(test)]
+pub(crate) fn take_screen_coordinate_resolutions() -> usize {
+    SCREEN_COORDINATE_RESOLUTIONS.with(|count| count.replace(0))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ScreenTextCell {
     pub wide: CellWide,
@@ -1163,6 +1178,8 @@ impl Terminal {
     }
 
     fn grid_ref(&self, point: ffi::GhosttyPoint) -> Result<ffi::GhosttyGridRef, Error> {
+        #[cfg(test)]
+        SCREEN_COORDINATE_RESOLUTIONS.with(|count| count.set(count.get().saturating_add(1)));
         let mut grid_ref = ffi::GhosttyGridRef {
             size: mem::size_of::<ffi::GhosttyGridRef>(),
             ..Default::default()

--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -2683,13 +2683,20 @@ fn ghostty_recent_text_for_terminal(
     terminal: &crate::ghostty::Terminal,
     lines: usize,
 ) -> Result<String, crate::ghostty::Error> {
-    let Some((start, end, cols)) = ghostty_recent_read_range(terminal, lines)? else {
+    let Some((start, end, _cols)) = ghostty_recent_read_range(terminal, lines)? else {
         return Ok(String::new());
     };
-    let mut rows = Vec::with_capacity(end.saturating_sub(start).saturating_add(1));
-    for y in start..=end {
-        rows.push(ghostty_screen_row(terminal, cols, y as u32)?);
-    }
+    // Read whole rows: `screen_text_rows_range` resolves one grid reference
+    // per row and walks its cells in place. Per-cell `screen_cell()` calls
+    // resolved every coordinate from scratch, and each resolution can
+    // traverse the entire scrollback through `PageList.pin`, which burned a
+    // core inside the locked detection snapshot on panes with retained
+    // scrollback (refs #2592).
+    let mut rows: Vec<String> = terminal
+        .screen_text_rows_range(start, end.saturating_add(1))?
+        .iter()
+        .map(screen_text_row_to_string)
+        .collect();
     trim_trailing_blank_rows(&mut rows);
     Ok(recent_text_from_rows(&rows, lines))
 }
@@ -2764,30 +2771,25 @@ fn ghostty_extract_selection(
         .read_text_screen((start_col, start_row), (end_col, end_row), false)
 }
 
-fn ghostty_screen_row(
-    terminal: &crate::ghostty::Terminal,
-    cols: u16,
-    y: u32,
-) -> Result<String, crate::ghostty::Error> {
+fn screen_text_row_to_string(row: &crate::ghostty::ScreenTextRow) -> String {
     let mut line = String::new();
-    for x in 0..cols {
-        let (wide, graphemes) = terminal.screen_cell(x, y)?;
-        if wide == crate::ghostty::CellWide::SpacerTail {
+    for cell in &row.cells {
+        if cell.wide == crate::ghostty::CellWide::SpacerTail {
             continue;
         }
-        if graphemes.is_empty()
-            || graphemes.first().copied() == Some(crate::ghostty::KITTY_UNICODE_PLACEHOLDER)
+        if cell.graphemes.is_empty()
+            || cell.graphemes.first().copied() == Some(crate::ghostty::KITTY_UNICODE_PLACEHOLDER)
         {
             line.push(' ');
         } else {
-            for codepoint in graphemes {
+            for &codepoint in &cell.graphemes {
                 if let Some(ch) = char::from_u32(codepoint) {
                     line.push(ch);
                 }
             }
         }
     }
-    Ok(line.trim_end().to_string())
+    line.trim_end().to_string()
 }
 
 fn ghostty_line_from_cells(
@@ -5168,6 +5170,28 @@ mod tests {
 
         assert!(pane.visible_text().contains("000000"));
         assert_eq!(pane.detection_text(), bottom_snapshot);
+    }
+
+    #[test]
+    fn detection_snapshot_scrollback_scaling() {
+        let (tx, _rx) = mpsc::channel(4);
+        let mut terminal = crate::ghostty::Terminal::new(120, 40, 10_000_000).unwrap();
+        write_numbered_lines(&mut terminal, 20_000);
+        let scrollback_rows = terminal.scrollback_rows().unwrap();
+        assert!(scrollback_rows > 0, "test setup did not retain scrollback");
+        let pane = GhosttyPaneTerminal::new(terminal, tx).unwrap();
+
+        crate::ghostty::take_screen_coordinate_resolutions();
+        let started = Instant::now();
+        let snapshot = pane.detection_text();
+        let elapsed = started.elapsed();
+        let coordinate_resolutions = crate::ghostty::take_screen_coordinate_resolutions();
+
+        assert!(snapshot.contains("019999"));
+        assert!(
+            coordinate_resolutions <= 40,
+            "detection snapshot over {scrollback_rows} scrollback rows took {elapsed:?} and resolved {coordinate_resolutions} independent screen coordinates; expected at most one scrollback traversal per output row"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Issue

Long-running Herdr servers lock up or live-lock burning CPU: panes stop responding, `herdr server stop` and pane operations block, and recovery can require SIGKILL plus manual socket cleanup, losing work. Independent reports cover Linux 0.7.5 (many-thread allocator/futex convoy with `ghostty_recent_text` on the stacks) and macOS 0.8.2 (one worker pinned in `PageList.pin` reached through `detection_text` while another thread waits on the pane-terminal mutex).

refs #2592

## Problem

The agent-detection snapshot is algorithmically amplified inside a lock. `detection_text()` holds the terminal-core mutex for the whole bottom-buffer snapshot, and `ghostty_recent_text_for_terminal` built every row by calling `screen_cell()` for every column. Each `screen_cell()` call resolves its screen coordinate from scratch through libghostty-vt's `PageList.pin`, which starts at the first page and walks the page list to reach a bottom row — the vendored header explicitly warns this coordinate mode is unsuitable for render-loop-style access. With retained scrollback that makes each 300ms detection tick do rows × cols full-depth traversals under the mutex (measured on the unfixed base: a 120×40 pane over ~9.3k scrollback rows resolved 4800 independent coordinates per snapshot), matching the macOS profile directly.

## How did we fix it?

`ghostty_recent_text_for_terminal` now reads the snapshot with the existing row-batched accessor `screen_text_rows_range`, which resolves one grid reference per row and walks that row's cells in place — one page-list traversal per output row instead of one per cell. The per-row string conversion keeps the exact prior semantics (spacer-tail skip, empty/Kitty-placeholder cells as spaces, grapheme codepoints, per-row trailing-whitespace trim), so detection text output is unchanged and no manifest or detection behavior changes. The now-unused per-cell row reader is removed, and the per-cell accessor it used carries a note pointing multi-cell readers at the row-batched path. This also shortens how long the snapshot holds the terminal-core mutex, per the multiplicative-path guidance in AGENTS.md. `pane read` recent-text snapshots share the same path and benefit equally.

Routing detection through `screen_text_rows_range` also required fixing a latent out-of-bounds read in that accessor, which all of its existing callers (search highlighting, word motion, retained text buffers, screen snapshots) were exposed to. It resolved each row at column 0 and then mutated the grid reference across the full terminal width; an incomplete reflow can leave a page narrower than the terminal, which `PageList.pin` rejects, so the later cell accesses could index past the row. Resolving at the row's last column validates the whole row for the same cost, because `pin`'s expense is the page-list walk, not the bounds check.

## Scope notes, stated plainly

- **This does not reduce allocator pressure.** `grid_ref_graphemes` still allocates one `Vec<u32>` per non-blank cell, so the malloc/free call count per snapshot is unchanged. The musl mallocng convoy hypothesis in the original Linux report is untouched by this change; what is removed is the rows × cols page-list traversal that both reported stack profiles point at.
- **One behavior change beyond the identical-text contract.** On a page left narrower than the terminal by an incomplete reflow, the snapshot now fails the whole range instead of reading out of bounds, so `detection_text()` returns an empty string for that tick rather than garbage. Erroring is the correct outcome over an out-of-bounds read, but it is a change and it is silent.
- **The reported multi-day full wedge was not live-reproduced**; triage could not rule out extreme-but-finite work versus page-list fragmentation or corruption. If a wedge report recurs on a build with this fix, the remaining alternatives deserve a fresh look.
- **Possible follow-up, deliberately not done here.** Detection reads exactly `rows` lines, which is precisely the active area. `pin` on screen coordinates walks forward from the top of scrollback, whereas the active-area top-left is found by walking backward from the last page and is independent of scrollback depth. Reading detection through active coordinates would remove the remaining scrollback dependence, but it changes the coordinate space of an accessor shared with search and word motion, so it is out of scope for this fix.

## Verification

- Characterization test `detection_snapshot_scrollback_scaling` (from the triage reproduction, its instrumentation moved to the real resolution point `Terminal::grid_ref`): writes 20,000 lines into a 120×40 terminal with retained scrollback, takes one detection snapshot, and asserts at most one coordinate resolution per output row. Restoring the per-cell path fails it with `detection snapshot over 9269 scrollback rows took 2.064667ms and resolved 4800 independent screen coordinates`; with the fix it passes, and the snapshot content assertion (`019999` visible) confirms unchanged output.
- The full `pane::terminal` and `ghostty` suites (168 tests) pass, including all existing detection-text, recent-text, wide-character/spacer, trim, and selection semantics tests — establishing the row-batched path produces the same text as the per-cell path.
- Rebased onto current `origin/master`. Local `just ci 'not binary(live_handoff)'` green (3371 passed), plus `just windows-lint` and the 98 maintenance script tests. The excluded `live_handoff` binary has two pre-existing failures on this host (`live_handoff_keeps_agent_started_pane_after_agent_exits`, `live_handoff_keeps_unmanaged_agent_name_bound_to_saved_session`); both fail identically on the untouched base `d2cb0961`, and the binary is already excluded on macOS CI.
