### PR TITLE
fix(server): transfer handoff descriptors in batches

### DIFF
--- a/src/server/handoff.rs
+++ b/src/server/handoff.rs
@@ -22,8 +22,11 @@ const HANDOFF_VERSION: u32 = 1;
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
 #[cfg(unix)]
 const OWNED_ACK_TIMEOUT: Duration = Duration::from_millis(500);
+// Descriptors are transferred in batches of this size. A single SCM_RIGHTS
+// control message caps out at 253 descriptors on Linux and 254 on macOS, so the
+// batch stays well below both limits and the number of panes stays unbounded.
 #[cfg(unix)]
-pub(crate) const MAX_FDS_PER_HANDOFF: usize = 64;
+const FDS_PER_MESSAGE: usize = 64;
 #[cfg(unix)]
 pub(crate) const MAX_REPLAY_BYTES_PER_PANE: usize = 8 * 1024;
 #[cfg(unix)]
@@ -174,12 +177,6 @@ pub(crate) fn accept_and_validate_on(
 
 #[cfg(unix)]
 pub(crate) fn send_fds_and_wait_restored(stream: &mut UnixStream, fds: &[RawFd]) -> io::Result<()> {
-    if fds.len() > MAX_FDS_PER_HANDOFF {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("handoff supports at most {MAX_FDS_PER_HANDOFF} pane file descriptors at once"),
-        ));
-    }
     send_fds(stream, fds)?;
 
     stream.set_read_timeout(Some(READY_TIMEOUT))?;
@@ -382,6 +379,14 @@ fn read_line_unbuffered(stream: &mut UnixStream) -> io::Result<String> {
 
 #[cfg(unix)]
 fn send_fds(stream: &UnixStream, fds: &[RawFd]) -> io::Result<()> {
+    for batch in fds.chunks(FDS_PER_MESSAGE) {
+        send_fd_batch(stream, batch)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn send_fd_batch(stream: &UnixStream, fds: &[RawFd]) -> io::Result<()> {
     if fds.is_empty() {
         return Ok(());
     }
@@ -415,16 +420,47 @@ fn send_fds(stream: &UnixStream, fds: &[RawFd]) -> io::Result<()> {
 }
 
 #[cfg(unix)]
-fn recv_fds(stream: &UnixStream, expected: usize) -> io::Result<Vec<RawFd>> {
-    if expected == 0 {
-        return Ok(Vec::new());
+fn close_raw_fds(fds: &[RawFd]) {
+    for fd in fds {
+        let _ = unsafe { libc::close(*fd) };
     }
+}
+
+#[cfg(unix)]
+fn recv_fds(stream: &UnixStream, expected: usize) -> io::Result<Vec<RawFd>> {
+    let mut out: Vec<RawFd> = Vec::with_capacity(expected);
+    while out.len() < expected {
+        let wanted = (expected - out.len()).min(FDS_PER_MESSAGE);
+        let batch = match recv_fd_batch(stream, wanted) {
+            Ok(batch) => batch,
+            Err(err) => {
+                close_raw_fds(&out);
+                return Err(err);
+            }
+        };
+        if batch.is_empty() {
+            let received = out.len();
+            close_raw_fds(&out);
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "handoff stream closed after {received} of {expected} pane file descriptors"
+                ),
+            ));
+        }
+        out.extend(batch);
+    }
+    Ok(out)
+}
+
+#[cfg(unix)]
+fn recv_fd_batch(stream: &UnixStream, wanted: usize) -> io::Result<Vec<RawFd>> {
     let mut byte = [0u8; 1];
     let mut iov = [libc::iovec {
         iov_base: byte.as_mut_ptr() as *mut libc::c_void,
         iov_len: byte.len(),
     }];
-    let fd_bytes = expected * std::mem::size_of::<RawFd>();
+    let fd_bytes = wanted * std::mem::size_of::<RawFd>();
     let mut control = vec![0u8; unsafe { libc::CMSG_SPACE(fd_bytes as u32) as usize }];
     let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
     msg.msg_iov = iov.as_mut_ptr();
@@ -436,33 +472,50 @@ fn recv_fds(stream: &UnixStream, expected: usize) -> io::Result<Vec<RawFd>> {
     if read < 0 {
         return Err(io::Error::last_os_error());
     }
-    if msg.msg_flags & libc::MSG_CTRUNC != 0 {
-        return Err(io::Error::other("handoff fd control message was truncated"));
-    }
 
     let mut out = Vec::new();
     unsafe {
-        let cmsg = libc::CMSG_FIRSTHDR(&msg);
-        if cmsg.is_null()
-            || (*cmsg).cmsg_level != libc::SOL_SOCKET
-            || (*cmsg).cmsg_type != libc::SCM_RIGHTS
-        {
-            return Err(io::Error::other("handoff fd message missing SCM_RIGHTS"));
-        }
-        let data_len = ((*cmsg).cmsg_len as usize).saturating_sub(libc::CMSG_LEN(0) as usize);
-        let count = data_len / std::mem::size_of::<RawFd>();
-        let data = libc::CMSG_DATA(cmsg) as *const RawFd;
-        for idx in 0..count {
-            out.push(*data.add(idx));
+        let control_end = control.as_ptr() as usize + msg.msg_controllen as usize;
+        let mut cmsg = libc::CMSG_FIRSTHDR(&msg);
+        while !cmsg.is_null() {
+            if (*cmsg).cmsg_level == libc::SOL_SOCKET && (*cmsg).cmsg_type == libc::SCM_RIGHTS {
+                let data = libc::CMSG_DATA(cmsg);
+                // Bound the payload by both the header's own length and the
+                // bytes the kernel wrote into `control`, so the read below can
+                // never run past the buffer.
+                let available = control_end.saturating_sub(data as usize);
+                let data_len = ((*cmsg).cmsg_len as usize)
+                    .saturating_sub(libc::CMSG_LEN(0) as usize)
+                    .min(available);
+                let count = data_len / std::mem::size_of::<RawFd>();
+                let data = data as *const RawFd;
+                for idx in 0..count {
+                    out.push(*data.add(idx));
+                }
+            }
+            cmsg = libc::CMSG_NXTHDR(&msg, cmsg);
         }
     }
-    if out.len() != expected {
-        for fd in out {
-            let _ = unsafe { libc::close(fd) };
-        }
+
+    // Truncation means the kernel closed the descriptors that did not fit, so
+    // the batch is unrecoverable rather than merely short.
+    if msg.msg_flags & libc::MSG_CTRUNC != 0 {
+        close_raw_fds(&out);
+        return Err(io::Error::other("handoff fd control message was truncated"));
+    }
+    if read == 0 {
+        close_raw_fds(&out);
+        return Ok(Vec::new());
+    }
+    if out.len() > wanted {
+        let received = out.len();
+        close_raw_fds(&out);
         return Err(io::Error::other(format!(
-            "expected {expected} handoff fds, received fewer"
+            "handoff fd message carried {received} descriptors, expected at most {wanted}"
         )));
+    }
+    if out.is_empty() {
+        return Err(io::Error::other("handoff fd message missing SCM_RIGHTS"));
     }
     Ok(out)
 }

--- a/src/server/headless/lifecycle.rs
+++ b/src/server/headless/lifecycle.rs
@@ -53,16 +53,6 @@ impl HeadlessServer {
                 }
             }
         }
-        if pane_by_terminal.len() > crate::server::handoff::MAX_FDS_PER_HANDOFF {
-            let _ = std::fs::remove_file(&socket_path);
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "live handoff supports at most {} panes in one update; close panes or restart herdr normally",
-                    crate::server::handoff::MAX_FDS_PER_HANDOFF
-                ),
-            ));
-        }
 
         self.handoff_in_progress = true;
         self.disconnect_all_clients_for_handoff();

--- a/tests/live_handoff.rs
+++ b/tests/live_handoff.rs
@@ -702,6 +702,79 @@ fn live_handoff_unknown_pane_exit_preserves_session_on_shutdown() {
     cleanup_test_base(&base);
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn live_handoff_carries_more_panes_than_one_scm_rights_message() {
+    const PANES: usize = 70;
+
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+
+    let spawned = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    register_runtime_dir(&runtime_dir);
+    let server_pid = spawned
+        .child
+        .process_id()
+        .expect("test server should expose pid");
+
+    let created = request(
+        &api_socket,
+        serde_json::json!({
+            "id": "test:workspace:create",
+            "method": "workspace.create",
+            "params": {"cwd": "/tmp", "focus": true}
+        }),
+    );
+    let workspace_id = created["result"]["workspace"]["workspace_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // One pane per tab keeps the layout shallow, so this exercises the fd
+    // transfer rather than the depth of a single split tree.
+    for index in 1..PANES {
+        assert_ok(request(
+            &api_socket,
+            serde_json::json!({
+                "id": format!("test:tab:create-{index}"),
+                "method": "tab.create",
+                "params": {"workspace_id": workspace_id, "focus": false}
+            }),
+        ));
+    }
+    wait_for_server_ptmx_fd_count(server_pid, PANES, Duration::from_secs(60));
+
+    assert_ok(request(
+        &api_socket,
+        serde_json::json!({"id":"test:handoff","method":"server.live_handoff","params":{}}),
+    ));
+    let replacement_pid =
+        wait_for_replacement_server_pid(&runtime_dir, server_pid, Duration::from_secs(30));
+    wait_for_api(&api_socket, Duration::from_secs(30));
+    wait_for_server_ptmx_fd_count(replacement_pid, PANES, Duration::from_secs(30));
+
+    let panes = request(
+        &api_socket,
+        serde_json::json!({"id":"test:pane:list","method":"pane.list","params":{}}),
+    );
+    assert_eq!(
+        panes["result"]["panes"].as_array().map(Vec::len),
+        Some(PANES),
+        "replacement server should report every pane after handoff"
+    );
+
+    let _ = request(
+        &api_socket,
+        serde_json::json!({"id":"test:stop","method":"server.stop","params":{}}),
+    );
+    drop(spawned);
+    cleanup_test_base(&base);
+}
+
 #[test]
 fn live_handoff_preserves_named_session_socket_paths() {
     let _lock = test_lock();


### PR DESCRIPTION
## Problem

`herdr server live-handoff` refuses a session with 65 or more panes:

    live handoff supports at most 64 panes in one update; close panes or
    restart herdr normally

The session then stays on the old build while the CLI moves ahead, and the
only supported way out is a normal restart, which ends the shell and agent
processes in every pane.

#3393 reports the same limit from `herdr update --handoff`, where the rejected
handoff additionally leaves the freshly installed CLI protocol-locked out of
the server that is still running. This change covers only the third option
listed there, chunking the transfer; the install ordering and the protocol
check on recovery commands are untouched, so it does not close that issue on
its own.

## Cause

`send_fds` packs every pane's pty master descriptor into a single
`SCM_RIGHTS` control message and calls `sendmsg` once. `recv_fds` mirrors
that with one `recvmsg`. A single control message cannot carry an unbounded
number of descriptors, so `MAX_FDS_PER_HANDOFF = 64` guards the send, once in
`send_fds_and_wait_restored` and once in `perform_live_handoff` before any
work starts.

## Fix

- send the descriptors in batches of `FDS_PER_MESSAGE` (64)
- drop both pane-count guards
- the receive side asks for `min(remaining, 64)` descriptors per `recvmsg`
  and accumulates across calls until `expected` have arrived, iterates every
  `cmsghdr` with `CMSG_NXTHDR` and bounds each `SCM_RIGHTS` payload by
  `msg_controllen` before reading it, rejects a batch that carries more
  descriptors than it asked for, treats `MSG_CTRUNC` as unrecoverable because
  the kernel has already closed the descriptors that did not fit, and closes
  the descriptors it already holds on any failure

A session of 64 panes or fewer still produces exactly one batch, so its wire
representation is unchanged and old and new implementations stay compatible
across the range that works today. A new sender handing more than 64 panes to
an old receiver (a downgrade) still fails, but that pane count is already
unsupported. `HANDOFF_VERSION` stays at 1; raising it would refuse even the
64-and-under handoffs that currently succeed.

The sending side of a handoff is always the previously running binary, so the
first update onto a build that carries this change is still refused by the old
server's guard; batching takes effect from the next handoff after that.

64 is kept as the batch width rather than raised: a single `SCM_RIGHTS`
message accepts at most 253 descriptors on Linux and 254 on macOS, measured
with a socketpair program, and 64 leaves room under both.

I'm happy to bump `HANDOFF_VERSION` or widen the batch if you'd rather.

## Verification

Measured on base e7d82207.

- macOS, end-to-end against a real server with an isolated config, runtime
  and socket path:

  | build | panes | `server live-handoff` | panes after |
  |---|---|---|---|
  | `origin/master` | 65 | fails: `at most 64 panes` | — |
  | `origin/master` | 71 | fails: `at most 64 panes` | — |
  | this branch | 65 | completes | 65 |
  | this branch | 66 | completes | 66 |
  | this branch | 71 | completes | 71 |
  | this branch | 131 | completes | 131 |

  131 panes splits into three batches (64 + 64 + 3), so this covers more than
  the two-batch case. The script creates one pane per tab over the socket API
  and then runs `herdr server live-handoff --import-exe` against the same
  binary; "panes after" is `herdr pane list` on the replacement server.
- Linux aarch64: `cargo nextest run --locked -E 'binary(live_handoff)'`; the
  new test passes, and 5/5 when repeated alongside
  `live_server_holds_one_pty_master_fd_per_pane`.

New test `live_handoff_carries_more_panes_than_one_scm_rights_message` builds
a 70-pane session, hands off, and asserts the replacement server holds 70 pty
master descriptors and lists 70 panes.

refs #3393

