### PR TITLE
fix: increase wait timeout for status command descendant in test

### DIFF
--- a/src/app/tab_bar_status.rs
+++ b/src/app/tab_bar_status.rs
@@ -685,7 +685,7 @@ mod tests {
             " ",
         );
         app.handle_tab_bar_status_tasks(std::time::Instant::now());
-        for _ in 0..50 {
+        for _ in 0..500 {
             if descendant_started.exists() {
                 break;
             }


### PR DESCRIPTION
## Summary
Fixes intermittent test failure in `app::tab_bar_status::tests::reload_aborts_an_in_flight_command_task_and_its_descendants`.

Under heavy machine load (e.g. running the full test suite in parallel across many cores), spawning the shell process and creating the canary file can exceed the previous 500ms timeout window. Increasing the polling iterations gives up to 5s of headroom under high CPU contention while retaining immediate exit on the fast path.

refs #3424