### PR TITLE
fix: make test-one work on Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,8 +9,14 @@ test:
     just plugin-marketplace-test
 
 # Run one nextest filter, e.g. `just test-one codex_stale_working`
+[unix]
 test-one filter:
     cargo nextest run --locked "{{filter}}" --status-level fail --final-status-level fail --failure-output final --success-output never
+
+[script("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File")]
+[windows]
+test-one filter:
+    cargo nextest run --locked --bin herdr "{{filter}}" --status-level fail --final-status-level fail --failure-output final --success-output never
 
 # Enforce deterministic UI hot-path architecture boundaries
 ui-hot-path-architecture-test:


### PR DESCRIPTION
## Problem

On native Windows, `just test-one <filter>` uses Just's default `sh` runner and fails before Cargo starts when `sh` is not installed. Running the underlying unscoped nextest command also compiles unrelated Unix-only integration-test binaries.

## Fix

- Keep the existing Unix recipe unchanged
- Add a native PowerShell recipe on Windows
- Restrict the Windows run to the supported `herdr` unit-test binary

## Validation

- Before: `just test-one identify_agent_in_job` fails with `just could not find the shell sh`
- After: the same command runs 24 matching tests from one binary; all pass
- `just check` passes: formatting, Windows Clippy, 168 Windows tests, 25 transport tests, the exact native-input test, and the Windows build