### PR TITLE
test: unset inherited herdr pane env in spawned test servers

### DIFF
--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -146,6 +146,7 @@ fn spawn_herdr_with_options(
     cmd.env_remove("HERDR_CLIENT_SOCKET_PATH");
     cmd.env("SHELL", shell);
     cmd.env_remove("HERDR_ENV");
+    cmd.env_remove("HERDR_STARTUP_CWD");
     if let Some(path) = path_override {
         cmd.env("PATH", path);
     }

--- a/tests/client_mode.rs
+++ b/tests/client_mode.rs
@@ -206,6 +206,8 @@ fn spawn_server_with_config(
     cmd.env_remove("HERDR_CLIENT_SOCKET_PATH");
     cmd.env("SHELL", "/bin/sh");
     cmd.env_remove("HERDR_ENV");
+    cmd.env_remove("HERDR_STARTUP_CWD");
+    cmd.env_remove("HERDR_SESSION");
 
     let child = pair.slave.spawn_command(cmd).unwrap();
     register_spawned_herdr_pid(child.process_id());

--- a/tests/cross_area.rs
+++ b/tests/cross_area.rs
@@ -122,6 +122,7 @@ fn spawn_server_with_path(
     cmd.env_remove("HERDR_CLIENT_SOCKET_PATH");
     cmd.env("SHELL", "/bin/sh");
     cmd.env_remove("HERDR_ENV");
+    cmd.env_remove("HERDR_STARTUP_CWD");
     if let Some(path) = path_override {
         cmd.env("PATH", path);
     }

--- a/tests/live_handoff.rs
+++ b/tests/live_handoff.rs
@@ -83,6 +83,7 @@ fn spawn_server_with_env(
         runtime_dir.join("herdr-client.sock"),
     );
     cmd.env("SHELL", "/bin/sh");
+    cmd.env_remove("HERDR_STARTUP_CWD");
     for (key, value) in extra_env {
         cmd.env(key, value);
     }

--- a/tests/multi_client.rs
+++ b/tests/multi_client.rs
@@ -129,6 +129,8 @@ fn spawn_server(config_home: &Path, runtime_dir: &Path, api_socket_path: &Path) 
     cmd.env_remove("HERDR_CLIENT_SOCKET_PATH");
     cmd.env("SHELL", "/bin/sh");
     cmd.env_remove("HERDR_ENV");
+    cmd.env_remove("HERDR_STARTUP_CWD");
+    cmd.env_remove("HERDR_SESSION");
 
     let child = pair.slave.spawn_command(cmd).unwrap();
     register_spawned_herdr_pid(child.process_id());


### PR DESCRIPTION
## Summary

Most of the integration-test helpers that spawn a `herdr server` binary cleared only `HERDR_ENV` and `HERDR_CLIENT_SOCKET_PATH`, and one cleared nothing. Unset `HERDR_STARTUP_CWD` in the five helpers the six failing tests use, and `HERDR_SESSION` in the two of them (`client_mode`, `multi_client`) whose tests read the server's data-directory paths. Test-only change; production behavior is untouched.

When the suite runs from a shell inside a herdr pane, the spawned test servers inherit the pane's herdr variables and six tests fail (refs #3440). `HERDR_STARTUP_CWD` makes a server with an empty config home seed a startup workspace before the test creates its own, which shifts pane counts and `pane.list` ordering. `HERDR_SESSION` moves the server's data directory to `sessions/<name>/`, away from the `session.json` fixture and the log path the tests read. `scripts/release_perf_case.sh` already unsets both before launching herdr, and three helpers already unset `HERDR_SESSION`; this applies the same cleanup to the helpers the six failing tests use.

## Validation

- master 4dd9aa5e, from a shell inside a herdr pane (both variables present): the six tests end `0 passed, 6 failed` (two runs); with this change, `6 passed`.
- Same checkout, unpatched, prefixed with `env -u HERDR_STARTUP_CWD -u HERDR_SESSION`: `6 passed` — the failures track the two variables.
- `just ci 'all() - test(=live_handoff_keeps_unmanaged_agent_name_bound_to_saved_session)'` from inside the pane, with this change applied: clippy clean, `3388 tests run: 3388 passed (5 leaky), 2 skipped`, and the follow-up test scripts in the recipe all reported 0 fail. The excluded test also fails on this machine with all herdr variables unset, so it is unrelated to this change.
