### PR TITLE
fix: anchor copy mode during streaming output

### DIFF
--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -2650,6 +2650,8 @@ mod tests {
             cursor_row: 0,
             cursor_col: 0,
             entry_offset_from_bottom: 0,
+            last_max_offset_from_bottom: 0,
+            last_offset_from_bottom: 0,
             selection: None,
             search: Default::default(),
         });
@@ -3371,6 +3373,8 @@ mod tests {
             cursor_row: 0,
             cursor_col: 0,
             entry_offset_from_bottom: 0,
+            last_max_offset_from_bottom: 0,
+            last_offset_from_bottom: 0,
             selection: None,
             search: Default::default(),
         });

--- a/src/app/api/plugins/mod.rs
+++ b/src/app/api/plugins/mod.rs
@@ -1443,6 +1443,8 @@ platforms = ["linux", "macos"]
             cursor_row: 2,
             cursor_col: 3,
             entry_offset_from_bottom: 4,
+            last_max_offset_from_bottom: 0,
+            last_offset_from_bottom: 4,
             selection: None,
             search: crate::app::state::CopyModeSearchState::default(),
         };

--- a/src/app/input/copy_mode.rs
+++ b/src/app/input/copy_mode.rs
@@ -56,9 +56,11 @@ impl AppState {
                 )
             })
             .unwrap_or_else(|| (info.inner_rect.height.saturating_sub(1), 0));
-        let entry_offset_from_bottom = self
+        let (entry_offset_from_bottom, last_max_offset_from_bottom) = self
             .pane_scroll_metrics(terminal_runtimes, pane_id)
-            .map_or(0, |metrics| metrics.offset_from_bottom);
+            .map_or((0, 0), |metrics| {
+                (metrics.offset_from_bottom, metrics.max_offset_from_bottom)
+            });
 
         self.clear_selection();
         self.copy_mode = Some(CopyModeState {
@@ -66,6 +68,8 @@ impl AppState {
             cursor_row: cursor.0.min(info.inner_rect.height.saturating_sub(1)),
             cursor_col: cursor.1.min(info.inner_rect.width.saturating_sub(1)),
             entry_offset_from_bottom,
+            last_max_offset_from_bottom,
+            last_offset_from_bottom: entry_offset_from_bottom,
             selection: None,
             search: crate::app::state::CopyModeSearchState {
                 geometry: Some((info.inner_rect.width, info.inner_rect.height)),
@@ -1813,6 +1817,36 @@ mod tests {
         let visible_before = runtime.visible_text();
         runtime.test_process_pty_bytes(b"more output\r\n");
         assert_eq!(runtime.visible_text(), visible_before);
+    }
+
+    #[tokio::test]
+    async fn copy_mode_anchors_live_bottom_when_output_arrives() {
+        let bytes = numbered_lines_bytes(32);
+        let (mut app, pane_id) = app_with_copy_scrollback(&bytes);
+        app.state.enter_copy_mode(&app.terminal_runtimes);
+        app.state.hide_tab_bar_when_single_tab = true;
+        let top_before = {
+            let top_before = copy_mode_viewport_top_row(&app, pane_id);
+            let runtime = app
+                .state
+                .runtime_for_pane_in_workspace(&app.terminal_runtimes, 0, pane_id)
+                .expect("runtime");
+            runtime.test_process_pty_bytes(b"live output\r\n");
+            top_before
+        };
+        crate::ui::compute_view_with_runtime_registry(
+            &mut app.state,
+            &app.terminal_runtimes,
+            Rect::new(0, 0, 46, 7),
+        );
+
+        let runtime = app
+            .state
+            .runtime_for_pane_in_workspace(&app.terminal_runtimes, 0, pane_id)
+            .expect("runtime");
+        assert_eq!(copy_mode_viewport_top_row(&app, pane_id), top_before);
+        assert!(runtime.visible_text().contains("live output"));
+        assert!(app.state.copy_mode.is_some());
     }
 
     #[tokio::test]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1037,6 +1037,8 @@ pub(crate) struct CopyModeState {
     pub cursor_row: u16,
     pub cursor_col: u16,
     pub entry_offset_from_bottom: usize,
+    pub last_max_offset_from_bottom: usize,
+    pub last_offset_from_bottom: usize,
     pub selection: Option<CopyModeSelection>,
     pub search: CopyModeSearchState,
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -136,6 +136,46 @@ pub fn compute_view_with_cell_size(
     compute_view_internal(app, terminal_runtimes, area, true, cell_size);
 }
 
+fn preserve_copy_mode_view(app: &mut AppState, terminal_runtimes: &TerminalRuntimeRegistry) {
+    let Some(ws_idx) = app.active else {
+        return;
+    };
+    let Some(copy_mode) = app.copy_mode.as_ref() else {
+        return;
+    };
+    let pane_id = copy_mode.pane_id;
+    let Some(metrics) = app.pane_scroll_metrics(terminal_runtimes, pane_id) else {
+        return;
+    };
+    let previous_top = copy_mode
+        .last_max_offset_from_bottom
+        .saturating_sub(copy_mode.last_offset_from_bottom);
+    let output_moved_viewport = metrics.max_offset_from_bottom
+        > copy_mode.last_max_offset_from_bottom
+        && metrics.offset_from_bottom == copy_mode.last_offset_from_bottom;
+    let top = if output_moved_viewport {
+        previous_top
+    } else {
+        metrics
+            .max_offset_from_bottom
+            .saturating_sub(metrics.offset_from_bottom)
+    };
+    let desired_offset = metrics.max_offset_from_bottom.saturating_sub(top);
+    if desired_offset != metrics.offset_from_bottom {
+        if let Some(runtime) = app.runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, pane_id)
+        {
+            runtime.set_scroll_offset_from_bottom(desired_offset);
+        }
+    }
+    let Some(updated_metrics) = app.pane_scroll_metrics(terminal_runtimes, pane_id) else {
+        return;
+    };
+    if let Some(copy_mode) = app.copy_mode.as_mut() {
+        copy_mode.last_max_offset_from_bottom = updated_metrics.max_offset_from_bottom;
+        copy_mode.last_offset_from_bottom = updated_metrics.offset_from_bottom;
+    }
+}
+
 /// Compute view geometry for a client-sized render without resizing pane runtimes.
 ///
 /// This is used by the headless server when a non-foreground client needs its
@@ -219,6 +259,7 @@ fn compute_view_internal(
     resize_panes: bool,
     cell_size: crate::kitty_graphics::HostCellSize,
 ) {
+    preserve_copy_mode_view(app, terminal_runtimes);
     if is_mobile_width(area, app.mobile_width_threshold) {
         compute_mobile_view(app, terminal_runtimes, area, resize_panes, cell_size);
         return;


### PR DESCRIPTION
## Summary
When copy mode is active and a pane's child process streams new output, the viewport follows live bottom: the scrollback maximum grows while `offset_from_bottom` stays 0, so the rows the user was reading scroll away. The copy-mode overlay stays up (so this is not a mode exit), but the anchor is lost - tmux semantics expect copy mode to hold position until the user exits.

## Reproduction (herdr 0.8.2)
1. Start a pane running `seq 1 40`; enter copy mode; scroll up.
2. Stream more output into the pane (e.g. `seq 41 52`).
3. `pane get <pane>` before: `max_offset_from_bottom=22, offset_from_bottom=0`; after: `max_offset_from_bottom=36, offset_from_bottom=0` - the visible rows jumped to the new tail while the copy-mode overlay remained.

## Root cause
- `src/app/input/copy_mode.rs` records the entry scroll offset and restores it only on exit; nothing maintains an anchor while copy mode is active.
- The PTY read path (`src/pane.rs`, `src/pane/terminal.rs`) grows `max_offset_from_bottom` and requests renders independently of copy-mode input state; at live bottom `offset_from_bottom` stays 0, so the viewport tracks the new tail.

## Fix
1. Snapshot the last observed maximum scrollback and offset in `CopyModeState`.
2. Reconcile at the start of view computation: when the maximum grows while the offset is unchanged (live-follow output), set the offset so the absolute viewport top is preserved.
3. Treat user scrolls and terminal-managed viewport movement as the new anchor.
4. Exit-time restoration of the entry offset is unchanged.
5. Regression test: `copy_mode_anchors_live_bottom_when_output_arrives`.

Verified on a disposable session: with the patch, streaming while in copy mode holds the visible rows; exiting still returns to live bottom.