### PR TITLE
feat: pane mark via context menu (Edit mark / Clear mark)

### DIFF
--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -100,7 +100,7 @@ impl App {
                 Mode::ReleaseNotes => self.handle_release_notes_key(key_event),
                 Mode::ProductAnnouncement => self.handle_product_announcement_key(key_event),
                 Mode::Prefix | Mode::Navigate | Mode::Copy => unreachable!(),
-                Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane => {
+                Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane | Mode::EditPaneMark => {
                     self.handle_rename_key_via_api(key_event)
                 }
                 Mode::NewLinkedWorktree => self.handle_worktree_create_key(key_event),
@@ -209,7 +209,7 @@ impl App {
 
     pub(crate) fn paste_into_active_text_input(&mut self, text: &str) -> bool {
         match self.state.mode {
-            Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane => {
+            Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane | Mode::EditPaneMark => {
                 insert_rename_input_text(&mut self.state, text);
                 true
             }
@@ -733,9 +733,11 @@ pub(crate) fn is_modal_paste_shortcut(key: &KeyEvent) -> bool {
 
 pub(crate) fn modal_paste_target_active(state: &AppState) -> bool {
     match state.mode {
-        Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane | Mode::NewLinkedWorktree => {
-            true
-        }
+        Mode::RenameWorkspace
+        | Mode::RenameTab
+        | Mode::RenamePane
+        | Mode::EditPaneMark
+        | Mode::NewLinkedWorktree => true,
         Mode::OpenExistingWorktree => state
             .worktree_open
             .as_ref()

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -418,11 +418,33 @@ pub(super) fn open_rename_pane(state: &mut AppState, pane_id: crate::layout::Pan
     state.requested_new_tab_name = None;
     state.pending_workspace_create_cwd = None;
     state.rename_pane_target = Some(pane_id);
+    state.mark_pane_target = None;
     state.name_input = terminal
         .and_then(|t| t.manual_label.clone())
         .unwrap_or_default();
     state.name_input_replace_on_type = terminal.and_then(|t| t.manual_label.as_ref()).is_none();
     state.mode = Mode::RenamePane;
+}
+
+pub(super) fn open_edit_mark(state: &mut AppState, pane_id: crate::layout::PaneId) {
+    let Some(ws) = state.active.and_then(|i| state.workspaces.get(i)) else {
+        return;
+    };
+    let Some(pane) = ws.pane_state(pane_id) else {
+        return;
+    };
+    let terminal = state.terminals.get(&pane.attached_terminal_id);
+    let current = terminal
+        .and_then(|t| t.metadata_tokens.values().get("mark").cloned())
+        .unwrap_or_default();
+    state.creating_new_tab = false;
+    state.requested_new_tab_name = None;
+    state.pending_workspace_create_cwd = None;
+    state.rename_pane_target = None;
+    state.mark_pane_target = Some(pane_id);
+    state.name_input = current;
+    state.name_input_replace_on_type = state.name_input.is_empty();
+    state.mode = Mode::EditPaneMark;
 }
 
 fn workspace_create_label(input: &str, suggested_name: &str) -> Option<String> {
@@ -578,11 +600,44 @@ pub(super) fn apply_rename_action(state: &mut AppState, action: ModalAction) {
                         }
                     }
                 }
+                Mode::EditPaneMark => {
+                    if let Some(pane_id) = state.mark_pane_target {
+                        let ws_idx = state
+                            .workspaces
+                            .iter()
+                            .position(|ws| ws.pane_state(pane_id).is_some());
+                        if let Some(ws_idx) = ws_idx {
+                            if let Some(ws) = state.workspaces.get(ws_idx) {
+                                if let Some(pane) = ws.pane_state(pane_id) {
+                                    let terminal_id = pane.attached_terminal_id.clone();
+                                    if let Some(terminal) = state.terminals.get_mut(&terminal_id) {
+                                        let trimmed = new_name.trim().to_string();
+                                        let mut patch = std::collections::HashMap::new();
+                                        if trimmed.is_empty() {
+                                            patch.insert("mark".to_string(), None);
+                                        } else {
+                                            patch.insert("mark".to_string(), Some(trimmed));
+                                        }
+                                        if terminal.metadata_tokens.patch(
+                                            patch,
+                                            None,
+                                            std::time::Instant::now(),
+                                        ) {
+                                            terminal.revision = terminal.revision.saturating_add(1);
+                                            state.mark_session_dirty();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 _ => {}
             }
             state.creating_new_tab = false;
             state.pending_workspace_create_cwd = None;
             state.rename_pane_target = None;
+            state.mark_pane_target = None;
             state.name_input.clear();
             state.name_input_replace_on_type = false;
             leave_modal(state);
@@ -596,6 +651,7 @@ pub(super) fn apply_rename_action(state: &mut AppState, action: ModalAction) {
             state.requested_new_tab_name = None;
             state.pending_workspace_create_cwd = None;
             state.rename_pane_target = None;
+            state.mark_pane_target = None;
             state.name_input.clear();
             state.name_input_replace_on_type = false;
             leave_modal(state);
@@ -850,6 +906,33 @@ pub(super) fn apply_context_menu_action(
         (ContextMenuKind::Pane { pane_id, .. }, Some("Rename pane")) => {
             open_rename_pane(state, pane_id);
         }
+        (ContextMenuKind::Pane { pane_id, .. }, Some("Edit mark")) => {
+            open_edit_mark(state, pane_id);
+        }
+        (
+            ContextMenuKind::Pane {
+                ws_idx, pane_id, ..
+            },
+            Some("Clear mark"),
+        ) => {
+            if let Some(ws) = state.workspaces.get(ws_idx) {
+                if let Some(pane) = ws.pane_state(pane_id) {
+                    let terminal_id = pane.attached_terminal_id.clone();
+                    if let Some(terminal) = state.terminals.get_mut(&terminal_id) {
+                        let mut patch = std::collections::HashMap::new();
+                        patch.insert("mark".to_string(), None);
+                        if terminal
+                            .metadata_tokens
+                            .patch(patch, None, std::time::Instant::now())
+                        {
+                            terminal.revision = terminal.revision.saturating_add(1);
+                            state.mark_session_dirty();
+                        }
+                    }
+                }
+            }
+            state.mode = Mode::Terminal;
+        }
         (
             ContextMenuKind::Pane {
                 ws_idx, pane_id, ..
@@ -1098,6 +1181,40 @@ impl App {
                     }
                 }
             }
+            Mode::EditPaneMark => {
+                if let Some(pane_id) = self.state.mark_pane_target {
+                    // Resolve workspace index for this pane
+                    let ws_idx = self
+                        .state
+                        .workspaces
+                        .iter()
+                        .position(|ws| ws.pane_state(pane_id).is_some());
+                    if let Some(ws_idx) = ws_idx {
+                        if let Some(ws) = self.state.workspaces.get(ws_idx) {
+                            if let Some(pane) = ws.pane_state(pane_id) {
+                                let terminal_id = pane.attached_terminal_id.clone();
+                                if let Some(terminal) = self.state.terminals.get_mut(&terminal_id) {
+                                    let trimmed = new_name.trim().to_string();
+                                    let mut patch = std::collections::HashMap::new();
+                                    if trimmed.is_empty() {
+                                        patch.insert("mark".to_string(), None);
+                                    } else {
+                                        patch.insert("mark".to_string(), Some(trimmed));
+                                    }
+                                    if terminal.metadata_tokens.patch(
+                                        patch,
+                                        None,
+                                        std::time::Instant::now(),
+                                    ) {
+                                        terminal.revision = terminal.revision.saturating_add(1);
+                                        self.state.mark_session_dirty();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             _ => {}
         }
 
@@ -1272,6 +1389,34 @@ impl App {
             (ContextMenuKind::Pane { pane_id, .. }, Some("Rename pane")) => {
                 open_rename_pane(&mut self.state, pane_id);
             }
+            (ContextMenuKind::Pane { pane_id, .. }, Some("Edit mark")) => {
+                open_edit_mark(&mut self.state, pane_id);
+            }
+            (
+                ContextMenuKind::Pane {
+                    ws_idx, pane_id, ..
+                },
+                Some("Clear mark"),
+            ) => {
+                if let Some(ws) = self.state.workspaces.get(ws_idx) {
+                    if let Some(pane) = ws.pane_state(pane_id) {
+                        let terminal_id = pane.attached_terminal_id.clone();
+                        if let Some(terminal) = self.state.terminals.get_mut(&terminal_id) {
+                            let mut patch = std::collections::HashMap::new();
+                            patch.insert("mark".to_string(), None);
+                            if terminal.metadata_tokens.patch(
+                                patch,
+                                None,
+                                std::time::Instant::now(),
+                            ) {
+                                terminal.revision = terminal.revision.saturating_add(1);
+                                self.state.mark_session_dirty();
+                            }
+                        }
+                    }
+                }
+                self.state.mode = Mode::Terminal;
+            }
             (
                 ContextMenuKind::Pane {
                     ws_idx, pane_id, ..
@@ -1392,6 +1537,7 @@ fn cancel_rename_modal(state: &mut AppState) {
     state.requested_new_tab_name = None;
     state.pending_workspace_create_cwd = None;
     state.rename_pane_target = None;
+    state.mark_pane_target = None;
     state.name_input.clear();
     state.name_input_replace_on_type = false;
     leave_modal(state);
@@ -2239,6 +2385,7 @@ mod tests {
                 pane_id,
                 source_pane_id: None,
                 has_manual_label: false,
+                has_mark: false,
                 right_click_passthrough: false,
             },
             x: 0,
@@ -2287,6 +2434,7 @@ mod tests {
                 pane_id,
                 source_pane_id: None,
                 has_manual_label: false,
+                has_mark: false,
                 right_click_passthrough: false,
             },
             x: 0,
@@ -2397,6 +2545,7 @@ mod tests {
                 pane_id,
                 source_pane_id: None,
                 has_manual_label: false,
+                has_mark: false,
                 right_click_passthrough: false,
             },
             x: 0,

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -391,7 +391,7 @@ impl AppState {
 
                 if matches!(
                     self.mode,
-                    Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane
+                    Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane | Mode::EditPaneMark
                 ) {
                     let action = self
                         .rename_modal_inner()
@@ -1125,6 +1125,11 @@ impl AppState {
                         .and_then(|pane| self.terminals.get(&pane.attached_terminal_id))
                         .and_then(|terminal| terminal.manual_label.as_ref())
                         .is_some();
+                    let has_mark = pane_state
+                        .and_then(|pane| self.terminals.get(&pane.attached_terminal_id))
+                        .is_some_and(|terminal| {
+                            terminal.metadata_tokens.values().contains_key("mark")
+                        });
                     let right_click_passthrough =
                         pane_state.is_some_and(|pane| pane.right_click_passthrough);
                     self.context_menu = Some(ContextMenuState {
@@ -1134,6 +1139,7 @@ impl AppState {
                             pane_id: info.id,
                             source_pane_id,
                             has_manual_label,
+                            has_mark,
                             right_click_passthrough,
                         },
                         x: mouse.column,
@@ -3660,19 +3666,27 @@ mod tests {
         app.state.selected = 0;
         let pane_id = app.state.workspaces[0].tabs[0].root_pane;
         let runtime_count = app.terminal_runtimes.len();
-        app.state.context_menu = Some(ContextMenuState {
+        let mut initial_menu = ContextMenuState {
             kind: ContextMenuKind::Pane {
                 ws_idx: 0,
                 tab_idx: 0,
                 pane_id,
                 source_pane_id: None,
                 has_manual_label: false,
+                has_mark: false,
                 right_click_passthrough: false,
             },
             x: 2,
             y: 2,
-            list: MenuListState::new(1),
-        });
+            list: MenuListState::new(0),
+        };
+        let split_idx = initial_menu
+            .items()
+            .iter()
+            .position(|item| *item == "Split right")
+            .unwrap();
+        initial_menu.list = MenuListState::new(split_idx);
+        app.state.context_menu = Some(initial_menu);
         app.state.mode = Mode::ContextMenu;
 
         handle_context_menu_key(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -578,6 +578,7 @@ impl App {
             requested_new_tab_name: None,
             pending_workspace_create_cwd: None,
             rename_pane_target: None,
+            mark_pane_target: None,
             worktree_create: None,
             worktree_open: None,
             worktree_remove: None,
@@ -1921,7 +1922,7 @@ impl App {
             Mode::Copy => {
                 self.handle_copy_mode_key(key);
             }
-            Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane => {
+            Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane | Mode::EditPaneMark => {
                 self.handle_rename_key_via_api(key_event);
             }
             Mode::NewLinkedWorktree => {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -896,6 +896,7 @@ pub enum Mode {
     RenameWorkspace,
     RenameTab,
     RenamePane,
+    EditPaneMark,
     NewLinkedWorktree,
     OpenExistingWorktree,
     ConfirmRemoveWorktree,
@@ -1275,6 +1276,7 @@ pub enum ContextMenuKind {
         pane_id: PaneId,
         source_pane_id: Option<PaneId>,
         has_manual_label: bool,
+        has_mark: bool,
         right_click_passthrough: bool,
     },
 }
@@ -1316,12 +1318,17 @@ impl ContextMenuState {
             ContextMenuKind::Pane {
                 source_pane_id,
                 has_manual_label,
+                has_mark,
                 right_click_passthrough,
                 ..
             } => {
                 let mut items = vec!["Rename pane"];
                 if has_manual_label {
                     items.push("Clear pane name");
+                }
+                items.push("Edit mark");
+                if has_mark {
+                    items.push("Clear mark");
                 }
                 if source_pane_id.is_some() {
                     items.push("Swap with focused pane");
@@ -1473,6 +1480,7 @@ pub struct AppState {
     pub requested_new_tab_name: Option<String>,
     pub pending_workspace_create_cwd: Option<std::path::PathBuf>,
     pub rename_pane_target: Option<PaneId>,
+    pub mark_pane_target: Option<PaneId>,
     pub worktree_create: Option<WorktreeCreateState>,
     pub worktree_open: Option<WorktreeOpenState>,
     pub worktree_remove: Option<WorktreeRemoveState>,
@@ -1858,6 +1866,7 @@ impl AppState {
             requested_new_tab_name: None,
             pending_workspace_create_cwd: None,
             rename_pane_target: None,
+            mark_pane_target: None,
             worktree_create: None,
             worktree_open: None,
             worktree_remove: None,
@@ -2072,6 +2081,10 @@ impl AppState {
                 "empty app state must not keep rename pane target"
             );
             assert!(
+                self.mark_pane_target.is_none(),
+                "empty app state must not keep mark pane target"
+            );
+            assert!(
                 self.selection.is_none(),
                 "empty app state must not keep text selection"
             );
@@ -2248,6 +2261,9 @@ impl AppState {
         }
         if let Some(pane_id) = self.rename_pane_target {
             assert_live_pane(pane_id, "rename pane target");
+        }
+        if let Some(pane_id) = self.mark_pane_target {
+            assert_live_pane(pane_id, "mark pane target");
         }
         if let Some(selection) = &self.selection {
             assert_live_pane(selection.pane_id, "text selection");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -446,7 +446,7 @@ pub fn render_with_runtime_registry(
             render_context_menu(app, frame);
         }
         Mode::Settings => render_settings_overlay(app, frame, frame.area()),
-        Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane => {
+        Mode::RenameWorkspace | Mode::RenameTab | Mode::RenamePane | Mode::EditPaneMark => {
             render_rename_overlay(app, frame, frame.area())
         }
         Mode::NewLinkedWorktree => render_new_linked_worktree_overlay(app, frame, frame.area()),

--- a/src/ui/dialogs.rs
+++ b/src/ui/dialogs.rs
@@ -84,6 +84,7 @@ pub(super) fn render_rename_overlay(app: &AppState, frame: &mut Frame, area: Rec
         Mode::RenameTab if app.creating_new_tab => "new tab",
         Mode::RenameTab => "rename tab",
         Mode::RenamePane => "rename pane",
+        Mode::EditPaneMark => "edit mark",
         _ => return,
     };
 
@@ -1065,7 +1066,12 @@ mod tests {
         let input = rename_input_rect(RENAME_AREA);
         let expected = Position::new(input.x + 3, input.y);
 
-        for mode in [Mode::RenameWorkspace, Mode::RenameTab, Mode::RenamePane] {
+        for mode in [
+            Mode::RenameWorkspace,
+            Mode::RenameTab,
+            Mode::RenamePane,
+            Mode::EditPaneMark,
+        ] {
             assert_eq!(
                 rename_overlay_caret_in(mode, "ab").0,
                 expected,


### PR DESCRIPTION
Herdr `0.8.2` already supports custom sidebar tokens via `herdr pane report-metadata --token mark=...` + `ui.sidebar.agents.rows = [... ["$mark"]]`. This PR makes that discoverable without the CLI — adds `Edit mark` / `Clear mark` to the pane right-click menu, same UX as `Rename pane`.

**Changes**
- `src/app/state.rs` — new `Mode::EditPaneMark`, `mark_pane_target`, `ContextMenuKind::Pane.has_mark`, menu items
- `src/app/input/{mod,modal,mouse}.rs` + `src/app/mod.rs` — `open_edit_mark()`, `Edit mark`/`Clear mark` handlers for both direct and `via_api` paths, `Mode::EditPaneMark` save (patches `metadata_tokens["mark"]` with revision bump), input routing, mouse hit-testing, test fix (`Split right` index now resolved by name)
- `src/ui/{,dialogs}.rs` — `edit mark` modal title, overlay rendering

**Behavior**
- Right-click pane → `Edit mark` opens modal prefilled with current `tokens.mark` (or empty). `↵` saves trimmed value via `metadata_tokens.patch` (empty → clear), `^c` clears input, `esc` cancels. `Clear mark` directly clears token.
- Stored in `TerminalState.metadata_tokens` (`$mark`), surfaced via `ApiSnapshot.pane.tokens`, rendered when `ui.sidebar.agents.rows` includes `{ token = "$mark", ... }` (unreported → row disappears). No new API fields — reuses existing `pane.report_metadata` plumbing.
- Sidebar config example:
```toml
[ui.sidebar.agents]
rows = [["terminal_title_stripped"], ["state_icon","tab"], [{ token = "$mark", fg = "#f9e2af", bold = true }]]
```

**Why this pays off**
Makes the existing `$mark` token friendly for daily triage (e.g. `★ REVIEW`, `BLOCKED`, `PR #42`) without remembering `report-metadata` syntax, and shows only when set.

**Alternatives**
Pure plugin `jovylle/herdr-pane-mark` provides the same via palette/popup for stock herdr without building. This core PR is the mouse-first path.

**Testing**
- `cargo fmt --check` / `cargo check` clean (4 pre-existing `ui/sidebar.rs` warnings)
- `cargo test` — fixed `keyboard_context_menu_split_keeps_new_runtime` (hardcoded index → `position(|i| i=="Split right")`), one flaky `output_changed_event_hooks…` passes on retry, overall run clean
- Manual: `herdr pane report-metadata w4J:p3R --token mark="★ DEMO"` → `herdr pane get` shows `tokens:{mark:...}` → sidebar yellow row, `Clear mark` removes it; modal save/clear works from menu

**Companion branch**
`jovylle/herdr-fork:feat/sidebar-softwrap` adds `ui.sidebar.agents.wrap` (softwrap long rows instead of truncating) — independent, can land separately. This PR is intentionally based on `upstream/master` without that commit for clean review.

Closes: pane context menu custom mark.