### PR TITLE
fix(windows): preserve native pane key identity

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocol": 21,
+  "protocol": 22,
   "schema_version": 1,
   "schemas": {
     "error_response": {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -23,7 +23,6 @@ pub(crate) use lease::{InputLeaseKey, InputLeaseTable, RepeatPlan};
 pub use model::ime_compatible_keyboard_enhancement_flags;
 #[cfg(any(unix, test))]
 pub use model::MouseProtocolMode;
-#[cfg(any(windows, test))]
 pub use model::WindowsKeyRecord;
 pub use model::{
     host_modify_other_keys_mode, KeyIdentity, KeyboardProtocol, MouseProtocolEncoding, TerminalKey,

--- a/src/input/model.rs
+++ b/src/input/model.rs
@@ -3,7 +3,6 @@ use crossterm::event::KeyboardEnhancementFlags;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use serde::{Deserialize, Serialize};
 
-#[cfg(any(windows, test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WindowsKeyRecord {
     pub key_down: bool,
@@ -167,12 +166,14 @@ impl TerminalKey {
         }
     }
 
-    #[cfg(any(windows, test))]
     pub(crate) fn windows_record(&self) -> Option<WindowsKeyRecord> {
+        #[cfg(any(windows, test))]
         match self.source {
             KeySource::WindowsConsole { record, .. } => Some(record),
             KeySource::Synthesized | KeySource::Vt { .. } => None,
         }
+        #[cfg(not(any(windows, test)))]
+        None
     }
 
     pub(crate) fn identity(&self) -> KeyIdentity {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2586,27 +2586,27 @@ mod tests {
     #[test]
     fn windows_conpty_native_encoder_uses_canonical_phase_and_repeat_count() {
         let key = crate::input::TerminalKey::new(
-            crossterm::event::KeyCode::Esc,
-            crossterm::event::KeyModifiers::empty(),
+            crossterm::event::KeyCode::Char('7'),
+            crossterm::event::KeyModifiers::CONTROL,
         )
         .with_windows_record(crate::input::WindowsKeyRecord {
             key_down: true,
             repeat_count: 3,
-            virtual_key_code: 27,
-            virtual_scan_code: 1,
-            unicode: 27,
-            control_key_state: 0,
+            virtual_key_code: 0x37,
+            virtual_scan_code: 0x08,
+            unicode: 0,
+            control_key_state: 0x0008,
         });
 
         assert_eq!(
             super::encode_windows_conpty_fallback(&key),
-            Some(b"\x1b[27;1;27;1;0;3_".to_vec())
+            Some(b"\x1b[55;8;0;1;8;3_".to_vec())
         );
         let mut release = key.with_kind(crossterm::event::KeyEventKind::Release);
         release.repeat_count = 3;
         assert_eq!(
             super::encode_windows_conpty_fallback(&release),
-            Some(b"\x1b[27;1;27;0;0;1_".to_vec())
+            Some(b"\x1b[55;8;0;0;8;1_".to_vec())
         );
     }
 

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Current protocol version. Bumped when wire format changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 21;
+pub const PROTOCOL_VERSION: u32 = 22;
 
 /// Maximum allowed frame payload size (2 MB). Frames larger than this are
 /// rejected to prevent denial-of-service via oversized length prefixes.
@@ -160,6 +160,7 @@ pub enum ClientPaneInputEvent {
         generated_text: Option<String>,
         tracks_release: bool,
         physical_key_id: Option<u32>,
+        windows_record: Option<crate::input::WindowsKeyRecord>,
     },
     TextCommit(String),
     Mouse {
@@ -305,6 +306,7 @@ impl ClientPaneInputEvent {
     pub(crate) fn from_terminal_key(key: crate::input::TerminalKey) -> Option<Self> {
         let tracks_release = key.generated_text.is_none() || key.has_physical_identity();
         let physical_key_id = key.physical_key_id();
+        let windows_record = key.windows_record();
         Some(Self::Key {
             code: ClientKeyCode::from_crossterm(key.code)?,
             modifiers: key.modifiers.bits(),
@@ -314,6 +316,7 @@ impl ClientPaneInputEvent {
             generated_text: key.generated_text,
             tracks_release,
             physical_key_id,
+            windows_record,
         })
     }
 
@@ -327,6 +330,7 @@ impl ClientPaneInputEvent {
                 shifted_codepoint,
                 generated_text,
                 tracks_release,
+                windows_record,
                 ..
             } => {
                 let mut key = crate::input::TerminalKey::new(
@@ -340,6 +344,12 @@ impl ClientPaneInputEvent {
                 if let Some(shifted_codepoint) = shifted_codepoint {
                     key = key.with_shifted_codepoint(*shifted_codepoint);
                 }
+                #[cfg(any(windows, test))]
+                if let Some(record) = windows_record {
+                    key = key.with_windows_record(*record);
+                }
+                #[cfg(not(any(windows, test)))]
+                let _ = windows_record;
                 crate::raw_input::RawInputEvent::Key(key)
             }
             Self::TextCommit(text) => {
@@ -1819,19 +1829,41 @@ mod tests {
     }
 
     #[test]
-    fn client_shell_pane_input_roundtrips_semantic_keys() {
+    fn client_shell_pane_input_roundtrips_semantic_and_windows_keys() {
+        let windows_record = crate::input::WindowsKeyRecord {
+            key_down: true,
+            repeat_count: 1,
+            virtual_key_code: 0x37,
+            virtual_scan_code: 0x08,
+            unicode: 0,
+            control_key_state: 0x0008,
+        };
         let message = ClientMessage::ClientShellPaneInput {
             pane_id: "w1:p2".into(),
-            events: vec![ClientPaneInputEvent::Key {
-                code: ClientKeyCode::Char('l'),
-                modifiers: crossterm::event::KeyModifiers::SHIFT.bits(),
-                kind: ClientKeyKind::Release,
-                repeat_count: 1,
-                shifted_codepoint: Some('L' as u32),
-                generated_text: None,
-                tracks_release: true,
-                physical_key_id: None,
-            }],
+            events: vec![
+                ClientPaneInputEvent::Key {
+                    code: ClientKeyCode::Char('l'),
+                    modifiers: crossterm::event::KeyModifiers::SHIFT.bits(),
+                    kind: ClientKeyKind::Release,
+                    repeat_count: 1,
+                    shifted_codepoint: Some('L' as u32),
+                    generated_text: None,
+                    tracks_release: true,
+                    physical_key_id: None,
+                    windows_record: None,
+                },
+                ClientPaneInputEvent::Key {
+                    code: ClientKeyCode::Char('7'),
+                    modifiers: crossterm::event::KeyModifiers::CONTROL.bits(),
+                    kind: ClientKeyKind::Press,
+                    repeat_count: 1,
+                    shifted_codepoint: None,
+                    generated_text: None,
+                    tracks_release: true,
+                    physical_key_id: Some(0x08),
+                    windows_record: Some(windows_record),
+                },
+            ],
         };
         let encoded = bincode::serde::encode_to_vec(&message, bincode::config::standard())
             .expect("encode targeted semantic input");
@@ -1842,11 +1874,17 @@ mod tests {
         let ClientMessage::ClientShellPaneInput { events, .. } = decoded else {
             panic!("expected targeted semantic input");
         };
-        let crate::raw_input::RawInputEvent::Key(key) = events[0].to_raw_input_event() else {
+        let crate::raw_input::RawInputEvent::Key(semantic) = events[0].to_raw_input_event() else {
             panic!("expected semantic key");
         };
-        assert_eq!(key.shifted_codepoint, Some('L' as u32));
-        assert_eq!(key.kind, crossterm::event::KeyEventKind::Release);
+        assert_eq!(semantic.shifted_codepoint, Some('L' as u32));
+        assert_eq!(semantic.kind, crossterm::event::KeyEventKind::Release);
+        let crate::raw_input::RawInputEvent::Key(key) = events[1].to_raw_input_event() else {
+            panic!("expected Windows key");
+        };
+        assert_eq!(key.code, crossterm::event::KeyCode::Char('7'));
+        assert_eq!(key.modifiers, crossterm::event::KeyModifiers::CONTROL);
+        assert_eq!(key.windows_record(), Some(windows_record));
     }
 
     #[test]

--- a/src/server/clients.rs
+++ b/src/server/clients.rs
@@ -188,6 +188,7 @@ impl ClientConnection {
                     shifted_codepoint,
                     tracks_release: true,
                     physical_key_id,
+                    windows_record,
                     ..
                 } => {
                     self.shell_held_inputs.insert(
@@ -203,6 +204,7 @@ impl ClientConnection {
                                 generated_text: None,
                                 tracks_release: true,
                                 physical_key_id: *physical_key_id,
+                                windows_record: *windows_record,
                             },
                         },
                     );
@@ -458,6 +460,7 @@ mod tests {
                 generated_text: Some("x".into()),
                 tracks_release: false,
                 physical_key_id: None,
+                windows_record: None,
             }],
         );
 
@@ -467,6 +470,14 @@ mod tests {
     #[test]
     fn physical_keys_with_the_same_semantic_code_keep_distinct_release_leases() {
         let mut client = shell_client();
+        let windows_record = crate::input::WindowsKeyRecord {
+            key_down: true,
+            repeat_count: 1,
+            virtual_key_code: 0x6c,
+            virtual_scan_code: 0x1c,
+            unicode: 13,
+            control_key_state: 0,
+        };
         let key = |kind, physical_key_id| ClientPaneInputEvent::Key {
             code: crate::protocol::ClientKeyCode::Enter,
             modifiers: 0,
@@ -476,6 +487,7 @@ mod tests {
             generated_text: None,
             tracks_release: true,
             physical_key_id: Some(physical_key_id),
+            windows_record: (physical_key_id == 108).then_some(windows_record),
         };
         client.track_shell_input(
             ClientShellInputTarget::Pane("w1:p1".into()),
@@ -494,8 +506,9 @@ mod tests {
                 code: crate::protocol::ClientKeyCode::Enter,
                 kind: ClientKeyKind::Release,
                 physical_key_id: Some(108),
+                windows_record: Some(record),
                 ..
-            }
+            } if *record == windows_record
         ));
     }
 }

--- a/src/server/headless/tests/mod.rs
+++ b/src/server/headless/tests/mod.rs
@@ -1262,6 +1262,7 @@ async fn client_shell_input_targets_runtime_without_server_shell_classification(
                     generated_text: None,
                     tracks_release: true,
                     physical_key_id: None,
+                    windows_record: None,
                 },
                 crate::protocol::ClientPaneInputEvent::Key {
                     code: crate::protocol::ClientKeyCode::Char('c'),
@@ -1272,6 +1273,7 @@ async fn client_shell_input_targets_runtime_without_server_shell_classification(
                     generated_text: None,
                     tracks_release: true,
                     physical_key_id: None,
+                    windows_record: None,
                 },
                 crate::protocol::ClientPaneInputEvent::Key {
                     code: crate::protocol::ClientKeyCode::Char('x'),
@@ -1282,6 +1284,7 @@ async fn client_shell_input_targets_runtime_without_server_shell_classification(
                     generated_text: None,
                     tracks_release: true,
                     physical_key_id: None,
+                    windows_record: None,
                 },
                 crate::protocol::ClientPaneInputEvent::Mouse {
                     kind: crate::protocol::ClientMouseKind::Down(
@@ -1386,6 +1389,7 @@ async fn client_shell_hidden_pane_rejects_presses_but_accepts_releases() {
         generated_text: None,
         tracks_release: true,
         physical_key_id: Some(0x2d),
+        windows_record: None,
     };
 
     assert!(
@@ -1592,6 +1596,7 @@ async fn client_shell_release_under_popup_renders_when_it_resets_scrollback() {
                 generated_text: None,
                 tracks_release: true,
                 physical_key_id: Some(0x2d),
+                windows_record: None,
             }],
         });
 
@@ -3000,6 +3005,7 @@ fn client_page_key(
         generated_text: None,
         tracks_release: true,
         physical_key_id: None,
+        windows_record: None,
     }
 }
 
@@ -3558,6 +3564,7 @@ async fn client_shell_release_cleanup_does_not_promote_and_survives_disconnect()
         generated_text: (kind == crate::protocol::ClientKeyKind::Press).then(|| "x".to_owned()),
         tracks_release: true,
         physical_key_id: Some(0x2d),
+        windows_record: None,
     };
 
     assert!(

--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -304,7 +304,7 @@ fn ping_over_socket_returns_version() {
     assert_eq!(value["result"]["version"], env!("CARGO_PKG_VERSION"));
     // Intentionally hardcoded so wire protocol bumps require updating this test.
     // Changing this value means old clients/servers are no longer compatible.
-    assert_eq!(value["result"]["protocol"], 21);
+    assert_eq!(value["result"]["protocol"], 22);
 
     cleanup_spawned_herdr(child, base);
 }

--- a/tests/cli/sessions.rs
+++ b/tests/cli/sessions.rs
@@ -389,7 +389,7 @@ fn status_commands_report_client_and_server_versions() {
         "stdout: {full_stdout}"
     );
     assert!(
-        full_stdout.contains("  protocol: 21"),
+        full_stdout.contains("  protocol: 22"),
         "stdout: {full_stdout}"
     );
     assert!(full_stdout.contains("server:\n"), "stdout: {full_stdout}");
@@ -422,7 +422,7 @@ fn status_commands_report_client_and_server_versions() {
         "stdout: {server_stdout}"
     );
     assert!(
-        server_stdout.contains("protocol: 21"),
+        server_stdout.contains("protocol: 22"),
         "stdout: {server_stdout}"
     );
 
@@ -434,7 +434,7 @@ fn status_commands_report_client_and_server_versions() {
         "stdout: {client_stdout}"
     );
     assert!(
-        client_stdout.contains("protocol: 21"),
+        client_stdout.contains("protocol: 22"),
         "stdout: {client_stdout}"
     );
     assert!(
@@ -444,7 +444,7 @@ fn status_commands_report_client_and_server_versions() {
 
     let full_json = run_cli_json(&socket_path, &["status", "--json"]);
     assert_eq!(full_json["client"]["version"], env!("CARGO_PKG_VERSION"));
-    assert_eq!(full_json["client"]["protocol"], 21);
+    assert_eq!(full_json["client"]["protocol"], 22);
     assert_eq!(full_json["server"]["status"], "running");
     assert_eq!(full_json["server"]["running"], true);
     assert_eq!(full_json["server"]["compatible"], true);
@@ -458,12 +458,12 @@ fn status_commands_report_client_and_server_versions() {
     let server_json = run_cli_json(&socket_path, &["status", "server", "--json"]);
     assert_eq!(server_json["status"], "running");
     assert_eq!(server_json["version"], env!("CARGO_PKG_VERSION"));
-    assert_eq!(server_json["protocol"], 21);
+    assert_eq!(server_json["protocol"], 22);
     assert_eq!(server_json["compatible"], true);
 
     let client_json = run_cli_json(&socket_path, &["status", "client", "--json"]);
     assert_eq!(client_json["version"], env!("CARGO_PKG_VERSION"));
-    assert_eq!(client_json["protocol"], 21);
+    assert_eq!(client_json["protocol"], 22);
     assert!(client_json["binary"]
         .as_str()
         .is_some_and(|path| !path.is_empty()));

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -13,7 +13,7 @@ static INIT: Once = Once::new();
 static CLEANUP_GUARD: OnceLock<CleanupGuard> = OnceLock::new();
 const WATCHDOG_SCAN_INTERVAL: Duration = Duration::from_secs(1);
 const RUNTIME_OWNER_MARKER: &str = ".herdr-test-owner-pid";
-pub const CURRENT_PROTOCOL: u32 = 21;
+pub const CURRENT_PROTOCOL: u32 = 22;
 pub const SERVER_MESSAGE_SERVER_SHUTDOWN: u32 = 3;
 pub const SERVER_MESSAGE_CLIENT_SHELL_SNAPSHOT: u32 = 12;
 pub const SERVER_MESSAGE_PANE_SURFACE: u32 = 13;
@@ -327,6 +327,7 @@ pub fn send_client_shell_shift_enter(stream: &mut UnixStream, pane_id: &str) -> 
     payload.push(0); // no generated text
     payload.push(0); // does not track release
     payload.push(0); // no physical key id
+    payload.push(0); // no Windows key record
 
     stream
         .write_all(&frame_message(&payload))


### PR DESCRIPTION
## Summary

- preserve the optional native Windows console record after Herdr consumes its own bindings and forwards pane input
- let each destination choose legacy ConPTY or negotiated Kitty encoding without per-key aliases
- preserve native key-up provenance for held-input cleanup and bump the published wire protocol to 22

## Root cause

Herdr received physical Ctrl+7 correctly, but ClientPaneInputEvent dropped its Windows record. Legacy encoding then reduced the key to byte 0x1f, and ConPTY reconstructed that byte as Ctrl+Shift+Minus. The same failure reproduces with and without SSH.

## Validation

- just test-one client_shell_pane_input_roundtrips_semantic_and_windows_keys
- just test-one windows_conpty_native_encoder_uses_canonical_phase_and_repeat_count
- just test-one physical_keys_with_the_same_semantic_code_keep_distinct_release_leases
- Windows check phases pass: 172 relevant Windows tests, client transport tests, input lease tests, shell routing tests, clippy, format, and build