### PR TITLE
fix(nix): fetch crates from static CDN

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "lastModified": 1779911860,
+        "narHash": "sha256-ubcLAcKBDCZjhxw/kH5DL5GdBZQdzLqpkTe7HonvJVs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "rev": "c0a89c379b4ac67c7b13b051ddbd4e0dbc9b0eaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- update only the Nixpkgs lock pin to the upstream crates.io fetch fix
- fetch Cargo lockfile crates from static.crates.io instead of the rate-limited API
- cover the same failure reported for aarch64-darwin in #3505

## Validation

- nix flake check --all-systems --no-build: passed for x86_64-linux, aarch64-linux, x86_64-darwin, and aarch64-darwin
- nix flake check: passed from a fresh Linux checkout; built the Herdr release package
- just check: build passed and 168/169 Windows tests passed; the unrelated windows_wmi_daemon_preserves_environment_and_working_directory fixture timed out

Upstream Nixpkgs fix: https://github.com/NixOS/nixpkgs/pull/524985