### PR TITLE
fix(windows): recognize durable wmi daemon jobs

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2827,9 +2827,10 @@ mod tests {
             fs::write(
                 capture,
                 format!(
-                    "{}\n{}",
+                    "{}\n{}\n{}",
                     cwd.display(),
-                    super::current_process_is_detached_server_daemon()
+                    unsafe { GetConsoleWindow() }.is_null(),
+                    !super::current_job_kills_processes_on_close().expect("inspect WMI daemon job")
                 ),
             )
             .expect("write WMI daemon test capture");
@@ -2860,7 +2861,7 @@ mod tests {
             .expect("launch detached process through WMI");
         assert_ne!(pid, 0, "WMI returned an invalid process id");
 
-        let expected = format!("{}\ntrue", base.display());
+        let expected = format!("{}\ntrue\ntrue", base.display());
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {
             if fs::read_to_string(&capture).is_ok_and(|captured| captured == expected) {


### PR DESCRIPTION
## Summary

- make the Windows WMI daemon test verify that the child has no console
- verify the WMI child job does not use `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
- keep the conservative production detached-daemon classification unchanged

## Root cause

The WMI child wrote its capture promptly, preserved its environment and working directory, and had no console. Windows placed it in a benign WMI job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` unset. The test incorrectly treated any job membership as a broken daemon launch, so it waited for an expected `true` value that could never arrive.

The fixed capture deadline was not the cause, and no timeout was increased.

## Review follow-up

A disposable nested-job probe confirmed Greptile's concern that an outer kill-on-close limit can be hidden by an immediate benign job. The runtime predicate change was therefore removed; this PR now corrects only the invalid test assertion.

## Validation

- revised exact WMI daemon test: 10/10 passes
- `just check`