### PR TITLE
Emit exact managed-agent identity on release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-width",
+ "uuid",
  "widestring",
  "windows-sys",
  "wmi",
@@ -2075,6 +2076,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ toml = "0.8"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 unicode-width = "0.2"
+uuid = { version = "1", features = ["serde", "v4"] }
 schemars = { version = "1.2.1", features = ["derive"] }
 
 [patch.crates-io]

--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -629,6 +629,12 @@
                     "null"
                   ]
                 },
+                "agent_instance_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "final_status": {
                   "anyOf": [
                     {
@@ -663,6 +669,12 @@
             {
               "properties": {
                 "agent": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "agent_instance_id": {
                   "type": [
                     "string",
                     "null"
@@ -760,6 +772,12 @@
         "PaneInfo": {
           "properties": {
             "agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_instance_id": {
               "type": [
                 "string",
                 "null"
@@ -5929,6 +5947,12 @@
                 "null"
               ]
             },
+            "agent_instance_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "agent_status": {
               "$ref": "#/schemas/subscription_event/$defs/AgentStatus"
             },
@@ -6127,6 +6151,12 @@
         "AgentInfo": {
           "properties": {
             "agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_instance_id": {
               "type": [
                 "string",
                 "null"
@@ -6917,6 +6947,12 @@
                     "null"
                   ]
                 },
+                "agent_instance_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "final_status": {
                   "anyOf": [
                     {
@@ -6951,6 +6987,12 @@
             {
               "properties": {
                 "agent": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "agent_instance_id": {
                   "type": [
                     "string",
                     "null"
@@ -7408,6 +7450,12 @@
         "PaneInfo": {
           "properties": {
             "agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_instance_id": {
               "type": [
                 "string",
                 "null"

--- a/docs/next/website/src/content/docs/socket-api.mdx
+++ b/docs/next/website/src/content/docs/socket-api.mdx
@@ -742,6 +742,8 @@ Session-only official integrations report native session references with `pane.r
 
 If no native session reference is stored, the field is omitted.
 
+`agent.start` returns a UUID `agent_instance_id` after the session snapshot containing it has been written. `agent.get`, `agent.list`, `pane.get`, `pane.list`, `pane.agent_detected`, and `pane.agent_status_changed` expose the same optional field. The UUID identifies one running agent instance: renaming or moving its pane and a live server handoff preserve it, while process exit or replacement makes the old UUID an invalid agent target. On a cold restart Herdr exposes the saved UUID only after the resumed provider reports the exact saved provider, agent, and native session reference; a missing, mismatched, or duplicate resume does not reuse it.
+
 `pane.get`, `pane.list`, `agent.get`, and `agent.list` also expose `foreground_cwd` when Herdr can resolve the cwd of the process currently controlling the pane PTY. The existing `cwd` field remains the pane/workspace cwd used for labels, follow-cwd behavior, and restored session state.
 
 `PaneInfo` and `AgentInfo` expose optional `terminal_title` and `terminal_title_stripped` fields. `terminal_title` is the latest OSC 0/2 title after safety normalization. `terminal_title_stripped` removes one recognized leading activity or spinner glyph and following whitespace. These server-owned values are ephemeral across a cold restart and are independent of the metadata `title` and semantic agent state.

--- a/src/agent_instance.rs
+++ b/src/agent_instance.rs
@@ -1,0 +1,52 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Opaque identity for one managed agent lifetime.
+///
+/// Unlike pane, terminal, process, or provider-conversation identifiers, this
+/// value names the Herdr-managed agent instance itself. It survives movement
+/// and live handoff, and it is never reused by a replacement agent.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AgentInstanceId(uuid::Uuid);
+
+impl AgentInstanceId {
+    pub fn alloc() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        uuid::Uuid::parse_str(value).ok().map(Self)
+    }
+}
+
+impl fmt::Display for AgentInstanceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn allocated_ids_are_canonical_uuid_v4_values() {
+        let first = AgentInstanceId::alloc();
+        let second = AgentInstanceId::alloc();
+
+        assert_ne!(first, second);
+        assert_eq!(AgentInstanceId::parse(&first.to_string()), Some(first));
+    }
+
+    #[test]
+    fn one_thousand_allocations_are_unique() {
+        let ids = (0..1_000)
+            .map(|_| AgentInstanceId::alloc().to_string())
+            .collect::<HashSet<_>>();
+
+        assert_eq!(ids.len(), 1_000);
+    }
+}

--- a/src/api/schema/agents.rs
+++ b/src/api/schema/agents.rs
@@ -184,6 +184,8 @@ pub struct AgentPromptParams {
 pub struct AgentInfo {
     pub terminal_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_instance_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,

--- a/src/api/schema/events.rs
+++ b/src/api/schema/events.rs
@@ -399,6 +399,8 @@ pub struct PaneOutputMatchedEvent {
 pub struct PaneAgentStatusChangedEvent {
     pub pane_id: String,
     pub workspace_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_instance_id: Option<String>,
     pub agent_status: AgentStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
@@ -531,6 +533,8 @@ pub enum EventData {
         pane_id: String,
         workspace_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        agent_instance_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         agent: Option<String>,
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         released: bool,
@@ -540,6 +544,8 @@ pub enum EventData {
     PaneAgentStatusChanged {
         pane_id: String,
         workspace_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        agent_instance_id: Option<String>,
         agent_status: AgentStatus,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         agent: Option<String>,

--- a/src/api/schema/panes.rs
+++ b/src/api/schema/panes.rs
@@ -447,6 +447,8 @@ pub struct PaneReleaseAgentParams {
 pub struct PaneInfo {
     pub pane_id: String,
     pub terminal_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_instance_id: Option<String>,
     pub workspace_id: String,
     pub tab_id: String,
     pub focused: bool,

--- a/src/api/schema/tests.rs
+++ b/src/api/schema/tests.rs
@@ -760,6 +760,7 @@ fn worktree_request_and_response_round_trip() {
             root_pane: PaneInfo {
                 pane_id: "w_1-1".into(),
                 terminal_id: "term_1".into(),
+                agent_instance_id: None,
                 workspace_id: "w_1".into(),
                 tab_id: "w_1:1".into(),
                 focused: true,
@@ -1188,6 +1189,7 @@ fn create_response_round_trips_with_root_pane() {
             root_pane: PaneInfo {
                 pane_id: "w_1-3".into(),
                 terminal_id: "term_example".into(),
+                agent_instance_id: None,
                 workspace_id: "w_1".into(),
                 tab_id: "w_1:2".into(),
                 focused: false,

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -941,6 +941,7 @@ mod tests {
         crate::api::schema::PaneInfo {
             pane_id: pane_id.into(),
             terminal_id: "term_1".into(),
+            agent_instance_id: None,
             workspace_id: "ws_1".into(),
             tab_id: "tab_1".into(),
             focused: true,

--- a/src/api/subscriptions.rs
+++ b/src/api/subscriptions.rs
@@ -64,6 +64,7 @@ pub(super) struct ActiveScrollChangedSubscription {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PanePresentationSnapshot {
+    agent_instance_id: Option<String>,
     title: Option<String>,
     display_agent: Option<String>,
     state_labels: std::collections::HashMap<String, String>,
@@ -72,6 +73,7 @@ struct PanePresentationSnapshot {
 impl PanePresentationSnapshot {
     fn from(pane: &crate::api::schema::PaneInfo) -> Self {
         Self {
+            agent_instance_id: pane.agent_instance_id.clone(),
             title: pane.title.clone(),
             display_agent: pane.display_agent.clone(),
             state_labels: pane.state_labels.clone(),
@@ -79,11 +81,13 @@ impl PanePresentationSnapshot {
     }
 
     fn from_event(
+        agent_instance_id: &Option<String>,
         title: &Option<String>,
         display_agent: &Option<String>,
         state_labels: &std::collections::HashMap<String, String>,
     ) -> Self {
         Self {
+            agent_instance_id: agent_instance_id.clone(),
             title: title.clone(),
             display_agent: display_agent.clone(),
             state_labels: state_labels.clone(),
@@ -215,6 +219,7 @@ impl ActiveSubscription {
                     .then_some(PaneAgentStatusChangedEvent {
                         pane_id: probe.pane_id.clone(),
                         workspace_id: probe.workspace_id,
+                        agent_instance_id: probe.agent_instance_id,
                         agent_status: probe.agent_status,
                         agent: probe.agent,
                         title: probe.title,
@@ -347,6 +352,7 @@ impl ActiveAgentStatusChangedSubscription {
             let crate::api::schema::EventData::PaneAgentStatusChanged {
                 pane_id,
                 workspace_id,
+                agent_instance_id,
                 agent_status,
                 agent,
                 title,
@@ -364,8 +370,12 @@ impl ActiveAgentStatusChangedSubscription {
             }
             saw_status_event = true;
 
-            let current_presentation =
-                PanePresentationSnapshot::from_event(&title, &display_agent, &state_labels);
+            let current_presentation = PanePresentationSnapshot::from_event(
+                &agent_instance_id,
+                &title,
+                &display_agent,
+                &state_labels,
+            );
             self.last_status = Some(agent_status);
             self.last_presentation = Some(current_presentation);
             if self
@@ -381,6 +391,7 @@ impl ActiveAgentStatusChangedSubscription {
                 data: SubscriptionEventData::PaneAgentStatusChanged(PaneAgentStatusChangedEvent {
                     pane_id,
                     workspace_id,
+                    agent_instance_id,
                     agent_status,
                     agent,
                     title,
@@ -447,6 +458,7 @@ impl ActiveAgentStatusChangedSubscription {
             data: SubscriptionEventData::PaneAgentStatusChanged(PaneAgentStatusChangedEvent {
                 pane_id: pane.pane_id,
                 workspace_id: pane.workspace_id,
+                agent_instance_id: pane.agent_instance_id,
                 agent_status: current_status,
                 agent: pane.agent,
                 title: pane.title,
@@ -593,6 +605,7 @@ mod tests {
             data: EventData::PaneAgentStatusChanged {
                 pane_id: "pane_1".into(),
                 workspace_id: "workspace_1".into(),
+                agent_instance_id: None,
                 agent_status: AgentStatus::Working,
                 agent: Some("pi".into()),
                 title: title.map(str::to_string),
@@ -615,6 +628,7 @@ mod tests {
         PaneInfo {
             pane_id: "pane_1".into(),
             terminal_id: "terminal_1".into(),
+            agent_instance_id: None,
             workspace_id: "workspace_1".into(),
             tab_id: "tab_1".into(),
             focused: true,
@@ -729,6 +743,7 @@ mod tests {
             status_filter: None,
             last_status: Some(AgentStatus::Working),
             last_presentation: Some(PanePresentationSnapshot {
+                agent_instance_id: None,
                 title: None,
                 display_agent: None,
                 state_labels: HashMap::new(),
@@ -766,6 +781,7 @@ mod tests {
             status_filter: Some(AgentStatus::Working),
             last_status: Some(AgentStatus::Working),
             last_presentation: Some(PanePresentationSnapshot {
+                agent_instance_id: None,
                 title: None,
                 display_agent: None,
                 state_labels: HashMap::new(),
@@ -774,6 +790,7 @@ mod tests {
             initial_event: Some(PaneAgentStatusChangedEvent {
                 pane_id: "pane_1".into(),
                 workspace_id: "workspace_1".into(),
+                agent_instance_id: None,
                 agent_status: AgentStatus::Working,
                 agent: Some("pi".into()),
                 title: None,
@@ -811,6 +828,7 @@ mod tests {
             status_filter: Some(AgentStatus::Working),
             last_status: Some(AgentStatus::Working),
             last_presentation: Some(PanePresentationSnapshot {
+                agent_instance_id: None,
                 title: Some("short lived".into()),
                 display_agent: None,
                 state_labels: HashMap::new(),
@@ -819,6 +837,7 @@ mod tests {
             initial_event: Some(PaneAgentStatusChangedEvent {
                 pane_id: "pane_1".into(),
                 workspace_id: "workspace_1".into(),
+                agent_instance_id: None,
                 agent_status: AgentStatus::Working,
                 agent: Some("pi".into()),
                 title: Some("short lived".into()),

--- a/src/api/wait.rs
+++ b/src/api/wait.rs
@@ -773,6 +773,7 @@ fn wait_matched_response(request_id: &str, event: serde_json::Value) -> String {
                 data: EventData::PaneAgentStatusChanged {
                     pane_id: data.pane_id,
                     workspace_id: data.workspace_id,
+                    agent_instance_id: data.agent_instance_id,
                     agent_status: data.agent_status,
                     agent: data.agent,
                     title: data.title,

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -257,6 +257,20 @@ pub struct PaneStateUpdate {
     pub suppress_completion: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedAgentRelease {
+    pub agent_instance_id: String,
+    pub agent: Option<String>,
+    pub final_status: crate::api::schema::AgentStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedAgentReconcile {
+    pub pane_id: PaneId,
+    pub ws_idx: usize,
+    pub release: Option<ManagedAgentRelease>,
+}
+
 // ---------------------------------------------------------------------------
 // Navigator operations
 // ---------------------------------------------------------------------------
@@ -3081,11 +3095,20 @@ impl AppState {
             .min()
     }
 
-    pub(crate) fn reconcile_managed_agents_at(&mut self, now: Instant) -> Vec<(usize, PaneId)> {
-        let mut changed_terminals = std::collections::HashSet::new();
+    pub(crate) fn reconcile_managed_agents_at(
+        &mut self,
+        now: Instant,
+    ) -> Vec<ManagedAgentReconcile> {
+        let mut changed_terminals = std::collections::HashMap::new();
         for (terminal_id, terminal) in &mut self.terminals {
+            let previous_agent_instance_id = terminal.agent_instance_id().map(ToString::to_string);
+            let previous_agent = terminal.effective_agent_label().map(str::to_string);
+            let previous_state = terminal.state;
             if terminal.reconcile_managed_agent_at(now, false) {
-                changed_terminals.insert(terminal_id.clone());
+                let released = previous_agent_instance_id
+                    .filter(|_| terminal.agent_instance_id().is_none())
+                    .map(|agent_instance_id| (agent_instance_id, previous_agent, previous_state));
+                changed_terminals.insert(terminal_id.clone(), released);
             }
         }
         if changed_terminals.is_empty() {
@@ -3100,8 +3123,18 @@ impl AppState {
                 workspace.tabs.iter().flat_map(move |tab| {
                     tab.panes.iter().filter_map(move |(&pane_id, pane)| {
                         changed_terminals
-                            .contains(&pane.attached_terminal_id)
-                            .then_some((ws_idx, pane_id))
+                            .get(&pane.attached_terminal_id)
+                            .map(|release| ManagedAgentReconcile {
+                                pane_id,
+                                ws_idx,
+                                release: release.clone().map(
+                                    |(agent_instance_id, agent, state)| ManagedAgentRelease {
+                                        agent_instance_id,
+                                        agent,
+                                        final_status: pane_agent_status(state, pane.seen),
+                                    },
+                                ),
+                            })
                     })
                 })
             })
@@ -3455,6 +3488,7 @@ mod tests {
     use crate::detect::{Agent, AgentState};
     use crate::workspace::Workspace;
     use ratatui::layout::Direction;
+    use std::time::Duration;
 
     fn app_with_workspaces(names: &[&str]) -> AppState {
         let mut state = AppState::test_new();
@@ -3469,6 +3503,36 @@ mod tests {
             state.mode = Mode::Terminal;
         }
         state
+    }
+
+    #[test]
+    fn managed_agent_timeout_reports_the_ended_instance() {
+        let mut state = app_with_workspaces(&["one"]);
+        let pane_id = state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = state.workspaces[0].terminal_id(pane_id).cloned().unwrap();
+        let now = Instant::now();
+        let agent_instance_id = {
+            let terminal = state.terminals.get_mut(&terminal_id).unwrap();
+            terminal.begin_managed_agent(
+                "builder".into(),
+                Agent::Codex,
+                now,
+                Duration::ZERO,
+                Duration::from_secs(1),
+            );
+            terminal.agent_instance_id().unwrap().to_string()
+        };
+
+        let updates = state.reconcile_managed_agents_at(now + Duration::from_secs(1));
+
+        assert_eq!(updates.len(), 1);
+        let release = updates[0]
+            .release
+            .as_ref()
+            .expect("timeout must report an ended managed instance");
+        assert_eq!(release.agent_instance_id, agent_instance_id);
+        assert_eq!(release.agent, None);
+        assert_eq!(state.terminals[&terminal_id].agent_instance_id(), None);
     }
 
     fn mark_linked_worktree(state: &mut AppState, ws_idx: usize) {

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2979,6 +2979,7 @@ impl AppState {
             mutation,
             managed_changed,
             agent_name_changed,
+            agent_instance_created,
             unchanged_change,
             managed_launch_pending,
             suppress_acquisition_completion,
@@ -2987,7 +2988,20 @@ impl AppState {
             let previous_agent_name = terminal.agent_name.clone();
             let managed_launch_pending = terminal.managed_agent_launch_pending();
             let mutation = update(terminal)?;
+            let agent_replaced = mutation
+                .effective_state_change
+                .as_ref()
+                .is_some_and(|change| {
+                    matches!(
+                        (&change.previous_agent_label, &change.agent_label),
+                        (Some(previous), Some(current)) if previous != current
+                    )
+                });
+            if mutation.agent_released || agent_replaced {
+                terminal.end_agent_instance();
+            }
             let managed_changed = terminal.reconcile_managed_agent_at(now, false);
+            let agent_instance_created = terminal.ensure_agent_instance_id();
             let suppress_acquisition_completion = terminal.finish_agent_process_acquisition();
             let agent_name_changed = terminal.agent_name != previous_agent_name;
             let unchanged_change = (mutation.agent_released || agent_name_changed)
@@ -2996,12 +3010,17 @@ impl AppState {
                 mutation,
                 managed_changed,
                 agent_name_changed,
+                agent_instance_created,
                 unchanged_change,
                 managed_launch_pending,
                 suppress_acquisition_completion,
             )
         };
-        if mutation.session_ref_changed || managed_changed || agent_name_changed {
+        if mutation.session_ref_changed
+            || managed_changed
+            || agent_name_changed
+            || agent_instance_created
+        {
             self.mark_session_dirty();
         }
         let agent_released = mutation.agent_released;

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -239,6 +239,8 @@ pub fn notification_context(
 pub struct PaneStateUpdate {
     pub pane_id: PaneId,
     pub ws_idx: usize,
+    pub previous_agent_instance_id: Option<String>,
+    pub agent_instance_id: Option<String>,
     pub previous_agent_label: Option<String>,
     pub previous_known_agent: Option<Agent>,
     pub previous_state: AgentState,
@@ -1035,15 +1037,16 @@ impl AppState {
             .into_iter()
             .filter_map(|(ws_idx, pane_id, terminal_id)| {
                 let previous_seen = self.workspaces[ws_idx].pane_state(pane_id)?.seen;
-                let mutation = self
-                    .terminals
-                    .get_mut(&terminal_id)?
-                    .expire_agent_metadata_at(scheduled_deadline, now)?;
+                let terminal = self.terminals.get_mut(&terminal_id)?;
+                let agent_instance_id = terminal.agent_instance_id().map(ToString::to_string);
+                let mutation = terminal.expire_agent_metadata_at(scheduled_deadline, now)?;
                 let change = mutation.effective_state_change?;
                 let seen = self.apply_pane_state_change(ws_idx, pane_id, &change, false)?;
                 let update = PaneStateUpdate {
                     pane_id,
                     ws_idx,
+                    previous_agent_instance_id: agent_instance_id.clone(),
+                    agent_instance_id,
                     previous_agent_label: change.previous_agent_label.clone(),
                     previous_known_agent: change.previous_known_agent,
                     previous_state: change.previous_state,
@@ -2980,11 +2983,14 @@ impl AppState {
             managed_changed,
             agent_name_changed,
             agent_instance_created,
+            previous_agent_instance_id,
+            agent_instance_id,
             unchanged_change,
             managed_launch_pending,
             suppress_acquisition_completion,
         ) = {
             let terminal = self.terminals.get_mut(&terminal_id)?;
+            let previous_agent_instance_id = terminal.agent_instance_id().map(ToString::to_string);
             let previous_agent_name = terminal.agent_name.clone();
             let managed_launch_pending = terminal.managed_agent_launch_pending();
             let mutation = update(terminal)?;
@@ -3002,6 +3008,7 @@ impl AppState {
             }
             let managed_changed = terminal.reconcile_managed_agent_at(now, false);
             let agent_instance_created = terminal.ensure_agent_instance_id();
+            let agent_instance_id = terminal.agent_instance_id().map(ToString::to_string);
             let suppress_acquisition_completion = terminal.finish_agent_process_acquisition();
             let agent_name_changed = terminal.agent_name != previous_agent_name;
             let unchanged_change = (mutation.agent_released || agent_name_changed)
@@ -3011,6 +3018,8 @@ impl AppState {
                 managed_changed,
                 agent_name_changed,
                 agent_instance_created,
+                previous_agent_instance_id,
+                agent_instance_id,
                 unchanged_change,
                 managed_launch_pending,
                 suppress_acquisition_completion,
@@ -3037,6 +3046,8 @@ impl AppState {
         let update = PaneStateUpdate {
             pane_id,
             ws_idx,
+            previous_agent_instance_id,
+            agent_instance_id,
             previous_agent_label: change.previous_agent_label.clone(),
             previous_known_agent: change.previous_known_agent,
             previous_state: change.previous_state,

--- a/src/app/agents.rs
+++ b/src/app/agents.rs
@@ -214,11 +214,13 @@ impl App {
             .ok_or_else(|| AgentStartError::TargetUnavailable(params.pane_id.clone()))?;
         terminal.begin_managed_agent(name.clone(), kind, now, AGENT_START_SETTLE_DELAY, timeout);
         if let Err(err) = runtime.try_send_bytes(Bytes::from(bytes)) {
+            terminal.end_agent_instance();
             terminal.clear_agent_name();
             return Err(AgentStartError::InputFailed(err.to_string()));
         }
         self.state.mark_session_dirty();
-        self.schedule_session_save();
+        self.save_session_now_checked()
+            .map_err(|err| AgentStartError::PersistenceFailed(err.to_string()))?;
 
         let agent = self
             .agent_info(ws_idx, pane_id)
@@ -262,6 +264,10 @@ impl App {
             AgentStartError::InputFailed(message) => crate::api::schema::ErrorBody {
                 code: "agent_start_input_failed".into(),
                 message,
+            },
+            AgentStartError::PersistenceFailed(message) => crate::api::schema::ErrorBody {
+                code: "agent_instance_persist_failed".into(),
+                message: format!("agent started but its instance identity was not persisted: {message}"),
             },
             AgentStartError::DuplicateName { name, candidates } => crate::api::schema::ErrorBody {
                 code: "agent_name_taken".into(),
@@ -372,6 +378,7 @@ impl App {
         let pane = self.pane_info(ws_idx, pane_id)?;
         Some(crate::api::schema::AgentInfo {
             terminal_id: pane.terminal_id,
+            agent_instance_id: terminal.agent_instance_id().map(ToString::to_string),
             name: terminal.agent_name.clone(),
             agent: pane.agent,
             title: pane.title,
@@ -449,6 +456,7 @@ pub(super) enum AgentStartError {
     TargetBusy(String),
     TargetUnavailable(String),
     InputFailed(String),
+    PersistenceFailed(String),
     DuplicateName {
         name: String,
         candidates: Vec<crate::api::schema::AgentInfo>,

--- a/src/app/agents.rs
+++ b/src/app/agents.rs
@@ -49,14 +49,44 @@ impl App {
         else {
             return;
         };
-        let changed = self
+        let previous_seen = self.state.workspaces[resolved.ws_idx]
+            .pane_state(resolved.pane_id)
+            .is_some_and(|pane| pane.seen);
+        let (changed, release) = self
             .state
             .terminals
             .get_mut(&terminal_id)
-            .is_some_and(|terminal| terminal.reconcile_managed_agent_at(Instant::now(), false));
+            .map(|terminal| {
+                let previous_agent_instance_id =
+                    terminal.agent_instance_id().map(ToString::to_string);
+                let previous_agent = terminal.effective_agent_label().map(str::to_string);
+                let previous_state = terminal.state;
+                let changed = terminal.reconcile_managed_agent_at(Instant::now(), false);
+                let release = changed
+                    .then_some(previous_agent_instance_id)
+                    .flatten()
+                    .filter(|_| terminal.agent_instance_id().is_none())
+                    .map(
+                        |agent_instance_id| crate::app::actions::ManagedAgentRelease {
+                            agent_instance_id,
+                            agent: previous_agent,
+                            final_status: super::api_helpers::pane_agent_status(
+                                previous_state,
+                                previous_seen,
+                            ),
+                        },
+                    );
+                (changed, release)
+            })
+            .unwrap_or((false, None));
         if changed {
             self.state.mark_session_dirty();
             self.schedule_session_save();
+            self.emit_managed_agent_release(&crate::app::actions::ManagedAgentReconcile {
+                pane_id: resolved.pane_id,
+                ws_idx: resolved.ws_idx,
+                release,
+            });
             self.emit_pane_updated(resolved.ws_idx, resolved.pane_id);
         }
     }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -667,6 +667,29 @@ impl App {
         }
     }
 
+    pub(crate) fn emit_managed_agent_release(
+        &mut self,
+        update: &crate::app::actions::ManagedAgentReconcile,
+    ) {
+        let Some(release) = update.release.as_ref() else {
+            return;
+        };
+        let Some(pane_id) = self.public_pane_id(update.ws_idx, update.pane_id) else {
+            return;
+        };
+        self.emit_event(crate::api::schema::EventEnvelope {
+            event: crate::api::schema::EventKind::PaneAgentDetected,
+            data: crate::api::schema::EventData::PaneAgentDetected {
+                pane_id,
+                workspace_id: self.public_workspace_id(update.ws_idx),
+                agent_instance_id: Some(release.agent_instance_id.clone()),
+                agent: release.agent.clone(),
+                released: true,
+                final_status: Some(release.final_status),
+            },
+        });
+    }
+
     fn emit_terminal_or_system_agent_notifications(
         &self,
         pane_updates: &[crate::app::actions::PaneStateUpdate],

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -614,14 +614,11 @@ impl App {
             return;
         };
         let workspace_id = self.public_workspace_id(update.ws_idx);
-        let agent_instance_id = self
-            .state
-            .workspaces
-            .get(update.ws_idx)
-            .and_then(|workspace| workspace.terminal_id(update.pane_id))
-            .and_then(|terminal_id| self.state.terminals.get(terminal_id))
-            .and_then(crate::terminal::TerminalState::agent_instance_id)
-            .map(ToString::to_string);
+        let agent_instance_id = if update.agent_released {
+            update.previous_agent_instance_id.clone()
+        } else {
+            update.agent_instance_id.clone()
+        };
 
         if update.agent_name_changed {
             self.emit_pane_updated(update.ws_idx, update.pane_id);
@@ -1978,6 +1975,8 @@ mod tests {
             app.state.ensure_test_terminals();
             let terminal = app.state.terminals.get_mut(&terminal_id).unwrap();
             terminal.set_detected_state(Some(Agent::Pi), AgentState::Idle);
+            terminal.ensure_agent_instance_id();
+            let agent_instance_id = terminal.agent_instance_id().unwrap().to_string();
             if let Some(agent_name) = agent_name {
                 terminal.set_agent_name(agent_name.into());
             }
@@ -1996,10 +1995,11 @@ mod tests {
             assert!(event_hub.events_after(0).iter().any(|(_, event)| matches!(
                 &event.data,
                 crate::api::schema::EventData::PaneAgentDetected {
+                    agent_instance_id: Some(released_id),
                     released: true,
                     final_status: Some(crate::api::schema::AgentStatus::Idle),
                     ..
-                }
+                } if released_id == &agent_instance_id
             )));
         }
     }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -614,6 +614,14 @@ impl App {
             return;
         };
         let workspace_id = self.public_workspace_id(update.ws_idx);
+        let agent_instance_id = self
+            .state
+            .workspaces
+            .get(update.ws_idx)
+            .and_then(|workspace| workspace.terminal_id(update.pane_id))
+            .and_then(|terminal_id| self.state.terminals.get(terminal_id))
+            .and_then(crate::terminal::TerminalState::agent_instance_id)
+            .map(ToString::to_string);
 
         if update.agent_name_changed {
             self.emit_pane_updated(update.ws_idx, update.pane_id);
@@ -625,6 +633,7 @@ impl App {
                 data: crate::api::schema::EventData::PaneAgentDetected {
                     pane_id: pane_id.clone(),
                     workspace_id: workspace_id.clone(),
+                    agent_instance_id: agent_instance_id.clone(),
                     agent: update.agent_label.clone(),
                     released: update.agent_released,
                     final_status: update.agent_release_status,
@@ -650,6 +659,7 @@ impl App {
                 data: crate::api::schema::EventData::PaneAgentStatusChanged {
                     pane_id,
                     workspace_id,
+                    agent_instance_id,
                     agent_status,
                     agent: update.agent_label.clone(),
                     title: presentation.title,

--- a/src/app/api/agents.rs
+++ b/src/app/api/agents.rs
@@ -347,7 +347,7 @@ mod tests {
                 80, 24, 0, b"", 1,
             );
         runtime.test_process_pty_bytes(b"\x1b[?2004h");
-        app.state.insert_test_runtime(pane_id, runtime);
+        app.terminal_runtimes.insert(terminal_id.clone(), runtime);
 
         let public_pane_id = app.public_pane_id(0, pane_id).unwrap();
         let bracketed_started = std::time::Instant::now();
@@ -427,7 +427,7 @@ mod tests {
         terminal.set_agent_name("reviewer".into());
         terminal.set_detected_state(Some(Agent::GithubCopilot), AgentState::Blocked);
         let (runtime, mut rx) = crate::terminal::TerminalRuntime::test_with_channel(80, 24);
-        app.state.insert_test_runtime(pane_id, runtime);
+        app.terminal_runtimes.insert(terminal_id.clone(), runtime);
 
         let response = app.handle_agent_prompt(
             "req".into(),
@@ -627,5 +627,131 @@ mod tests {
                 Some("shell-pane")
             );
         }
+    }
+
+    #[tokio::test]
+    async fn managed_agent_instance_id_is_queryable_and_survives_rename() {
+        let mut app = app_with_agent();
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = app.state.workspaces[0].tabs[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        let (runtime, mut input) = crate::terminal::TerminalRuntime::test_with_channel(80, 24);
+        app.terminal_runtimes.insert(terminal_id.clone(), runtime);
+        let public_pane_id = app.public_pane_id(0, pane_id).unwrap();
+
+        let started = app.handle_agent_start(
+            "start".into(),
+            AgentStartParams {
+                name: "builder".into(),
+                kind: "codex".into(),
+                pane_id: public_pane_id,
+                args: Vec::new(),
+                timeout_ms: None,
+            },
+        );
+        let started: SuccessResponse =
+            serde_json::from_str(&started).unwrap_or_else(|err| panic!("{err}: {started}"));
+        let ResponseResult::AgentStarted { agent, .. } = started.result else {
+            panic!("expected started response");
+        };
+        let instance_id = agent
+            .agent_instance_id
+            .expect("managed start must return an instance id");
+        assert!(uuid::Uuid::parse_str(&instance_id).is_ok());
+        assert!(
+            input.try_recv().is_ok(),
+            "start must submit the agent command"
+        );
+
+        let fetched = app.handle_agent_get(
+            "get".into(),
+            AgentTarget {
+                target: instance_id.clone(),
+            },
+        );
+        let fetched: SuccessResponse = serde_json::from_str(&fetched).unwrap();
+        let ResponseResult::AgentInfo { agent } = fetched.result else {
+            panic!("expected agent info");
+        };
+        assert_eq!(
+            agent.agent_instance_id.as_deref(),
+            Some(instance_id.as_str())
+        );
+
+        {
+            let terminal = app.state.terminals.get_mut(&terminal_id).unwrap();
+            terminal.set_detected_state(Some(Agent::Codex), AgentState::Idle);
+            assert!(terminal.reconcile_managed_agent_at(
+                std::time::Instant::now() + crate::app::AGENT_START_SETTLE_DELAY,
+                false,
+            ));
+        }
+
+        let renamed = app.handle_agent_rename(
+            "rename".into(),
+            AgentRenameParams {
+                target: instance_id.clone(),
+                name: Some("reviewer".into()),
+            },
+        );
+        let renamed: SuccessResponse = serde_json::from_str(&renamed).unwrap();
+        let ResponseResult::AgentInfo { agent } = renamed.result else {
+            panic!("expected renamed agent info");
+        };
+        assert_eq!(agent.name.as_deref(), Some("reviewer"));
+        assert_eq!(
+            agent.agent_instance_id.as_deref(),
+            Some(instance_id.as_str())
+        );
+        assert_eq!(
+            app.state.terminals[&terminal_id]
+                .agent_instance_id()
+                .map(ToString::to_string)
+                .as_deref(),
+            Some(instance_id.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn replacement_gets_a_new_id_and_stale_instance_lookup_refuses() {
+        let mut app = app_with_agent();
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = app.state.workspaces[0].tabs[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        let (runtime, _input) = crate::terminal::TerminalRuntime::test_with_channel(80, 24);
+        app.terminal_runtimes.insert(terminal_id.clone(), runtime);
+        let public_pane_id = app.public_pane_id(0, pane_id).unwrap();
+        let start = |app: &mut App, request: &str| {
+            let response = app.handle_agent_start(
+                request.into(),
+                AgentStartParams {
+                    name: "builder".into(),
+                    kind: "codex".into(),
+                    pane_id: public_pane_id.clone(),
+                    args: Vec::new(),
+                    timeout_ms: None,
+                },
+            );
+            let response: SuccessResponse = serde_json::from_str(&response).unwrap();
+            let ResponseResult::AgentStarted { agent, .. } = response.result else {
+                panic!("expected start");
+            };
+            agent.agent_instance_id.unwrap()
+        };
+
+        let first = start(&mut app, "first");
+        {
+            let terminal = app.state.terminals.get_mut(&terminal_id).unwrap();
+            terminal.end_agent_instance();
+            terminal.clear_agent_name();
+        }
+        let second = start(&mut app, "second");
+        assert_ne!(first, second);
+
+        let stale = app.handle_agent_get("stale".into(), AgentTarget { target: first });
+        let stale: crate::api::schema::ErrorResponse = serde_json::from_str(&stale).unwrap();
+        assert_eq!(stale.error.code, "agent_not_found");
     }
 }

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -2597,6 +2597,18 @@ mod tests {
         let target_tab = app.state.workspaces[0].test_add_tab(Some("target"));
         let target = app.state.workspaces[0].tabs[target_tab].root_pane;
         seed_terminal_states(&mut app);
+        let now = std::time::Instant::now();
+        let source_agent_instance_id = {
+            let terminal = app.state.terminals.get_mut(&source_terminal).unwrap();
+            terminal.begin_managed_agent(
+                "builder".into(),
+                crate::detect::Agent::Codex,
+                now,
+                std::time::Duration::from_secs(3),
+                std::time::Duration::from_secs(30),
+            );
+            terminal.agent_instance_id().unwrap().to_string()
+        };
         let source_public = app.public_pane_id(0, source).unwrap();
         let source_tab_public = app.public_tab_id(0, 0).unwrap();
         let target_public = app.public_pane_id(0, target).unwrap();
@@ -2627,6 +2639,10 @@ mod tests {
         assert_eq!(move_result.pane.pane_id, move_result.previous_pane_id);
         assert_eq!(move_result.pane.tab_id, target_tab_public);
         assert_eq!(move_result.pane.terminal_id, source_terminal.to_string());
+        assert_eq!(
+            move_result.pane.agent_instance_id.as_deref(),
+            Some(source_agent_instance_id.as_str())
+        );
         assert_eq!(move_result.closed_tab_id, Some(source_tab_public));
         assert_eq!(move_result.closed_workspace_id, None);
         assert_eq!(move_result.target_layout.panes.len(), 2);
@@ -2635,6 +2651,13 @@ mod tests {
         assert_eq!(
             app.state.workspaces[0].tabs[0].terminal_id(source),
             Some(&source_terminal)
+        );
+        assert_eq!(
+            app.state.terminals[&source_terminal]
+                .agent_instance_id()
+                .map(ToString::to_string)
+                .as_deref(),
+            Some(source_agent_instance_id.as_str())
         );
     }
 
@@ -2766,11 +2789,12 @@ mod tests {
             .clone();
         let target = app.state.workspaces[1].tabs[0].root_pane;
         seed_terminal_states(&mut app);
-        app.state
-            .terminals
-            .get_mut(&source_terminal)
-            .unwrap()
-            .set_detected_state(Some(Agent::Pi), AgentState::Idle);
+        let source_agent_instance_id = {
+            let terminal = app.state.terminals.get_mut(&source_terminal).unwrap();
+            terminal.set_detected_state(Some(Agent::Pi), AgentState::Idle);
+            terminal.ensure_agent_instance_id();
+            terminal.agent_instance_id().unwrap().to_string()
+        };
         let previous_pane_id = app.public_pane_id(0, source).unwrap();
         let previous_workspace_id = app.public_workspace_id(0);
         let target_workspace_id = app.public_workspace_id(1);
@@ -2807,6 +2831,10 @@ mod tests {
         assert_eq!(move_result.pane.workspace_id, target_workspace_id);
         assert_eq!(move_result.pane.tab_id, target_tab_id);
         assert_eq!(move_result.pane.terminal_id, source_terminal.to_string());
+        assert_eq!(
+            move_result.pane.agent_instance_id.as_deref(),
+            Some(source_agent_instance_id.as_str())
+        );
         assert_eq!(app.state.workspaces.len(), 1);
         assert_eq!(
             app.state.workspaces[0].tabs[0].terminal_id(source),
@@ -2818,6 +2846,7 @@ mod tests {
             Err(crate::app::terminal_targets::TerminalTargetError::NotFound { .. })
         ));
         assert!(app.resolve_agent_target(&move_result.pane.pane_id).is_ok());
+        assert!(app.resolve_agent_target(&source_agent_instance_id).is_ok());
     }
 
     #[test]

--- a/src/app/creation.rs
+++ b/src/app/creation.rs
@@ -445,6 +445,7 @@ impl App {
         Some(crate::api::schema::PaneInfo {
             pane_id: self.public_pane_id(ws_idx, pane_id)?,
             terminal_id: terminal.id.to_string(),
+            agent_instance_id: terminal.agent_instance_id().map(ToString::to_string),
             workspace_id: self.public_workspace_id(ws_idx),
             tab_id: self.public_tab_id(ws_idx, tab_idx)?,
             focused,

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -334,8 +334,9 @@ impl App {
         {
             let panes = self.state.reconcile_managed_agents_at(now);
             if !panes.is_empty() {
-                for (ws_idx, pane_id) in panes {
-                    self.emit_pane_updated(ws_idx, pane_id);
+                for update in panes {
+                    self.emit_managed_agent_release(&update);
+                    self.emit_pane_updated(update.ws_idx, update.pane_id);
                 }
                 self.schedule_session_save();
                 changed = true;

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -96,6 +96,27 @@ impl App {
         run_session_save_job(self.capture_session_save_job());
         self.session_save_deadline = None;
     }
+
+    pub(crate) fn save_session_now_checked(&mut self) -> std::io::Result<()> {
+        if let Some(thread) = self.session_save_thread.take() {
+            let _ = thread.join();
+        }
+
+        if self.no_session {
+            self.session_save_deadline = None;
+            return Ok(());
+        }
+
+        match self.capture_session_save_job() {
+            SessionSaveJob::Clear => crate::persist::clear_checked()?,
+            SessionSaveJob::Save { snapshot, history } => {
+                crate::persist::save_checked(&snapshot, history.as_ref())?
+            }
+        }
+        self.state.session_dirty = false;
+        self.session_save_deadline = None;
+        Ok(())
+    }
 }
 
 fn run_session_save_job(job: SessionSaveJob) {

--- a/src/app/terminal_targets.rs
+++ b/src/app/terminal_targets.rs
@@ -76,6 +76,25 @@ impl App {
         &self,
         target: &str,
     ) -> Result<TerminalTarget, TerminalTargetError> {
+        let instance_matches: Vec<_> = self
+            .terminal_targets()
+            .into_iter()
+            .filter(|candidate| {
+                self.state
+                    .terminals
+                    .values()
+                    .find(|terminal| terminal.id.to_string() == candidate.terminal_id)
+                    .is_some_and(|terminal| {
+                        terminal
+                            .agent_instance_id()
+                            .is_some_and(|id| id.to_string() == target)
+                    })
+            })
+            .collect();
+        if let Some(resolved) = self.single_terminal_match(target, instance_matches)? {
+            return Ok(resolved);
+        }
+
         if let Some((ws_idx, pane_id)) = self.parse_current_public_pane_id(target) {
             if let Some(resolved) = self
                 .terminal_target_for_pane(ws_idx, pane_id)

--- a/src/app/terminal_targets.rs
+++ b/src/app/terminal_targets.rs
@@ -89,6 +89,7 @@ impl App {
                             .agent_instance_id()
                             .is_some_and(|id| id.to_string() == target)
                     })
+                    && self.target_is_agent(candidate)
             })
             .collect();
         if let Some(resolved) = self.single_terminal_match(target, instance_matches)? {
@@ -210,5 +211,42 @@ impl App {
                 .map(|cwd| cwd.display().to_string()),
             agent_status: pane_agent_status(terminal.state, pane.seen),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn instance_id_does_not_resolve_after_terminal_stops_being_an_agent() {
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            &crate::config::Config::default(),
+            true,
+            None,
+            api_rx,
+            crate::api::EventHub::default(),
+        );
+        app.state.workspaces = vec![crate::workspace::Workspace::test_new("one")];
+        app.state.ensure_test_terminals();
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = app.state.workspaces[0]
+            .terminal_id(pane_id)
+            .cloned()
+            .unwrap();
+        let terminal = app.state.terminals.get_mut(&terminal_id).unwrap();
+        terminal.set_detected_state(
+            Some(crate::detect::Agent::Codex),
+            crate::detect::AgentState::Idle,
+        );
+        terminal.ensure_agent_instance_id();
+        let agent_instance_id = terminal.agent_instance_id().unwrap().to_string();
+        terminal.set_detected_state(None, crate::detect::AgentState::Unknown);
+
+        assert!(matches!(
+            app.resolve_agent_target(&agent_instance_id),
+            Err(TerminalTargetError::NotFound { .. })
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ fn set_host_color_scheme_reports(enabled: bool) -> io::Result<()> {
     io::stdout().flush()
 }
 
+mod agent_instance;
 mod agent_resume;
 mod api;
 mod app;

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -9,7 +9,7 @@ pub mod plugin_registry;
 mod restore;
 mod snapshot;
 
-pub use self::io::{clear, clear_history, load, load_history, save};
+pub use self::io::{clear, clear_checked, clear_history, load, load_history, save, save_checked};
 pub use self::restore::restore;
 #[cfg(unix)]
 pub use self::restore::{handoff_pane_aliases, restore_handoff};

--- a/src/persist/io.rs
+++ b/src/persist/io.rs
@@ -84,23 +84,36 @@ pub(super) fn clear_path(path: &Path) -> std::io::Result<()> {
 }
 
 pub fn save(snapshot: &SessionSnapshot, history: Option<&SessionHistorySnapshot>) {
+    if let Err(err) = save_checked(snapshot, history) {
+        let path = session_path();
+        crate::logging::session_save_failed(&path, &err.to_string());
+    }
+}
+
+pub fn save_checked(
+    snapshot: &SessionSnapshot,
+    history: Option<&SessionHistorySnapshot>,
+) -> std::io::Result<()> {
     let path = session_path();
     let history_path = session_history_path();
-    if let Err(err) = save_to_paths(&path, &history_path, snapshot, history) {
-        crate::logging::session_save_failed(&path, &err.to_string());
-        return;
-    }
+    save_to_paths(&path, &history_path, snapshot, history)?;
     crate::logging::session_saved(&path, snapshot.workspaces.len());
+    Ok(())
 }
 
 pub fn clear() {
-    let path = session_path();
-    if let Err(err) = clear_path(&path) {
+    if let Err(err) = clear_checked() {
+        let path = session_path();
         crate::logging::session_clear_failed(&path, &err.to_string());
-        return;
     }
+}
+
+pub fn clear_checked() -> std::io::Result<()> {
+    let path = session_path();
+    clear_path(&path)?;
     clear_history();
     crate::logging::session_cleared(&path);
+    Ok(())
 }
 
 pub fn clear_history() {

--- a/src/persist/restore.rs
+++ b/src/persist/restore.rs
@@ -492,6 +492,9 @@ fn restore_tab(
 
         let saved_label = saved_pane.and_then(|p| p.label.clone());
         let saved_agent_name = saved_pane.and_then(|p| p.agent_name.clone());
+        let saved_agent_instance_id = saved_pane
+            .and_then(|pane| pane.agent_instance_id.as_deref())
+            .and_then(crate::agent_instance::AgentInstanceId::parse);
         let saved_managed_agent = saved_pane
             .and_then(|pane| pane.managed_agent_kind.as_deref())
             .and_then(crate::detect::parse_canonical_agent_label);
@@ -537,6 +540,12 @@ fn restore_tab(
             let terminal_id = TerminalId::alloc();
             let mut terminal = TerminalState::new(terminal_id.clone(), cwd.clone())
                 .with_pending_agent_resume_plan(plan);
+            if let (Some(agent_instance_id), Some(session)) = (
+                saved_agent_instance_id.clone(),
+                restored_agent_session.as_ref(),
+            ) {
+                terminal = terminal.with_pending_agent_instance_resume(agent_instance_id, session);
+            }
             if let Some(label) = saved_label {
                 terminal.set_manual_label(label);
             }
@@ -630,6 +639,9 @@ fn restore_tab(
                 let terminal_id = TerminalId::alloc();
                 let mut terminal = TerminalState::new(terminal_id.clone(), cwd.clone());
                 if was_imported {
+                    if let Some(agent_instance_id) = saved_agent_instance_id {
+                        terminal = terminal.with_agent_instance_id(agent_instance_id);
+                    }
                     if let Some(argv) = saved_launch_argv {
                         terminal = terminal.with_launch_argv(argv).with_respawn_shell_on_exit();
                     }
@@ -1190,6 +1202,7 @@ mod tests {
                             cwd,
                             label: Some("reviewer".into()),
                             agent_name: Some("reviewer".into()),
+                            agent_instance_id: None,
                             managed_agent_kind: Some("opencode".into()),
                             agent_session: Some(super::super::snapshot::PaneAgentSessionSnapshot {
                                 source: "herdr:opencode".into(),
@@ -1276,6 +1289,7 @@ mod tests {
                                 cwd: cwd.clone(),
                                 label: None,
                                 agent_name: None,
+                                agent_instance_id: None,
                                 managed_agent_kind: None,
                                 agent_session: None,
                                 launch_argv: None,
@@ -1287,6 +1301,7 @@ mod tests {
                                 cwd: cwd.clone(),
                                 label: None,
                                 agent_name: None,
+                                agent_instance_id: None,
                                 managed_agent_kind: None,
                                 agent_session: None,
                                 launch_argv: None,
@@ -1340,6 +1355,7 @@ mod tests {
                     cwd: cwd.clone(),
                     label: None,
                     agent_name: None,
+                    agent_instance_id: None,
                     managed_agent_kind: None,
                     agent_session: None,
                     launch_argv: None,
@@ -1350,6 +1366,7 @@ mod tests {
             cwd: cwd.clone(),
             label: Some("planner".into()),
             agent_name: Some("planner".into()),
+            agent_instance_id: None,
             managed_agent_kind: None,
             agent_session: Some(super::super::snapshot::PaneAgentSessionSnapshot {
                 source: "herdr:codex".into(),
@@ -1481,6 +1498,7 @@ mod tests {
     #[cfg(unix)]
     async fn native_agent_restore_defers_runtime_launch() {
         let cwd = std::env::current_dir().unwrap();
+        let saved_instance_id = crate::agent_instance::AgentInstanceId::alloc().to_string();
         let snapshot = SessionSnapshot {
             version: super::super::snapshot::SNAPSHOT_VERSION,
             workspaces: vec![WorkspaceSnapshot {
@@ -1501,6 +1519,7 @@ mod tests {
                             cwd,
                             label: None,
                             agent_name: None,
+                            agent_instance_id: Some(saved_instance_id.clone()),
                             managed_agent_kind: None,
                             agent_session: Some(super::super::snapshot::PaneAgentSessionSnapshot {
                                 source: "herdr:codex".into(),
@@ -1525,7 +1544,7 @@ mod tests {
         };
         let (events, _event_rx) = mpsc::channel(4);
 
-        let (_workspaces, terminals, runtimes) = restore(
+        let (_workspaces, mut terminals, runtimes) = restore(
             &snapshot,
             None,
             24,
@@ -1543,6 +1562,11 @@ mod tests {
             .values()
             .next()
             .expect("native agent restore should create terminal state");
+        assert_eq!(
+            terminal.agent_instance_id(),
+            None,
+            "cold restore must not expose the old instance before exact conversation proof"
+        );
         assert!(
             terminal.pending_agent_resume_plan.is_some(),
             "restored native agent panes should defer resume until client terminal context is known"
@@ -1554,6 +1578,19 @@ mod tests {
         assert!(
             runtimes.is_empty(),
             "native agent restore should not spawn a fallback-size runtime during snapshot restore"
+        );
+        let terminal = terminals.values_mut().next().unwrap();
+        let proof = terminal.set_agent_session_ref_for_session_start(
+            "herdr:codex".into(),
+            "codex".into(),
+            crate::agent_resume::AgentSessionRef::id("codex-session"),
+            Some(1),
+            Some("resume".into()),
+        );
+        assert!(proof.is_some(), "exact resumed session should be accepted");
+        assert_eq!(
+            terminal.agent_instance_id().map(ToString::to_string),
+            Some(saved_instance_id.clone())
         );
         let mut imports = HashMap::new();
         let (_handoff_workspaces, handoff_terminals, handoff_runtimes) = restore_handoff(
@@ -1667,6 +1704,7 @@ mod tests {
                 cwd: cwd.clone(),
                 label: None,
                 agent_name: None,
+                agent_instance_id: None,
                 managed_agent_kind: None,
                 agent_session: None,
                 launch_argv: None,

--- a/src/persist/snapshot.rs
+++ b/src/persist/snapshot.rs
@@ -102,6 +102,8 @@ pub struct PaneSnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_instance_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub managed_agent_kind: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_session: Option<PaneAgentSessionSnapshot>,
@@ -337,6 +339,9 @@ fn capture_tab(
                 )
             })
             .unwrap_or_default();
+        let agent_instance_id = terminal
+            .and_then(crate::terminal::TerminalState::agent_instance_id_for_snapshot)
+            .map(ToString::to_string);
         let launch_argv = terminal.and_then(|terminal| terminal.launch_argv.clone());
         let agent_session = terminal.and_then(|terminal| {
             if let Some(authority) = terminal.hook_authority.as_ref() {
@@ -365,6 +370,7 @@ fn capture_tab(
                 cwd,
                 label,
                 agent_name,
+                agent_instance_id,
                 managed_agent_kind,
                 agent_session,
                 launch_argv,
@@ -645,6 +651,7 @@ mod tests {
                 cwd: PathBuf::from("/home/can/Projects/herdr"),
                 label: None,
                 agent_name: None,
+                agent_instance_id: None,
                 managed_agent_kind: None,
                 agent_session: None,
                 launch_argv: None,
@@ -656,6 +663,7 @@ mod tests {
                 cwd: PathBuf::from("/home/can/Projects/website"),
                 label: Some("website".into()),
                 agent_name: None,
+                agent_instance_id: None,
                 managed_agent_kind: None,
                 agent_session: None,
                 launch_argv: None,
@@ -1176,6 +1184,39 @@ mod tests {
     }
 
     #[test]
+    fn capture_persists_instance_id_while_managed_start_is_pending() {
+        let mut state = state_with_workspaces(&["one"]);
+        let root = state.workspaces[0].tabs[0].root_pane;
+        state.ensure_test_terminals();
+        let terminal_id = state.workspaces[0].tabs[0].panes[&root]
+            .attached_terminal_id
+            .clone();
+        let terminal = state.terminals.get_mut(&terminal_id).unwrap();
+        let now = std::time::Instant::now();
+        terminal.begin_managed_agent(
+            "builder".into(),
+            crate::detect::Agent::Codex,
+            now,
+            std::time::Duration::from_secs(3),
+            std::time::Duration::from_secs(30),
+        );
+        let instance_id = terminal.agent_instance_id().unwrap().to_string();
+
+        let snapshot = capture_from_state(&state);
+        let saved = &snapshot.workspaces[0].tabs[0].panes[&root.raw()];
+
+        assert_eq!(
+            saved.agent_instance_id.as_deref(),
+            Some(instance_id.as_str())
+        );
+        assert_eq!(
+            saved.agent_name, None,
+            "pending launch is not resumable by name"
+        );
+        assert_eq!(saved.managed_agent_kind, None);
+    }
+
+    #[test]
     fn old_unversioned_snapshot_loads_as_version_0() {
         let json = r#"{"workspaces":[],"active":null,"selected":0}"#;
         let snap = parse_snapshot(json).unwrap();
@@ -1204,6 +1245,7 @@ mod tests {
                 cwd: PathBuf::from("/tmp/this-directory-does-not-exist-for-herdr-test"),
                 label: None,
                 agent_name: None,
+                agent_instance_id: None,
                 managed_agent_kind: None,
                 agent_session: None,
                 launch_argv: None,
@@ -1217,6 +1259,7 @@ mod tests {
                     .unwrap_or_else(|_| PathBuf::from("/tmp")),
                 label: None,
                 agent_name: None,
+                agent_instance_id: None,
                 managed_agent_kind: None,
                 agent_session: None,
                 launch_argv: None,

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -76,6 +76,14 @@ struct ManagedAgent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingAgentInstanceResume {
+    id: crate::agent_instance::AgentInstanceId,
+    source: String,
+    agent: String,
+    session_ref: crate::agent_resume::AgentSessionRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EffectiveStateChange {
     pub previous_agent_label: Option<String>,
     pub previous_known_agent: Option<Agent>,
@@ -119,6 +127,8 @@ struct RecentAgentProcessExit {
 /// metadata.
 pub struct TerminalState {
     pub id: TerminalId,
+    agent_instance_id: Option<crate::agent_instance::AgentInstanceId>,
+    pending_agent_instance_resume: Option<PendingAgentInstanceResume>,
     pub cwd: PathBuf,
     pub detected_agent: Option<Agent>,
     pub fallback_state: AgentState,
@@ -153,6 +163,8 @@ impl TerminalState {
     pub fn new(id: TerminalId, cwd: PathBuf) -> Self {
         Self {
             id,
+            agent_instance_id: None,
+            pending_agent_instance_resume: None,
             cwd,
             detected_agent: None,
             fallback_state: AgentState::Unknown,
@@ -246,6 +258,74 @@ impl TerminalState {
     pub fn with_respawn_shell_on_exit(mut self) -> Self {
         self.respawn_shell_on_exit = true;
         self
+    }
+
+    pub fn with_agent_instance_id(mut self, id: crate::agent_instance::AgentInstanceId) -> Self {
+        self.agent_instance_id = Some(id);
+        self.pending_agent_instance_resume = None;
+        self
+    }
+
+    pub fn with_pending_agent_instance_resume(
+        mut self,
+        id: crate::agent_instance::AgentInstanceId,
+        session: &crate::agent_resume::PersistedAgentSession,
+    ) -> Self {
+        self.pending_agent_instance_resume = Some(PendingAgentInstanceResume {
+            id,
+            source: session.source.clone(),
+            agent: session.agent.clone(),
+            session_ref: session.session_ref.clone(),
+        });
+        self
+    }
+
+    pub fn agent_instance_id(&self) -> Option<&crate::agent_instance::AgentInstanceId> {
+        self.agent_instance_id.as_ref()
+    }
+
+    pub fn agent_instance_id_for_snapshot(
+        &self,
+    ) -> Option<&crate::agent_instance::AgentInstanceId> {
+        self.agent_instance_id.as_ref().or_else(|| {
+            self.pending_agent_instance_resume
+                .as_ref()
+                .map(|pending| &pending.id)
+        })
+    }
+
+    pub fn ensure_agent_instance_id(&mut self) -> bool {
+        if self.agent_instance_id.is_some()
+            || self.pending_agent_instance_resume.is_some()
+            || !self.is_agent_terminal()
+        {
+            return false;
+        }
+        self.agent_instance_id = Some(crate::agent_instance::AgentInstanceId::alloc());
+        true
+    }
+
+    fn observe_resumed_agent_session(
+        &mut self,
+        source: &str,
+        agent: &str,
+        session_ref: &crate::agent_resume::AgentSessionRef,
+    ) -> bool {
+        let Some(pending) = self.pending_agent_instance_resume.take() else {
+            return false;
+        };
+        if pending.source == source && pending.agent == agent && pending.session_ref == *session_ref
+        {
+            self.agent_instance_id = Some(pending.id);
+        } else if self.is_agent_terminal() {
+            self.agent_instance_id = Some(crate::agent_instance::AgentInstanceId::alloc());
+        }
+        true
+    }
+
+    pub fn end_agent_instance(&mut self) {
+        self.agent_instance_id = None;
+        self.pending_agent_instance_resume = None;
     }
 
     #[cfg(any(windows, test))]
@@ -723,6 +803,9 @@ impl TerminalState {
                 }
             }
         }
+        let resume_proof = session_ref
+            .as_ref()
+            .map(|session_ref| (source.clone(), agent_label.clone(), session_ref.clone()));
         self.persisted_agent_session = None;
         self.hook_authority = Some(HookAuthority {
             source,
@@ -731,6 +814,9 @@ impl TerminalState {
             message,
             reported_at: now,
             session_ref,
+        });
+        let resumed_instance_changed = resume_proof.is_some_and(|(source, agent, session_ref)| {
+            self.observe_resumed_agent_session(&source, &agent, &session_ref)
         });
         let current_session = self.current_session_identity_for_persistence();
         Some(TerminalStateMutation {
@@ -741,7 +827,7 @@ impl TerminalState {
                 previous_presentation,
                 now,
             ),
-            session_ref_changed: previous_session != current_session,
+            session_ref_changed: previous_session != current_session || resumed_instance_changed,
             agent_released: false,
         })
     }
@@ -1587,6 +1673,8 @@ impl TerminalState {
             self.hook_authority = None;
         }
         self.reconcile_agent_name_owner(&agent_label, Some(&session_ref));
+        let resumed_instance_changed =
+            self.observe_resumed_agent_session(&source, &agent_label, &session_ref);
         self.persisted_agent_session = Some(crate::agent_resume::PersistedAgentSession {
             source,
             agent: agent_label,
@@ -1601,7 +1689,7 @@ impl TerminalState {
                 previous_presentation,
                 now,
             ),
-            session_ref_changed: previous_session != current_session,
+            session_ref_changed: previous_session != current_session || resumed_instance_changed,
             agent_released: false,
         })
     }
@@ -1901,6 +1989,8 @@ impl TerminalState {
         settle_delay: Duration,
         timeout: Duration,
     ) {
+        self.agent_instance_id = Some(crate::agent_instance::AgentInstanceId::alloc());
+        self.pending_agent_instance_resume = None;
         self.set_agent_name(name);
         self.agent_name_owner = Some(AgentNameOwner {
             agent_label: crate::detect::agent_label(kind).to_string(),
@@ -1963,6 +2053,7 @@ impl TerminalState {
                 && observed_expected
                 && known_agent.is_none();
         if clear {
+            self.end_agent_instance();
             self.clear_agent_name();
             return true;
         }
@@ -1990,6 +2081,7 @@ impl TerminalState {
                 return true;
             }
             if now >= deadline {
+                self.end_agent_instance();
                 self.clear_agent_name();
                 return true;
             }
@@ -2047,6 +2139,7 @@ impl TerminalState {
     }
 
     pub fn clear_agent_runtime_identity_after_respawn(&mut self) {
+        self.end_agent_instance();
         self.detected_agent = None;
         self.fallback_state = AgentState::Unknown;
         self.fallback_visible_blocker = false;
@@ -2200,6 +2293,49 @@ mod tests {
             agent: agent_label.into(),
             session_ref,
         });
+    }
+
+    #[test]
+    fn cold_resume_promotes_instance_only_for_exact_conversation() {
+        let session = crate::agent_resume::PersistedAgentSession {
+            source: "herdr:codex".into(),
+            agent: "codex".into(),
+            session_ref: crate::agent_resume::AgentSessionRef::id("conversation-a").unwrap(),
+        };
+        let saved_id = crate::agent_instance::AgentInstanceId::alloc();
+        let mut terminal =
+            test_terminal().with_pending_agent_instance_resume(saved_id.clone(), &session);
+
+        assert_eq!(terminal.agent_instance_id(), None);
+        assert!(terminal.observe_resumed_agent_session(
+            "herdr:codex",
+            "codex",
+            &crate::agent_resume::AgentSessionRef::id("conversation-a").unwrap(),
+        ));
+        assert_eq!(terminal.agent_instance_id(), Some(&saved_id));
+    }
+
+    #[test]
+    fn mismatched_cold_resume_never_reuses_saved_instance() {
+        let session = crate::agent_resume::PersistedAgentSession {
+            source: "herdr:codex".into(),
+            agent: "codex".into(),
+            session_ref: crate::agent_resume::AgentSessionRef::id("conversation-a").unwrap(),
+        };
+        let saved_id = crate::agent_instance::AgentInstanceId::alloc();
+        let mut terminal =
+            test_terminal().with_pending_agent_instance_resume(saved_id.clone(), &session);
+        terminal.set_detected_state(Some(Agent::Codex), AgentState::Idle);
+
+        assert!(terminal.observe_resumed_agent_session(
+            "herdr:codex",
+            "codex",
+            &crate::agent_resume::AgentSessionRef::id("conversation-b").unwrap(),
+        ));
+        let replacement = terminal
+            .agent_instance_id()
+            .expect("mismatched live agent should get a replacement instance");
+        assert_ne!(replacement, &saved_id);
     }
 
     #[test]

--- a/tests/live_handoff.rs
+++ b/tests/live_handoff.rs
@@ -1385,7 +1385,7 @@ fn live_handoff_keeps_agent_started_pane_after_agent_exits() {
     fs::write(
         &fake_pi,
         format!(
-            "#!/bin/sh\nexport HERDR_AGENT=pi\necho started > {}\n/bin/sleep 1\necho exited > {}\n",
+            "#!/bin/sh\nexport HERDR_AGENT=pi\necho started > {}\n/bin/sleep 8\necho exited > {}\n",
             started_marker.display(),
             exited_marker.display()
         ),
@@ -1416,20 +1416,42 @@ fn live_handoff_keeps_agent_started_pane_after_agent_exits() {
         .unwrap()
         .to_string();
 
-    let started = request(
-        &api_socket,
-        serde_json::json!({
-            "id": "test:agent-start",
-            "method": "agent.start",
-            "params": {
-                "name": "handoff-agent",
-                "kind": "pi",
-                "pane_id": pane_id,
-                "timeout_ms": 5000
-            }
-        }),
+    let start_deadline = Instant::now() + Duration::from_secs(10);
+    let started = loop {
+        let response = request(
+            &api_socket,
+            serde_json::json!({
+                "id": "test:agent-start",
+                "method": "agent.start",
+                "params": {
+                    "name": "handoff-agent",
+                    "kind": "pi",
+                    "pane_id": pane_id,
+                    "timeout_ms": 5000
+                }
+            }),
+        );
+        if response.get("result").is_some() {
+            break response;
+        }
+        assert_eq!(response["error"]["code"], "agent_pane_busy");
+        assert!(
+            Instant::now() < start_deadline,
+            "new pane shell never became available: {response}"
+        );
+        thread::sleep(Duration::from_millis(50));
+    };
+    assert_ok(started.clone());
+    let agent_instance_id = started["result"]["agent"]["agent_instance_id"]
+        .as_str()
+        .expect("agent.start must return an immutable instance id")
+        .to_string();
+    let session = fs::read_to_string(config_home.join("herdr-dev/session.json"))
+        .expect("agent.start success must follow durable session persistence");
+    assert!(
+        session.contains(&agent_instance_id),
+        "agent.start returned before its instance id was durable: {session}"
     );
-    assert_ok(started);
     support::wait_for_file(&started_marker, Duration::from_secs(5));
 
     assert_ok(request(
@@ -1438,8 +1460,32 @@ fn live_handoff_keeps_agent_started_pane_after_agent_exits() {
     ));
     drop(spawned);
     wait_for_api(&api_socket, Duration::from_secs(10));
-    support::wait_for_file(&exited_marker, Duration::from_secs(5));
+
+    let after_handoff = request(
+        &api_socket,
+        serde_json::json!({
+            "id": "test:agent-by-instance-after-handoff",
+            "method": "agent.get",
+            "params": {"target": agent_instance_id}
+        }),
+    );
+    assert_ok(after_handoff.clone());
+    assert_eq!(
+        after_handoff["result"]["agent"]["agent_instance_id"],
+        agent_instance_id
+    );
+    support::wait_for_file(&exited_marker, Duration::from_secs(12));
     thread::sleep(Duration::from_millis(300));
+
+    let stale = request(
+        &api_socket,
+        serde_json::json!({
+            "id": "test:stale-instance-after-exit",
+            "method": "agent.get",
+            "params": {"target": agent_instance_id}
+        }),
+    );
+    assert_eq!(stale["error"]["code"], "agent_not_found");
 
     assert_ok(request(
         &api_socket,


### PR DESCRIPTION
## Summary

- emit the exact managed-agent instance identity when a managed launch ends
- preserve the released instance id in pane agent events
- add coverage for timeout/release reporting

## Scope

This PR is a narrow implementation slice related to #3277. It does **not** claim the complete immutable-instance contract from the issue: durable identity across rename/move/handoff, cold restore proof, replacement generation, or stale lookup refusal remain follow-up work.

## Validation

The branch contains the implementation and its focused Rust test. Please review against current `master` and the full B1 acceptance list in #3277.
