### PR TITLE
fix(client): batch host palette updates

### DIFF
--- a/src/client/shell/input.rs
+++ b/src/client/shell/input.rs
@@ -58,6 +58,24 @@ fn host_theme_update(event: &RawInputEvent) -> Option<crate::protocol::ClientHos
     }
 }
 
+fn push_host_theme_update(
+    requests: &mut Vec<ClientMessage>,
+    update: crate::protocol::ClientHostThemeUpdate,
+) {
+    if let crate::protocol::ClientHostThemeUpdate::PaletteColors(colors) = &update {
+        if let Some(ClientMessage::ClientShellHostTheme {
+            update: crate::protocol::ClientHostThemeUpdate::PaletteColors(pending),
+        }) = requests.last_mut()
+        {
+            if pending.len() + colors.len() <= 256 {
+                pending.extend_from_slice(colors);
+                return;
+            }
+        }
+    }
+    requests.push(ClientMessage::ClientShellHostTheme { update });
+}
+
 impl ClientShellState {
     pub(crate) fn host_keyboard_report_all_requested(&self) -> bool {
         matches!(
@@ -142,9 +160,7 @@ impl ClientShellState {
         }
         for event in events {
             if let Some(update) = host_theme_update(&event) {
-                outcome
-                    .requests
-                    .push(ClientMessage::ClientShellHostTheme { update });
+                push_host_theme_update(&mut outcome.requests, update);
             }
             match event {
                 RawInputEvent::Key(key) => self.handle_key(key, &mut outcome),

--- a/src/client/shell/tests/input.rs
+++ b/src/client/shell/tests/input.rs
@@ -77,6 +77,34 @@ fn host_appearance_prefers_explicit_reports_over_background_inference() {
 }
 
 #[test]
+fn full_host_palette_response_is_sent_as_one_theme_update() {
+    use std::fmt::Write as _;
+
+    let mut state = ClientShellState::new(ClientShellConfig::from_config(&Config::default()));
+    let mut responses = String::new();
+    for index in 0..=u8::MAX {
+        let _ = write!(responses, "\x1b]4;{index};rgb:1111/2222/3333\x1b\\");
+    }
+
+    let outcome = state.handle_input_bytes(responses.as_bytes());
+
+    let [ClientMessage::ClientShellHostTheme {
+        update: crate::protocol::ClientHostThemeUpdate::PaletteColors(colors),
+    }] = outcome.requests.as_slice()
+    else {
+        panic!(
+            "expected one batched palette update, got {} requests",
+            outcome.requests.len()
+        );
+    };
+    assert_eq!(colors.len(), 256);
+    assert_eq!(
+        colors.iter().map(|(index, _)| *index).collect::<Vec<_>>(),
+        (0..=u8::MAX).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn modal_paste_shortcut_modifiers_are_platform_specific() {
     let key = |code, modifiers| crate::input::TerminalKey::new(code, modifiers);
 


### PR DESCRIPTION
## Summary

- batch a full 256-color host palette response into one client-shell theme update
- preserve message ordering and the existing 256-color protocol limit
- add regression coverage for the complete response path

## Tests

- `just check`