### PR TITLE
fix(windows): preserve LF paste order

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -3121,6 +3121,7 @@ impl PaneRuntime {
     }
 
     fn paste_payload(&self, text: String) -> Bytes {
+        let text = crate::platform::prepare_paste_text_for_pty(text);
         let bracketed = self.bracketed_paste_enabled();
         let payload = if bracketed {
             format!("\x1b[200~{text}\x1b[201~")

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -39,6 +39,15 @@ pub(crate) fn apply_pane_runtime_marker(command: &mut portable_pty::CommandBuild
     apply_pane_runtime_marker_platform(command);
 }
 
+pub(crate) fn prepare_paste_text_for_pty(text: String) -> String {
+    prepare_paste_text_for_pty_platform(text)
+}
+
+#[cfg(not(windows))]
+fn prepare_paste_text_for_pty_platform(text: String) -> String {
+    text
+}
+
 #[cfg(not(windows))]
 pub(crate) fn terminal_title_for_presentation(title: &str) -> &str {
     title

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -134,6 +134,10 @@ pub(crate) fn terminal_title_for_presentation(title: &str) -> &str {
     title.strip_prefix("Administrator: ").unwrap_or(title)
 }
 
+pub(crate) fn prepare_paste_text_for_pty_platform(text: String) -> String {
+    text.replace("\r\n", "\n").replace('\n', "\r\n")
+}
+
 /// Resolves against the current foreground layout because asynchronous console
 /// records do not retain the layout that was active when the key was pressed.
 pub(crate) fn resolve_base_printable_key(vk: u16, scan: u16) -> Option<char> {
@@ -2597,6 +2601,14 @@ mod tests {
     use windows_sys::Win32::System::Console::{
         AllocConsole, FreeConsole, GetConsoleProcessList, GetConsoleWindow,
     };
+
+    #[test]
+    fn paste_text_uses_windows_line_endings() {
+        assert_eq!(
+            super::prepare_paste_text_for_pty_platform("one\ntwo\r\nthree\rfour".to_owned()),
+            "one\r\ntwo\r\nthree\rfour"
+        );
+    }
 
     #[test]
     fn private_remote_directory_supports_long_paths() {

--- a/src/server/headless/tests/mod.rs
+++ b/src/server/headless/tests/mod.rs
@@ -4276,7 +4276,11 @@ fn terminal_attach_paste_uses_plain_text_when_runtime_did_not_enable_brackets() 
 
         assert_eq!(
             input_rx.try_recv().expect("forwarded paste"),
-            Bytes::from_static(b"line one\nline two")
+            Bytes::from_static(if cfg!(windows) {
+                b"line one\r\nline two"
+            } else {
+                b"line one\nline two"
+            })
         );
     });
 }
@@ -4289,7 +4293,11 @@ fn terminal_attach_paste_preserves_brackets_when_runtime_enabled_them() {
 
         assert_eq!(
             input_rx.try_recv().expect("forwarded paste"),
-            Bytes::from_static(b"\x1b[200~line one\nline two\x1b[201~")
+            Bytes::from_static(if cfg!(windows) {
+                b"\x1b[200~line one\r\nline two\x1b[201~"
+            } else {
+                b"\x1b[200~line one\nline two\x1b[201~"
+            })
         );
     });
 }


### PR DESCRIPTION
## Summary

- normalize semantic paste line endings for Windows ConPTY at the shared PTY formatter
- preserve existing CRLF and lone CR behavior while leaving raw/API input and non-Windows paste unchanged
- cover plain and bracketed paste payloads

## Validation

- `just test-one paste_text_uses_windows_line_endings`
- `just test-one terminal_attach_paste_`
- `just check`
- `just build`
- live Windows PowerShell reproduction: LF and CRLF both preserve command order

refs #3172
