### PR TITLE
fix: start on filesystems that cannot chmod socket files

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -7,9 +7,6 @@ use std::time::{Duration, Instant};
 use interprocess::local_socket::traits::{ListenerExt as _, Stream as _};
 use tracing::{debug, error, info, warn};
 
-#[cfg(all(test, unix))]
-use std::fs;
-
 use crate::api::schema::{
     ErrorBody, ErrorResponse, Method, Request, ResponseResult, ServerCapabilities, SuccessResponse,
 };
@@ -17,14 +14,13 @@ use crate::api::subscriptions::ActiveSubscription;
 use crate::api::wait::{prompt_agent, wait_for_agent, wait_for_event, wait_for_output};
 use crate::api::{request_changes_ui, socket_path, ApiRequestMessage, ApiRequestSender, EventHub};
 use crate::ipc::{
-    bind_local_listener, is_connection_closed_error, local_stream_peer_closed,
+    bind_private_local_listener, is_connection_closed_error, local_stream_peer_closed,
     poll_local_stream_read, remove_socket_file_if_owned, set_local_stream_polling,
     socket_file_identity, LocalStream, LocalStreamRead, SocketFileIdentity,
 };
 
 mod pane_graphics_stream;
 
-const SOCKET_PERMISSION_MODE: u32 = 0o600;
 pub(super) const CONNECTION_POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub(super) const APP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 const INITIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -81,8 +77,7 @@ fn start_server_inner(
     let path = socket_path();
     prepare_socket_path(&path)?;
 
-    let listener = bind_local_listener(&path)?;
-    restrict_socket_permissions(&path)?;
+    let listener = bind_private_local_listener(&path)?;
     let identity = socket_file_identity(&path)?;
     info!(path = %path.display(), "api server listening");
 
@@ -134,10 +129,6 @@ fn prepare_socket_path(path: &Path) -> std::io::Result<()> {
             path.display()
         )
     })
-}
-
-fn restrict_socket_permissions(path: &Path) -> std::io::Result<()> {
-    crate::ipc::restrict_socket_permissions(path, SOCKET_PERMISSION_MODE)
 }
 
 #[cfg(test)]
@@ -904,8 +895,6 @@ mod tests {
     use interprocess::local_socket::traits::Listener as _;
     use std::collections::HashMap;
     use std::io::{BufRead, BufReader};
-    use std::os::unix::fs::PermissionsExt;
-    use std::os::unix::net::UnixListener;
     use std::sync::{Mutex, OnceLock};
     use tokio::sync::mpsc;
 
@@ -1047,23 +1036,6 @@ mod tests {
 
         std::env::remove_var(crate::session::SESSION_ENV_VAR);
         std::env::remove_var("XDG_CONFIG_HOME");
-    }
-
-    #[test]
-    fn restrict_socket_permissions_sets_user_only_mode() {
-        let dir = unique_test_path("socket-perms");
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("api.sock");
-        let _listener = UnixListener::bind(&path).unwrap();
-
-        restrict_socket_permissions(&path).unwrap();
-
-        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, SOCKET_PERMISSION_MODE);
-
-        drop(_listener);
-        let _ = fs::remove_file(&path);
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -10,6 +10,10 @@ use interprocess::local_socket::traits::Stream as _;
 pub(crate) type LocalListener = interprocess::local_socket::Listener;
 pub(crate) type LocalStream = interprocess::local_socket::Stream;
 
+/// Sockets carrying terminal traffic are owner-only.
+#[cfg(unix)]
+const SOCKET_PERMISSION_MODE: u32 = 0o600;
+
 pub(crate) enum LocalStreamRead {
     Data,
     Pending,
@@ -51,6 +55,9 @@ pub(crate) fn connect_local_stream(path: &Path) -> io::Result<LocalStream> {
     }
 }
 
+/// Binds a listener without restricting who may connect. Production callers
+/// want [`bind_private_local_listener`].
+#[cfg(test)]
 pub(crate) fn bind_local_listener(path: &Path) -> io::Result<LocalListener> {
     #[cfg(unix)]
     {
@@ -138,12 +145,13 @@ pub(crate) fn shutdown_local_stream_write(stream: &LocalStream) -> io::Result<()
     }
 }
 
-/// Binds a listener for private terminal traffic. Unix callers restrict the
-/// socket file after binding; Windows must set the named-pipe DACL at creation.
+/// Binds a listener for private terminal traffic. Unix applies the socket mode
+/// to the descriptor before binding; Windows must set the named-pipe DACL at
+/// creation.
 pub(crate) fn bind_private_local_listener(path: &Path) -> io::Result<LocalListener> {
     #[cfg(unix)]
     {
-        bind_local_listener(path)
+        bind_private_socket(path, bind_local_listener_with_mode)
     }
 
     #[cfg(windows)]
@@ -165,6 +173,72 @@ pub(crate) fn bind_private_local_listener(path: &Path) -> io::Result<LocalListen
             .create_sync()?;
         fs::write(path, windows_socket_marker())?;
         Ok(listener)
+    }
+}
+
+/// Binds a private listener for callers that need the std `UnixListener` type.
+#[cfg(unix)]
+pub(crate) fn bind_private_unix_listener(
+    path: &Path,
+) -> io::Result<std::os::unix::net::UnixListener> {
+    match bind_private_socket(path, bind_local_listener_with_mode)? {
+        // `reclaim_name(false)` is already set, and the conversion forgets the
+        // reclaim guard, so unlinking stays the caller's responsibility.
+        LocalListener::UdSocket(listener) => Ok(listener.into()),
+    }
+}
+
+#[cfg(unix)]
+fn bind_local_listener_with_mode(path: &Path, mode: Option<u32>) -> io::Result<LocalListener> {
+    use interprocess::local_socket::{prelude::*, GenericFilePath, ListenerOptions};
+    use interprocess::os::unix::local_socket::ListenerOptionsExt as _;
+
+    let name = path.to_fs_name::<GenericFilePath>()?;
+    let options = ListenerOptions::new().name(name).reclaim_name(false);
+    match mode {
+        Some(mode) => options.mode(mode as libc::mode_t).create_sync(),
+        None => options.create_sync(),
+    }
+}
+
+/// Binds `path` so that only the owner can connect.
+///
+/// The mode is requested on the socket descriptor before `bind(2)`, so the
+/// pathname is never `chmod`ed. Filesystems that reject `fchmod` on a socket
+/// (virtiofs, and macOS for any unbound socket) surface `Unsupported`; those
+/// fall back to restricting the bound pathname instead. Any other bind error
+/// stays fatal.
+#[cfg(unix)]
+fn bind_private_socket<T>(
+    path: &Path,
+    bind: impl FnMut(&Path, Option<u32>) -> io::Result<T>,
+) -> io::Result<T> {
+    bind_private_socket_with(path, bind, |path| {
+        restrict_socket_permissions(path, SOCKET_PERMISSION_MODE)
+    })
+}
+
+#[cfg(unix)]
+fn bind_private_socket_with<T>(
+    path: &Path,
+    mut bind: impl FnMut(&Path, Option<u32>) -> io::Result<T>,
+    restrict: impl FnOnce(&Path) -> io::Result<()>,
+) -> io::Result<T> {
+    match bind(path, Some(SOCKET_PERMISSION_MODE)) {
+        Ok(bound) => Ok(bound),
+        Err(err) if err.kind() == io::ErrorKind::Unsupported => {
+            let bound = bind(path, None)?;
+            let identity = socket_file_identity(path)?;
+            if let Err(err) = restrict(path) {
+                // `reclaim_name(false)` means nothing unlinks the socket for
+                // us, so an unrestricted pathname would stay published.
+                drop(bound);
+                let _ = remove_socket_file_if_owned(path, &identity);
+                return Err(err);
+            }
+            Ok(bound)
+        }
+        Err(err) => Err(err),
     }
 }
 
@@ -333,15 +407,10 @@ fn windows_socket_marker() -> String {
 }
 
 #[cfg(unix)]
-pub(crate) fn restrict_socket_permissions(path: &Path, mode: u32) -> io::Result<()> {
+fn restrict_socket_permissions(path: &Path, mode: u32) -> io::Result<()> {
     let mut permissions = fs::metadata(path)?.permissions();
     permissions.set_mode(mode);
     fs::set_permissions(path, permissions)
-}
-
-#[cfg(windows)]
-pub(crate) fn restrict_socket_permissions(_path: &Path, _mode: u32) -> io::Result<()> {
-    Ok(())
 }
 
 #[cfg(test)]
@@ -436,5 +505,169 @@ mod tests {
     #[cfg(windows)]
     fn temp_socket_marker_path(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("herdr-{name}-{}.sock", std::process::id()))
+    }
+
+    #[cfg(unix)]
+    mod unix_socket_mode {
+        use super::*;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        fn unique_dir(name: &str) -> std::path::PathBuf {
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+            let dir = std::env::temp_dir().join(format!(
+                "herdr-ipc-{name}-{}-{}",
+                std::process::id(),
+                COUNTER.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir_all(&dir).unwrap();
+            dir
+        }
+
+        fn mode_of(path: &Path) -> u32 {
+            fs::symlink_metadata(path).unwrap().permissions().mode() & 0o777
+        }
+
+        #[test]
+        fn private_listener_binds_owner_only_without_touching_the_parent() {
+            let dir = unique_dir("owner-only");
+            let parent_mode = mode_of(&dir);
+            let path = dir.join("herdr.sock");
+
+            let listener = bind_private_local_listener(&path).unwrap();
+
+            assert_eq!(mode_of(&path), SOCKET_PERMISSION_MODE);
+            assert_eq!(
+                mode_of(&dir),
+                parent_mode,
+                "binding must not modify the parent directory"
+            );
+
+            drop(listener);
+            let _ = fs::remove_dir_all(&dir);
+        }
+
+        #[test]
+        fn private_unix_listener_binds_owner_only() {
+            let dir = unique_dir("owner-only-std");
+            let path = dir.join("herdr.sock");
+
+            let listener = bind_private_unix_listener(&path).unwrap();
+
+            assert_eq!(mode_of(&path), SOCKET_PERMISSION_MODE);
+
+            drop(listener);
+            let _ = fs::remove_dir_all(&dir);
+        }
+
+        #[test]
+        fn unsupported_creation_mode_falls_back_to_restricting_the_bound_socket() {
+            let dir = unique_dir("fallback");
+            let path = dir.join("herdr.sock");
+            let attempts = std::cell::Cell::new(0);
+
+            let listener = bind_private_socket(&path, |path, mode| {
+                attempts.set(attempts.get() + 1);
+                if mode.is_some() {
+                    // Stand in for virtiofs, and for macOS, where `fchmod` on an
+                    // unbound socket always fails this way.
+                    return Err(io::Error::from(io::ErrorKind::Unsupported));
+                }
+                bind_local_listener(path)
+            })
+            .unwrap();
+
+            assert_eq!(attempts.get(), 2, "the mode attempt must be retried once");
+            assert_eq!(mode_of(&path), SOCKET_PERMISSION_MODE);
+
+            drop(listener);
+            let _ = fs::remove_dir_all(&dir);
+        }
+
+        #[test]
+        fn creation_errors_other_than_unsupported_stay_fatal() {
+            // `interprocess` maps `fchmod`'s `EINVAL` to `Unsupported`, so no
+            // other kind may silently take the fallback path and bind a socket
+            // that nothing restricts.
+            for kind in [
+                io::ErrorKind::InvalidInput,
+                io::ErrorKind::PermissionDenied,
+                io::ErrorKind::AddrInUse,
+            ] {
+                let dir = unique_dir("fatal");
+                let path = dir.join("herdr.sock");
+                let attempts = std::cell::Cell::new(0);
+
+                let err = bind_private_socket(&path, |path, _mode| {
+                    attempts.set(attempts.get() + 1);
+                    let _ = path;
+                    Err::<LocalListener, _>(io::Error::from(kind))
+                })
+                .unwrap_err();
+
+                assert_eq!(err.kind(), kind);
+                assert_eq!(attempts.get(), 1, "{kind:?} must not be retried");
+                assert!(!path.exists());
+
+                let _ = fs::remove_dir_all(&dir);
+            }
+        }
+
+        #[test]
+        fn failed_restriction_unpublishes_the_socket_it_bound() {
+            let dir = unique_dir("restrict-fails");
+            let path = dir.join("herdr.sock");
+
+            let err = bind_private_socket_with(
+                &path,
+                |path, mode| {
+                    if mode.is_some() {
+                        return Err(io::Error::from(io::ErrorKind::Unsupported));
+                    }
+                    bind_local_listener(path)
+                },
+                |_| Err(io::Error::from(io::ErrorKind::PermissionDenied)),
+            )
+            .unwrap_err();
+
+            assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+            assert!(
+                !path.exists(),
+                "an unrestricted socket must not stay published"
+            );
+
+            let _ = fs::remove_dir_all(&dir);
+        }
+
+        #[test]
+        fn failed_restriction_leaves_a_replaced_socket_alone() {
+            let dir = unique_dir("replaced");
+            let path = dir.join("herdr.sock");
+            let mut survivor = None;
+
+            let err = bind_private_socket_with(
+                &path,
+                |path, mode| {
+                    if mode.is_some() {
+                        return Err(io::Error::from(io::ErrorKind::Unsupported));
+                    }
+                    bind_local_listener(path)
+                },
+                |path| {
+                    // Another process replaces the pathname after we bound it,
+                    // and then our restriction fails. The replacement is not
+                    // ours to unlink.
+                    fs::remove_file(path)?;
+                    survivor = Some(bind_local_listener(path)?);
+                    Err(io::Error::from(io::ErrorKind::PermissionDenied))
+                },
+            )
+            .unwrap_err();
+
+            assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+            assert!(path.exists(), "the replacement socket must survive");
+
+            drop(survivor);
+            let _ = fs::remove_dir_all(&dir);
+        }
     }
 }

--- a/src/remote/attach.rs
+++ b/src/remote/attach.rs
@@ -23,7 +23,6 @@ use std::time::{Duration, Instant};
 const BRIDGE_ACCEPT_POLL: Duration = Duration::from_millis(50);
 #[cfg(windows)]
 const BRIDGE_IO_POLL: Duration = Duration::from_millis(1);
-const BRIDGE_SOCKET_PERMISSION_MODE: u32 = 0o600;
 const REMOTE_SERVER_SHUTDOWN_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
 const REMOTE_SERVER_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const CURRENT_PROTOCOL: u32 = crate::protocol::PROTOCOL_VERSION;
@@ -1678,12 +1677,6 @@ impl SshStdioBridge {
         })?;
         let listener = crate::ipc::bind_private_local_listener(&local_socket)?;
         let socket_identity = crate::ipc::socket_file_identity(&local_socket)?;
-        if let Err(err) =
-            crate::ipc::restrict_socket_permissions(&local_socket, BRIDGE_SOCKET_PERMISSION_MODE)
-        {
-            let _ = crate::ipc::remove_socket_file_if_owned(&local_socket, &socket_identity);
-            return Err(err);
-        }
         if let Err(err) = listener.set_nonblocking(ListenerNonblockingMode::Accept) {
             let _ = crate::ipc::remove_socket_file_if_owned(&local_socket, &socket_identity);
             return Err(err);
@@ -2211,7 +2204,7 @@ mod tests {
         .expect("start bridge listener");
 
         let mode = std::fs::metadata(&socket).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, BRIDGE_SOCKET_PERMISSION_MODE);
+        assert_eq!(mode, 0o600);
 
         drop(bridge);
         let _ = std::fs::remove_file(socket);
@@ -2326,10 +2319,7 @@ mod tests {
         }
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(
-            mode, BRIDGE_SOCKET_PERMISSION_MODE,
-            "keepalive config must be user-only"
-        );
+        assert_eq!(mode, 0o600, "keepalive config must be user-only");
         // The config lives in a private 0700 dir, not a predictable temp path.
         let dir = path.parent().expect("config has a parent dir");
         let dir_mode = std::fs::metadata(dir).unwrap().permissions().mode() & 0o777;

--- a/src/server/handoff.rs
+++ b/src/server/handoff.rs
@@ -134,9 +134,8 @@ pub(crate) fn cleanup_failed_import_child(child: &mut Child) {
 #[cfg(unix)]
 pub(crate) fn bind_listener(socket_path: &Path) -> io::Result<UnixListener> {
     let _ = std::fs::remove_file(socket_path);
-    let listener = UnixListener::bind(socket_path)?;
+    let listener = crate::ipc::bind_private_unix_listener(socket_path)?;
     listener.set_nonblocking(true)?;
-    restrict_socket_permissions(socket_path)?;
     Ok(listener)
 }
 
@@ -321,13 +320,6 @@ pub(crate) fn manifest_for(
         panes,
         api_window_title,
     }
-}
-
-#[cfg(unix)]
-fn restrict_socket_permissions(path: &Path) -> io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
 }
 
 #[cfg(unix)]

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -40,7 +40,7 @@ use crate::app;
 use crate::config;
 use crate::events::AppEvent;
 use crate::ipc::{
-    bind_local_listener, remove_socket_file_if_owned, socket_file_identity, LocalListener,
+    bind_private_local_listener, remove_socket_file_if_owned, socket_file_identity, LocalListener,
     SocketFileIdentity,
 };
 use crate::protocol::{
@@ -66,9 +66,7 @@ use crate::server::pane_input::{
     apply_client_pane_input_events, apply_client_popup_input_events, apply_terminal_attach_input,
     apply_terminal_attach_scroll, terminal_attach_mouse_position,
 };
-use crate::server::socket_paths::{
-    client_socket_path, prepare_socket_path, restrict_socket_permissions,
-};
+use crate::server::socket_paths::{client_socket_path, prepare_socket_path};
 use crate::server::terminal_attach::paste_payload_for_runtime;
 
 mod bootstrap;
@@ -316,8 +314,7 @@ impl HeadlessServer {
         let client_path = client_socket_path();
         prepare_socket_path(&client_path)?;
 
-        let listener = bind_local_listener(&client_path)?;
-        restrict_socket_permissions(&client_path)?;
+        let listener = bind_private_local_listener(&client_path)?;
         let client_socket_identity = socket_file_identity(&client_path)?;
         info!(path = %client_path.display(), "client protocol socket listening");
 

--- a/src/server/headless/lifecycle.rs
+++ b/src/server/headless/lifecycle.rs
@@ -256,8 +256,7 @@ impl HeadlessServer {
 
         let client_path = client_socket_path();
         prepare_socket_path(&client_path)?;
-        let listener = bind_local_listener(&client_path)?;
-        restrict_socket_permissions(&client_path)?;
+        let listener = bind_private_local_listener(&client_path)?;
         let client_socket_identity = socket_file_identity(&client_path)?;
         listener.set_nonblocking(ListenerNonblockingMode::Accept)?;
 

--- a/src/server/headless/tests/mod.rs
+++ b/src/server/headless/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ipc::bind_local_listener;
 
 #[path = "pane_graphics.rs"]
 mod pane_graphics_tests;

--- a/src/server/socket_paths.rs
+++ b/src/server/socket_paths.rs
@@ -8,9 +8,6 @@ use std::path::{Path, PathBuf};
 /// client-only override when `HERDR_SOCKET_PATH` is not set.
 pub const CLIENT_SOCKET_PATH_ENV_VAR: &str = "HERDR_CLIENT_SOCKET_PATH";
 
-/// Socket permission mode (owner read/write only).
-const SOCKET_PERMISSION_MODE: u32 = 0o600;
-
 /// Returns the path for the client protocol socket.
 ///
 /// Contract-aligned override behavior:
@@ -67,11 +64,6 @@ pub(crate) fn prepare_socket_path(path: &Path) -> io::Result<()> {
             path.display()
         )
     })
-}
-
-/// Restricts socket file permissions to owner-only (0o600).
-pub(crate) fn restrict_socket_permissions(path: &Path) -> io::Result<()> {
-    crate::ipc::restrict_socket_permissions(path, SOCKET_PERMISSION_MODE)
 }
 
 #[cfg(all(test, unix))]


### PR DESCRIPTION
## Summary

- apply the socket mode to the descriptor before `bind(2)`, so the pathname is never `chmod`ed
- route the four listeners through the existing `ipc::bind_private_local_listener`, completing its Unix branch
- keep the current bind-then-restrict path as a fallback when `fchmod` on a socket is unsupported, which is always the case on macOS
- collapse four copies of `restrict_socket_permissions` into one constant and one implementation

`herdr server` exited `Os { code: 22, kind: InvalidInput }` when the config directory sat on a filesystem that rejects `chmod` on socket inodes. This is a crash fix, not a security fix: virtiofs discards the requested socket mode and enforces no Unix permissions between guest users, so nothing in-process can make the socket private there. Where permissions are enforced the socket is `0600` as before.

Supersedes #3377, which I closed; reasoning is in the closing comment there.

## Validation

- `just check`
- reporter's stack — Apple `container` 1.3.1, macOS 26.2, real `virtiofs (rw,relatime)`, cross-compiled `aarch64-unknown-linux-gnu`: `master` exits 1, this branch starts and serves `session list`, `pane list`, and named sessions
- `strace` on virtiofs and overlayfs: `fchmod(4, 0600) = 0` then `bind(...)`, and zero `chmod` calls on the pathname
- unit tests covering the mode, the `Unsupported` fallback, non-`Unsupported` errors staying fatal, and socket cleanup when the fallback restrict fails

refs #3212
