### PR TITLE
fix: statically link the Windows CRT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## Summary

- statically link the MSVC CRT for the Windows target
- apply the policy once through Cargo configuration for release, preview, manual artifact, and CI builds

## Validation

- `cargo build --release --locked --target x86_64-pc-windows-msvc`
- `dumpbin /DEPENDENTS target\x86_64-pc-windows-msvc\release\herdr.exe`
- `target\x86_64-pc-windows-msvc\release\herdr.exe --version`
- `just check`

Refs #3089