### PR TITLE
fix(integration): resolve Devin config on Windows

### DIFF
--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -175,9 +175,7 @@ herdr integration install devin
 
 The hook reports native session identity from Devin session, prompt, tool-use, permission, and stop events. Devin state still comes from Herdr's screen manifest and OSC detection because Devin hooks do not emit a reliable state transition after every permission cancellation or user interrupt.
 
-On Linux and macOS, Herdr uses `~/.config/devin` by default, or `$XDG_CONFIG_HOME/devin` when `XDG_CONFIG_HOME` is set. The Devin config directory must already exist. Install writes `herdr-agent-state.sh` and updates `config.json` with Herdr hook entries. The hook refreshes the session reference while Devin runs. Uninstall removes Herdr entries from `config.json` and deletes the hook script.
-
-Devin integration installation is not currently supported on Windows. Devin stores its Windows config under `%APPDATA%\devin`, which Herdr does not yet resolve. Native process and screen detection still work without the hook.
+Herdr uses `$XDG_CONFIG_HOME/devin` when `XDG_CONFIG_HOME` is set. Otherwise, it uses `~/.config/devin` on Linux and macOS or `%APPDATA%\devin` on Windows. The Devin config directory must already exist. Install writes `herdr-agent-state.sh` on Unix or `herdr-agent-state.ps1` on Windows and updates `config.json` with Herdr hook entries. The hook refreshes the session reference while Devin runs. Uninstall removes Herdr entries from `config.json` and deletes the hook script.
 
 Herdr resumes stored Devin sessions with `devin --resume <id>`. Native screen manifest detection remains the state authority whether or not the hook is installed.
 

--- a/docs/next/website/src/content/docs/ja/integrations.mdx
+++ b/docs/next/website/src/content/docs/ja/integrations.mdx
@@ -177,9 +177,7 @@ herdr integration install devin
 
 このフックは、Devin のセッション、プロンプト、ツール使用、許可、停止の各イベントからネイティブセッション識別を報告します。Devin のフックはすべての許可キャンセルやユーザー割り込みの後に信頼できる状態遷移を発行しないため、Devin の状態は引き続き Herdr のスクリーンマニフェストと OSC 検出から得られます。
 
-Linux と macOS では、Herdr はデフォルトで `~/.config/devin` を使い、`XDG_CONFIG_HOME` が設定されていれば `$XDG_CONFIG_HOME/devin` を使います。Devin の設定ディレクトリはあらかじめ存在している必要があります。インストールは `herdr-agent-state.sh` を書き込み、`config.json` に Herdr のフックエントリを追加します。フックは Devin の実行中にセッション参照を更新します。アンインストールは `config.json` から Herdr のエントリを削除し、フックスクリプトを削除します。
-
-Devin インテグレーションのインストールは、現在 Windows ではサポートされていません。Devin の Windows 設定は `%APPDATA%\devin` に保存されますが、Herdr はまだその場所を解決できません。フックがなくても、ネイティブプロセス検出とスクリーン検出は動作します。
+`XDG_CONFIG_HOME` が設定されていれば、Herdr は `$XDG_CONFIG_HOME/devin` を使います。それ以外では、Linux と macOS では `~/.config/devin`、Windows では `%APPDATA%\devin` を使います。Devin の設定ディレクトリはあらかじめ存在している必要があります。インストールは Unix では `herdr-agent-state.sh`、Windows では `herdr-agent-state.ps1` を書き込み、`config.json` に Herdr のフックエントリを追加します。フックは Devin の実行中にセッション参照を更新します。アンインストールは `config.json` から Herdr のエントリを削除し、フックスクリプトを削除します。
 
 Herdr は保存された Devin セッションを `devin --resume <id>` で resume します。フックのインストール有無にかかわらず、スクリーンマニフェスト検出が状態の権威のままです。
 

--- a/docs/next/website/src/content/docs/ja/windows-beta.mdx
+++ b/docs/next/website/src/content/docs/ja/windows-beta.mdx
@@ -51,7 +51,7 @@ Windows ビルドは安定版とプレビューの両方のアップデートチ
 
 Windows のエージェントプロセス検出は、ペインのシェルの子孫プロセスをスキャンし、npm/Node や Git Bash のプロセスチェーンを含む直接のエージェントと一般的なコマンドラッパーを認識します。Git Bash から起動したエージェントはエミュレートされた `exec` 境界を越えて追跡されますが、Unix のフォアグラウンドプロセスグループ検出と同じものではありません。
 
-Windows でインテグレーションをインストールできるのは、現在 Pi、OMP、Claude Code、Codex、GitHub Copilot CLI、OpenCode、Kilo Code CLI、Droid、Kimi Code CLI、Qoder CLI、Antigravity CLI です。利用可能な対象は Unix より少なく、インストール形式が Windows で未対応のインテグレーションは表示されないか拒否されます。Devin CLI のプロセス検出とスクリーン検出は Windows でも動作しますが、オプションのセッション識別フックは現在インストールできません。
+Windows でインテグレーションをインストールできるのは、現在 Pi、OMP、Claude Code、Codex、GitHub Copilot CLI、Devin CLI、OpenCode、Kilo Code CLI、Droid、Kimi Code CLI、Qoder CLI、Antigravity CLI です。利用可能な対象は Unix より少なく、インストール形式が Windows で未対応のインテグレーションは表示されないか拒否されます。
 
 プラグインは、プレビューとしてマニフェストのプラットフォームに `windows` をサポートします。GitHub インストール、ローカルリンク、ビルドコマンド、アクション、イベント、プラグインペインは Windows ではベストエフォートです。コマンドは argv 形式で Windows 互換である必要があります。`npm`、`bun`、`node` のような Node パッケージの shim は `PATH` にあれば動作するはずですが、`sh` や Bash を使う Unix 専用の例には Windows 向けの代替が必要です。プラットフォームフィルターは、未サポートのビルドコマンドをスキップし、未サポートのアクションやペインには `platform_unsupported` を返します。
 

--- a/docs/next/website/src/content/docs/windows-beta.mdx
+++ b/docs/next/website/src/content/docs/windows-beta.mdx
@@ -51,7 +51,7 @@ Local persistent sessions continue running after the client detaches or its term
 
 Windows agent process detection scans descendants of the pane shell and recognizes direct agents plus common command wrappers, including npm/Node and Git Bash process chains. It follows Git Bash-launched agents across emulated `exec` boundaries, but it is not the same as Unix foreground process-group detection.
 
-Windows integration installation currently supports Pi, OMP, Claude Code, Codex, GitHub Copilot CLI, OpenCode, Kilo Code CLI, Droid, Kimi Code CLI, Qoder CLI, and Antigravity CLI. Availability is narrower than on Unix; Herdr hides or rejects integrations whose install format is not supported on Windows. Devin CLI process and screen detection work on Windows, but its optional session-identity hook cannot currently be installed.
+Windows integration installation currently supports Pi, OMP, Claude Code, Codex, GitHub Copilot CLI, Devin CLI, OpenCode, Kilo Code CLI, Droid, Kimi Code CLI, Qoder CLI, and Antigravity CLI. Availability is narrower than on Unix; Herdr hides or rejects integrations whose install format is not supported on Windows.
 
 Plugins support `windows` as a manifest platform in preview. GitHub install, local link, build commands, actions, events, and plugin panes are best-effort on Windows. Commands are argv commands and must be Windows-compatible; Node package shims such as `npm`, `bun`, and `node` are expected to work when they are on `PATH`, while Unix-only examples using `sh` or Bash need Windows-specific alternatives. Platform filters skip unsupported build commands and return `platform_unsupported` for unsupported actions or panes.
 

--- a/docs/next/website/src/content/docs/zh-cn/integrations.mdx
+++ b/docs/next/website/src/content/docs/zh-cn/integrations.mdx
@@ -177,9 +177,7 @@ herdr integration install devin
 
 该钩子从 Devin 的会话、提示、工具使用、权限和停止事件中上报原生会话身份。Devin 的状态仍来自 Herdr 的屏幕清单和 OSC 检测,因为 Devin 钩子不会在每次权限取消或用户中断后都发出可靠的状态转换。
 
-在 Linux 和 macOS 上,Herdr 默认使用 `~/.config/devin`,设置了 `XDG_CONFIG_HOME` 时使用 `$XDG_CONFIG_HOME/devin`。Devin 配置目录必须已经存在。安装会写入 `herdr-agent-state.sh`,并向 `config.json` 添加 Herdr 钩子条目。钩子在 Devin 运行期间刷新会话引用。卸载会从 `config.json` 中移除 Herdr 条目并删除钩子脚本。
-
-Devin 集成目前不支持在 Windows 上安装。Devin 的 Windows 配置存放在 `%APPDATA%\devin`,Herdr 尚不能解析该位置。即使没有钩子,原生进程检测和屏幕检测仍然可用。
+设置了 `XDG_CONFIG_HOME` 时,Herdr 使用 `$XDG_CONFIG_HOME/devin`。否则,在 Linux 和 macOS 上使用 `~/.config/devin`,在 Windows 上使用 `%APPDATA%\devin`。Devin 配置目录必须已经存在。安装在 Unix 上写入 `herdr-agent-state.sh`,在 Windows 上写入 `herdr-agent-state.ps1`,并向 `config.json` 添加 Herdr 钩子条目。钩子在 Devin 运行期间刷新会话引用。卸载会从 `config.json` 中移除 Herdr 条目并删除钩子脚本。
 
 Herdr 用 `devin --resume <id>` 恢复保存的 Devin 会话。无论钩子是否安装,屏幕清单检测始终是状态权威。
 

--- a/docs/next/website/src/content/docs/zh-cn/windows-beta.mdx
+++ b/docs/next/website/src/content/docs/zh-cn/windows-beta.mdx
@@ -51,7 +51,7 @@ Windows 构建同时通过稳定版和预览版更新通道提供。新安装默
 
 Windows 智能体进程检测会扫描窗格 shell 的后代进程,识别直接运行的智能体和常见的命令包装器,包括 npm/Node 和 Git Bash 进程链。它会跨越模拟的 `exec` 边界跟踪从 Git Bash 启动的智能体,但这和 Unix 前台进程组检测不是一回事。
 
-Windows 目前支持安装 Pi、OMP、Claude Code、Codex、GitHub Copilot CLI、OpenCode、Kilo Code CLI、Droid、Kimi Code CLI、Qoder CLI 和 Antigravity CLI 集成。可用范围比 Unix 更窄;安装格式不受 Windows 支持的集成会被隐藏或拒绝。Devin CLI 的进程检测和屏幕检测可在 Windows 上工作,但目前无法安装其可选的会话身份钩子。
+Windows 目前支持安装 Pi、OMP、Claude Code、Codex、GitHub Copilot CLI、Devin CLI、OpenCode、Kilo Code CLI、Droid、Kimi Code CLI、Qoder CLI 和 Antigravity CLI 集成。可用范围比 Unix 更窄;安装格式不受 Windows 支持的集成会被隐藏或拒绝。
 
 插件以预览状态支持在清单中声明 `windows` 平台。GitHub 安装、本地链接、构建命令、动作、事件和插件窗格在 Windows 上尽力而为。命令是 argv 命令,必须兼容 Windows;`npm`、`bun`、`node` 之类的 Node 包 shim 只要在 `PATH` 上就应该能用,而使用 `sh` 或 Bash 的 Unix 专用示例需要 Windows 专用的替代方案。平台过滤器会跳过不支持的构建命令,并对不支持的动作或窗格返回 `platform_unsupported`。
 

--- a/src/integration/env.rs
+++ b/src/integration/env.rs
@@ -76,6 +76,11 @@ pub(crate) fn devin_dir() -> io::Result<PathBuf> {
         return expand_tilde_path(PathBuf::from(value)).map(|path| path.join("devin"));
     }
 
+    #[cfg(windows)]
+    if let Some(value) = std::env::var_os("APPDATA").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(value).join("devin"));
+    }
+
     Ok(home_dir()?.join(".config").join("devin"))
 }
 
@@ -215,7 +220,31 @@ pub(crate) fn home_dir() -> io::Result<PathBuf> {
 }
 
 #[cfg(test)]
-pub(crate) fn integration_env_lock() -> MutexGuard<'static, ()> {
+pub(crate) struct IntegrationEnvLock {
+    _guard: MutexGuard<'static, ()>,
+    #[cfg(windows)]
+    appdata: Option<std::ffi::OsString>,
+}
+
+#[cfg(test)]
+impl Drop for IntegrationEnvLock {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        if let Some(appdata) = self.appdata.take() {
+            std::env::set_var("APPDATA", appdata);
+        } else {
+            std::env::remove_var("APPDATA");
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn integration_env_lock() -> IntegrationEnvLock {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    let guard = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    IntegrationEnvLock {
+        _guard: guard,
+        #[cfg(windows)]
+        appdata: std::env::var_os("APPDATA"),
+    }
 }

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -134,6 +134,8 @@ fn clear_integration_path_env() {
     std::env::remove_var(COPILOT_HOME_ENV_VAR);
     std::env::remove_var(KIMI_CODE_HOME_ENV_VAR);
     std::env::remove_var("XDG_CONFIG_HOME");
+    #[cfg(windows)]
+    std::env::remove_var("APPDATA");
     std::env::remove_var(QODERCLI_CONFIG_DIR_ENV_VAR);
     std::env::remove_var(QWEN_HOME_ENV_VAR);
     std::env::remove_var(CURSOR_CONFIG_DIR_ENV_VAR);
@@ -206,6 +208,36 @@ fn home_dir_uses_userprofile_when_home_is_missing() {
         std::env::set_var("USERPROFILE", userprofile);
     } else {
         std::env::remove_var("USERPROFILE");
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_devin_dir_uses_appdata_without_xdg_override() {
+    let previous_appdata;
+    {
+        let _lock = integration_env_lock();
+        previous_appdata = std::env::var_os("APPDATA");
+        let previous_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let base = unique_base();
+        let appdata = base.join("appdata");
+        let xdg = base.join("xdg");
+        std::env::set_var("APPDATA", &appdata);
+
+        assert_eq!(devin_dir().unwrap(), appdata.join("devin"));
+
+        std::env::set_var("XDG_CONFIG_HOME", &xdg);
+        assert_eq!(devin_dir().unwrap(), xdg.join("devin"));
+
+        if let Some(value) = previous_xdg {
+            std::env::set_var("XDG_CONFIG_HOME", value);
+        } else {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+    }
+    {
+        let _lock = integration_env_lock();
+        assert_eq!(std::env::var_os("APPDATA"), previous_appdata);
     }
 }
 


### PR DESCRIPTION
## Summary

- Resolve the standard Devin config under %APPDATA%\devin on Windows while preserving an explicit XDG_CONFIG_HOME override.
- Add focused Windows resolver coverage and isolate integration status tests from real user AppData.
- Update the next-release English, Japanese, and Simplified Chinese docs.

## Validation

- just test-one windows_devin_dir_uses_appdata_without_xdg_override
- just test-one install_devin_writes_hook_and_updates_settings
- Isolated CLI install: exit 0; hook and config written under %APPDATA%\devin
- just check
- Review Suite fast: clean
- Ponytail review: lean

Refs #2724