### PR TITLE
fix: match claude bash permission prompts at every cursor position

### DIFF
--- a/distribution/agent-detection/claude.toml
+++ b/distribution/agent-detection/claude.toml
@@ -1,7 +1,7 @@
 id = "claude"
-version = "2026.08.31.1"
+version = "2026.09.04.1"
 min_engine_version = 2
-updated_at = "2026-08-31T00:00:00Z"
+updated_at = "2026-09-04T00:00:00Z"
 aliases = ["claude-code"]
 
 [[rules]]
@@ -162,8 +162,20 @@ any = [
   { contains = ["tab to amend"] },
   { contains = ["ctrl+e to explain"] },
 ]
+# Claude marks the selected option with "❯", so every option branch has to allow
+# that prefix. Numbered branches that omit it only match options the cursor has
+# moved away from, which left the resting layout below unmatched here (#2650):
+#   ❯ 1. Yes / 2. Yes, and don't ask again for: <cmd> / 3. No
+# Cover both the two-option and "don't ask again" three-option shapes so this
+# rule, not the narrower generic_permission_prompt, claims Bash approvals.
 all = [
-  { any = [{ line_regex = ['(?i)^\s*❯?\s*yes\b'] }, { line_regex = ['(?i)^\s*1\.\s*yes\b'] }, { line_regex = ['(?i)^\s*2\.\s*no\b'] }] },
+  { any = [
+    { line_regex = ['(?i)^\s*❯?\s*yes\b'] },
+    { line_regex = ['(?i)^\s*❯?\s*1\.\s*yes\b'] },
+    { line_regex = ['(?i)^\s*❯?\s*2\.\s*yes\b'] },
+    { line_regex = ['(?i)^\s*❯?\s*2\.\s*no\b'] },
+    { line_regex = ['(?i)^\s*❯?\s*3\.\s*no\b'] },
+  ] },
 ]
 
 [[rules]]

--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -739,6 +739,108 @@ fn claude_blocker_with_background_shell_remains_blocked() {
 }
 
 #[test]
+fn claude_bash_prompt_with_dont_ask_again_option_matches_bash_rule() {
+    // Captured from a Bash approval prompt at its resting cursor position. The
+    // "don't ask again" choice pushes No to option 3, so the only cursor-free
+    // option line is one bash_permission_prompt used not to cover, which let
+    // the narrower generic_permission_prompt claim the prompt instead (#2650).
+    let screen = concat!(
+        "────────────────────────────────────────────────────────────────
+",
+        " Bash command
+
+",
+        "   curl -sS -o /tmp/probe.html https://example.com
+",
+        "   Download example.com to /tmp/probe.html
+
+",
+        " This command requires approval
+
+",
+        " Do you want to proceed?
+",
+        " ❯ 1. Yes
+",
+        "   2. Yes, and don't ask again for: curl *
+",
+        "   3. No
+
+",
+        " Esc to cancel · Tab to amend · ctrl+e to explain
+",
+    );
+    let result = osc_explain(Agent::Claude, screen, "", "");
+
+    assert_eq!(result.state, AgentState::Blocked);
+    assert_eq!(
+        result.matched_rule.as_ref().map(|rule| rule.id.as_str()),
+        Some("bash_permission_prompt")
+    );
+    assert!(result.visible_blocker);
+}
+
+#[test]
+fn claude_permission_prompt_matches_at_every_cursor_position() {
+    // The selected option carries "❯", so no option branch may assume its line
+    // is cursor-free. Walk the cursor across both option layouts.
+    let layouts: [&[&str]; 2] = [
+        &[" ❯ 1. Yes", "   2. No"],
+        &[
+            " ❯ 1. Yes",
+            "   2. Yes, and don't ask again for: curl *",
+            "   3. No",
+        ],
+    ];
+
+    for layout in layouts {
+        for selected in 0..layout.len() {
+            let options: Vec<String> = layout
+                .iter()
+                .enumerate()
+                .map(|(index, line)| {
+                    let bare = line.trim_start().trim_start_matches('❯').trim_start();
+                    if index == selected {
+                        format!(" ❯ {bare}")
+                    } else {
+                        format!("   {bare}")
+                    }
+                })
+                .collect();
+            let screen = format!(
+                concat!(
+                    "────────────────────────────────────────────────────────────────
+",
+                    " Bash command
+
+",
+                    "   curl -sS https://example.com
+
+",
+                    " Do you want to proceed?
+",
+                    "{}
+
+",
+                    " Esc to cancel · Tab to amend · ctrl+e to explain
+",
+                ),
+                options.join("\n"),
+            );
+            let result = osc_explain(Agent::Claude, &screen, "", "");
+
+            assert_eq!(
+                result.matched_rule.as_ref().map(|rule| rule.id.as_str()),
+                Some("bash_permission_prompt"),
+                "{options:?} selected={selected}"
+            );
+            assert_eq!(result.state, AgentState::Blocked, "selected={selected}");
+            assert!(result.visible_blocker, "selected={selected}");
+        }
+    }
+}
+
+#[test]
 fn claude_osc_title_braille_prefix_is_working() {
     // "⠂" is U+2802, in the braille block U+2800-U+28FF
     let result = osc_explain(Agent::Claude, "", "⠂ project", "");

--- a/src/detect/manifests/claude.toml
+++ b/src/detect/manifests/claude.toml
@@ -1,7 +1,7 @@
 id = "claude"
-version = "2026.08.31.1"
+version = "2026.09.04.1"
 min_engine_version = 2
-updated_at = "2026-08-31T00:00:00Z"
+updated_at = "2026-09-04T00:00:00Z"
 aliases = ["claude-code"]
 
 [[rules]]
@@ -162,8 +162,20 @@ any = [
   { contains = ["tab to amend"] },
   { contains = ["ctrl+e to explain"] },
 ]
+# Claude marks the selected option with "❯", so every option branch has to allow
+# that prefix. Numbered branches that omit it only match options the cursor has
+# moved away from, which left the resting layout below unmatched here (#2650):
+#   ❯ 1. Yes / 2. Yes, and don't ask again for: <cmd> / 3. No
+# Cover both the two-option and "don't ask again" three-option shapes so this
+# rule, not the narrower generic_permission_prompt, claims Bash approvals.
 all = [
-  { any = [{ line_regex = ['(?i)^\s*❯?\s*yes\b'] }, { line_regex = ['(?i)^\s*1\.\s*yes\b'] }, { line_regex = ['(?i)^\s*2\.\s*no\b'] }] },
+  { any = [
+    { line_regex = ['(?i)^\s*❯?\s*yes\b'] },
+    { line_regex = ['(?i)^\s*❯?\s*1\.\s*yes\b'] },
+    { line_regex = ['(?i)^\s*❯?\s*2\.\s*yes\b'] },
+    { line_regex = ['(?i)^\s*❯?\s*2\.\s*no\b'] },
+    { line_regex = ['(?i)^\s*❯?\s*3\.\s*no\b'] },
+  ] },
 ]
 
 [[rules]]


### PR DESCRIPTION
## Summary

- allow the ❯ cursor prefix on every option branch in bash_permission_prompt
- cover the two-Yes, do-not-ask-again layout in the Bash rule
- bump the Claude manifest to 2026.09.04.1 and mirror it to the published catalog

Rule 850 dropped out on the resting three-option Bash layout (❯ 1. Yes / 2. Yes, … / 3. No), because its numbered branches omitted the cursor prefix and it did not cover the second Yes or third No options. The narrower generic_permission_prompt rule 840 claimed the prompt instead.

The updated Bash gate recognizes both two-option and three-option approval layouts at every cursor position, so the Bash-specific whole_recent rule wins on priority without broadening generic permission detection.

## Evidence

Issue #2650 includes a real Claude Code 2.1.226 detection-source snapshot showing the three-option Bash approval and rule 840 winning.

A live Claude Code 2.1.260 Bash approval was also checked in an isolated session through both manifests: 2026.08.31.1 selected rule 840 and 2026.09.04.1 selected rule 850. That capture rendered option 2 as Yes, and always allow access to the directory from this project, so the rule relies on stable numbered Yes and No controls rather than the full option prose.

Live session: https://claude.ai/code/session_011f1C5CWxCnGu4BTezGMJrx

## Validation

- just ci with only live_handoff_preserves_pane_process_io excluded: 2,930 Rust tests passed, plus maintenance, architecture, integration, and marketplace tests
- just windows-lint
- just docs-contract-test
- regression coverage for the reported snapshot and cursor movement across both Bash layouts
- bundled and published Claude manifests are byte-identical and pass the manifest catalog validator

On this machine, just check stops only at live_handoff_preserves_pane_process_io with PTY Invalid argument (os error 22); this is the same unrelated environmental failure documented before this narrowing.

refs #2650