### PR TITLE
fix: detect codex startup update prompts

### DIFF
--- a/distribution/agent-detection/codex.toml
+++ b/distribution/agent-detection/codex.toml
@@ -1,7 +1,7 @@
 id = "codex"
-version = "2026.08.28.1"
+version = "2026.09.05.1"
 min_engine_version = 3
-updated_at = "2026-08-28T00:00:00Z"
+updated_at = "2026-09-05T00:00:00Z"
 
 [[rules]]
 id = "osc_title_blocked"
@@ -41,6 +41,15 @@ all = [
   { regex = ['\A> You are in [^\r\n]+(?:\r?\n|$)'] },
   { regex = ['(?s)Do\s+you\s+trust\s+the\s+contents\s+of\s+this\s+directory\?'] },
 ]
+
+[[rules]]
+id = "startup_update"
+state = "blocked"
+priority = 950
+region = "bottom_non_empty_lines(20)"
+visible_blocker = true
+contains = ["Update available!", "Update now"]
+regex = ['Skip\s+until\s+next\s+version', 'Press enter to continue\s*\z']
 
 [[rules]]
 id = "live_strong_blocker"

--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -932,6 +932,47 @@ fn codex_trust_directory_requires_live_top_region() {
 }
 
 #[test]
+fn codex_startup_update_requires_complete_live_chooser() {
+    let chooser = "Update available! 0.153.0 -> 9.8.7\n\
+        Run bun add -g @openai/codex to update.\n\n\
+        › 1. Update now\n\
+          2. Skip until next version\n\n\
+        Press enter to continue   \n";
+    let wrapped = "✨ Update available! 0.153.0\n\n\
+        Release notes: https://example\n\n\
+        › 1. Update now (runs `npm\n\
+             install -g\n\
+             @openai/codex`)\n\
+          2. Skip\n\
+          3. Skip until next\n\
+             version\n\n\
+        Press enter to continue\n";
+
+    for screen in [chooser, wrapped] {
+        let result = osc_explain(Agent::Codex, screen, "project", "");
+        assert_eq!(result.state, AgentState::Blocked);
+        assert_eq!(
+            result.matched_rule.as_ref().map(|rule| rule.id.as_str()),
+            Some("startup_update")
+        );
+        assert!(result.visible_blocker);
+    }
+
+    for screen in [
+        chooser.replace("Update now", "Install"),
+        format!("{wrapped}\n› Ask Codex to do anything\n"),
+    ] {
+        let result = osc_explain(Agent::Codex, &screen, "project", "");
+        assert_eq!(result.state, AgentState::Idle);
+        assert_ne!(
+            result.matched_rule.as_ref().map(|rule| rule.id.as_str()),
+            Some("startup_update")
+        );
+        assert!(!result.visible_blocker);
+    }
+}
+
+#[test]
 fn codex_background_terminal_screen_does_not_override_osc_idle() {
     // Background terminal tasks can be long-lived helpers such as dev servers.
     // They should not make Codex look busy once the foreground turn is idle.

--- a/src/detect/manifests/codex.toml
+++ b/src/detect/manifests/codex.toml
@@ -1,7 +1,7 @@
 id = "codex"
-version = "2026.08.28.1"
+version = "2026.09.05.1"
 min_engine_version = 3
-updated_at = "2026-08-28T00:00:00Z"
+updated_at = "2026-09-05T00:00:00Z"
 
 [[rules]]
 id = "osc_title_blocked"
@@ -41,6 +41,15 @@ all = [
   { regex = ['\A> You are in [^\r\n]+(?:\r?\n|$)'] },
   { regex = ['(?s)Do\s+you\s+trust\s+the\s+contents\s+of\s+this\s+directory\?'] },
 ]
+
+[[rules]]
+id = "startup_update"
+state = "blocked"
+priority = 950
+region = "bottom_non_empty_lines(20)"
+visible_blocker = true
+contains = ["Update available!", "Update now"]
+regex = ['Skip\s+until\s+next\s+version', 'Press enter to continue\s*\z']
 
 [[rules]]
 id = "live_strong_blocker"


### PR DESCRIPTION
Codex's startup update chooser fell through to idle detection, allowing managed startup to report readiness while Update now was selected. Add a Codex blocker rule requiring the update controls and an end-anchored footer. It accepts wrapped option text and keeps the bundled and published manifests aligned.

Validation:
- Reproduced on Windows with Herdr 0.8.2 and Codex 0.153.0.
- Live hot reload: all three selections report blocked in wide and narrow panes; Skip clears the update rule; fresh managed startup returns `agent_not_ready`.
- One semantic regression covers complete and wrapped choosers, missing controls, and stale chooser text above a composer.
- `just check`, the focused regression, and both changed-manifest validations passed.

Distribution validation passed in CI. The direct Windows run hits an existing Grok exception digest mismatch caused by checkout CRLF conversion; the committed file matches its recorded exception. Temporary reproduction sessions and overrides were removed.

refs #3632
