### PR TITLE
fix: retain mouse selections across unrelated terminal output

### DIFF
--- a/src/client/shell/state.rs
+++ b/src/client/shell/state.rs
@@ -1564,8 +1564,7 @@ impl ClientShellState {
                 return false;
             };
             previous.content_revision != next.content_revision
-                && (!selection.is_in_progress()
-                    || !previous.content_revision.is_multiple_of(2)
+                && (!previous.content_revision.is_multiple_of(2)
                     || !next.content_revision.is_multiple_of(2)
                     || previous.inner_rect.width != next.inner_rect.width
                     || previous.inner_rect.height != next.inner_rect.height

--- a/src/client/shell/tests/copy.rs
+++ b/src/client/shell/tests/copy.rs
@@ -199,6 +199,16 @@ fn retained_mouse_selection_copies_only_on_exact_copy_shortcut() {
         .as_ref()
         .is_some_and(crate::selection::Selection::is_finalized));
 
+    // Agent output outside the selected text must not cancel a pending copy.
+    let mut updated = state.pane_surface.clone().expect("pane surface");
+    updated.panes[0].content_revision = 2;
+    updated.frame.cells[4].symbol = "-".into();
+    state.set_pane_surface(updated);
+    assert!(state
+        .selection
+        .as_ref()
+        .is_some_and(crate::selection::Selection::is_finalized));
+
     let copy = state.handle_raw_events(vec![RawInputEvent::Key(crate::input::TerminalKey::new(
         KeyCode::Char('c'),
         KeyModifiers::CONTROL,


### PR DESCRIPTION
With `ui.copy_on_select = false`, releasing a mouse selection made the next terminal content update clear it, even when only an agent spinner or another unselected row changed. Keep completed selections through the existing selected-cell stability check so Ctrl+C can still copy them. Changes to the selected text, unstable content revisions, geometry, and screen transitions still invalidate the selection.

Validation:
- Reproduced on master `7916be16` with a native Windows client regression: mouse down, drag, release, then update an unselected row. The selection assertion failed before the fix and passes after it.
- Windows client-shell tests: 141 passed; one unrelated worktree-path test fails because it expects Unix separators (`worktree_create_previews_the_endpoint_owned_checkout_path`).
- No live paid-agent or manual desktop reproduction; the regression drives the actual client mouse, surface-update, and Ctrl+C handlers.
- `just check` passed on Windows: formatting, Clippy, Windows/transport/input tests, and application build.
