### PR TITLE
chore(backup): preserve pre-reinstall work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ __pycache__/
 
 /.wrangler/
 **/.wrangler/
+/.worktrees/


### PR DESCRIPTION
## Summary
- preserve the existing local pre-reinstall Herdr work

## Validation
- branch pushed to personal fork
- build currently blocked because `zig` is not installed