### PR TITLE
test: handle actor shutdown in closed pty submission assertion

### DIFF
--- a/src/pty/actor/unix.rs
+++ b/src/pty/actor/unix.rs
@@ -1183,10 +1183,14 @@ mod tests {
             Bytes::from_static(b"\r"),
             Duration::ZERO,
         ) {
-            Ok(completion) => completion
-                .recv()
-                .expect("actor reports submission")
-                .expect_err("closed PTY rejects submission"),
+            Ok(completion) => match completion.recv_timeout(Duration::from_secs(1)) {
+                Ok(result) => result.expect_err("closed PTY rejects submission"),
+                // The actor can exit before processing the queued submission.
+                Err(std_mpsc::RecvTimeoutError::Disconnected) => return,
+                Err(std_mpsc::RecvTimeoutError::Timeout) => {
+                    panic!("actor did not reject submission after PTY closed")
+                }
+            },
             Err(err) => err,
         };
 


### PR DESCRIPTION
This commit fixes issue where the actor can exit before picking up the submission queued after the peer close which drops the channel and sometimes causes CI failure even though it is already handled in the API

The change wait at most one second for the reply.