### PR TITLE
feat: host remote servers in the signed-in windows desktop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "widestring",
+ "windows",
  "windows-sys",
  "wmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,12 @@ portable-pty = { path = "vendor/portable-pty" }
 # UTF-16 SDDL input for interprocess security descriptors.
 widestring = "1.2"
 wmi = { version = "0.18.4", default-features = false }
+windows = { version = "0.62.2", features = [
+    "Win32_System_Com",
+    "Win32_System_Ole",
+    "Win32_System_TaskScheduler",
+    "Win32_System_Variant",
+] }
 windows-sys = { version = "0.61.2", features = [
     "Wdk_System_Threading",
     "Win32_Foundation",
@@ -69,6 +75,7 @@ windows-sys = { version = "0.61.2", features = [
     "Win32_System_Memory",
     "Win32_System_Ole",
     "Win32_System_Pipes",
+    "Win32_System_RemoteDesktop",
     "Win32_System_Threading",
     "Win32_UI_Input_Ime",
     "Win32_UI_Input_KeyboardAndMouse",

--- a/docs/next/website/src/content/docs/connecting-machines.mdx
+++ b/docs/next/website/src/content/docs/connecting-machines.mdx
@@ -17,7 +17,7 @@ ssh workbox
 
 `workbox` can be a host from your SSH config. You can also use a target such as `ssh://you@server:2222`.
 
-Multi-machine connections are supported on Linux and macOS clients, connecting to Linux and macOS servers on x86_64 or aarch64. Multi-machine connections are not yet verified or supported on Windows; standalone `herdr --remote` remains supported on Windows. Native Windows servers are not supported as SSH targets. See [Remote attach over SSH](/docs/persistence-remote/#remote-attach-over-ssh) for SSH configuration, authentication, and custom binaries.
+Saved SSH machines support Linux, macOS, and Windows clients connecting to Linux or macOS hosts on x86_64 or aarch64, and Windows hosts on x86_64. Windows hosts need a compatible Herdr package installed first. See [Remote attach over SSH](/docs/persistence-remote/#remote-attach-over-ssh) for SSH configuration, authentication, desktop access, and custom binaries.
 
 ## Add a machine
 
@@ -36,6 +36,8 @@ herdr machine add workbox --label "Build machine" --remote-session agents
 ```
 
 Herdr checks both the installed binary and the running server. It starts the requested background server before saving the profile. Compatible client and server versions do not have to match. Missing or incompatible installations go through an approval-based setup. When the running server needs replacement, setup asks before stopping it and its pane processes, then starts the compatible server. The default answer is No. If installation and replacement are both needed, one confirmation covers them. `machine add` does not use experimental live handoff. Cancelling or failing setup leaves the profile unsaved.
+
+On Windows targets with desktop hosting support and an eligible signed-in account, setup offers desktop access before launching: **y** for this start only, **a** to remember approval for this machine/account, or **n** (the default) to continue without desktop access. An existing ordinary server stays running; stop it explicitly or choose another session to switch to desktop access. Background reconnect never starts a desktop server, even when approval is remembered.
 
 Run `herdr` to open the UI. If a local client is already open, added and enabled machines normally appear within a second and connect in the background without changing your selection. An in-progress machine switch finishes before profile changes are applied. The remote server keeps running after setup exits.
 
@@ -58,7 +60,6 @@ When a connection is lost, the last workspace and agent state remains visible bu
 Read profile IDs from the list rather than deriving them from labels or hostnames:
 
 ```bash
-herdr machine add windows-workbox --label "Desktop agents" --remote-desktop
 herdr machine list
 herdr machine rename <profile-id> --label "New name"
 herdr machine disable <profile-id>
@@ -98,7 +99,7 @@ Workspace, tab, pane IDs, and agent names are scoped to one server. Two machines
 
 ## Updates and saved data
 
-Saved profiles contain only an opaque ID, label, SSH target, explicit remote session, and enabled state. Herdr does not store passwords, private keys, agent tickets, or SSH control sockets in the catalog. Authentication stays with OpenSSH.
+Saved profiles contain only an opaque ID, label, SSH target, explicit remote session, enabled state, and required desktop placement. Remembered launch approval is stored separately on the client. Herdr does not store passwords, private keys, agent tickets, or SSH control sockets in the catalog. Authentication stays with OpenSSH.
 
 The client and server negotiate compatibility rather than requiring identical versions. Saved-machine connections additionally need the server's `surface_interest` and `health_check` capabilities. Older servers without those capabilities show Attention until explicitly updated, even if a standalone attach works. Other missing server methods disable only their corresponding actions.
 

--- a/docs/next/website/src/content/docs/connecting-machines.mdx
+++ b/docs/next/website/src/content/docs/connecting-machines.mdx
@@ -58,6 +58,7 @@ When a connection is lost, the last workspace and agent state remains visible bu
 Read profile IDs from the list rather than deriving them from labels or hostnames:
 
 ```bash
+herdr machine add windows-workbox --label "Desktop agents" --remote-desktop
 herdr machine list
 herdr machine rename <profile-id> --label "New name"
 herdr machine disable <profile-id>

--- a/docs/next/website/src/content/docs/persistence-remote.mdx
+++ b/docs/next/website/src/content/docs/persistence-remote.mdx
@@ -50,15 +50,17 @@ herdr --remote ssh://you@server:2222
 
 In this mode, the remote server owns the running panes and sends their terminal content and session state over SSH. Your local Herdr draws the UI, including its sidebar, menus, and theme. Because the client runs locally, Herdr can bridge local desktop features such as image clipboard paste into the remote session by copying the image to a remote temp file and pasting that path.
 
-Windows SSH normally starts processes outside the signed-in desktop. To let agents on a Windows target interact with desktop apps, opt in explicitly:
+Windows SSH normally starts processes outside the signed-in desktop. With a desktop-capable Windows Herdr package installed, the normal connection command offers desktop access before starting a server:
 
 ```bash
-herdr --remote windows-workbox --remote-desktop
+herdr --remote windows-workbox
 ```
 
-Install a Windows Herdr package that supports desktop hosting first. Herdr checks `PATH` and the active managed package, but this option does not install or update the remote binary.
+Choose **y** to allow this start once, **a** to remember approval for this SSH target and Windows host/account, or **n** (the default) to continue without desktop access. Herdr uses a temporary Task Scheduler task to launch in the account's single active desktop login, then removes the task. Remembered approval applies to future interactive connections; automatic reconnects only attach and never start desktop servers. To forget remembered approvals, remove `remote-desktop-approvals` from the client's state directory.
 
-To start a desktop server, Herdr requires exactly one active desktop login for the SSH account. It asks for confirmation, creates a one-time Windows task to launch the server in that login, and removes the task after the server is ready. Automatic reconnects only attach; they do not create tasks or start a server. A server with the same Herdr session name in Windows Session 0 or another login is left running and reported as a conflict. Use a different `--session` or stop that server explicitly. This option does not sign in, unlock Windows, or move existing panes between Windows sessions.
+An existing desktop server is reused. An ordinary server stays running, with an explanation that switching requires stopping it explicitly or choosing another `--session`. Without a unique active desktop login or desktop-capable package, ordinary SSH mode remains available. Desktop discovery must be able to identify active sessions; a query or account lookup failure is reported rather than guessing which login to use. Desktop hosting does not sign in, unlock Windows, or move existing panes between Windows sessions.
+
+Herdr checks `PATH` and the active managed Windows package; it does not install or update Windows packages. `--remote-desktop` remains available when desktop placement is required: declining or finding an ordinary server fails instead of falling back.
 
 By default, `herdr --remote` uses your local Herdr keybindings for that attach. This keeps local muscle memory even when the remote server has different config. After editing local keybindings, use the UI's `reload config` action to apply them without detaching. Use `--remote-keybindings server` when you want the remote server config instead. Local custom command keybindings are not sent, because those commands would run on the remote host.
 
@@ -77,7 +79,7 @@ Then attach with:
 herdr --remote workbox
 ```
 
-Remote attach and saved SSH machines support Linux, macOS, and Windows local clients connecting to Linux or macOS hosts on x86_64 and aarch64, or Windows hosts on x86_64. Local and remote versions do not need to match once both support the stable endpoint generation. On Linux and macOS hosts, Herdr prefers a compatible `herdr` already on the remote `PATH`, then checks common direct, Homebrew, mise, and Nix profile install paths. If no compatible binary exists, interactive runs prompt to install one to `~/.local/bin/herdr`; non-interactive runs fail instead of modifying the host. If `~/.local/bin` is not on the remote `PATH`, Herdr warns after install. Windows hosts must already have a compatible Herdr package with remote host support on `PATH`; remote attach does not install or update it.
+Remote attach and saved SSH machines support Linux, macOS, and Windows local clients connecting to Linux or macOS hosts on x86_64 and aarch64, or Windows hosts on x86_64. Local and remote versions do not need to match once both support the stable endpoint generation. On Linux and macOS hosts, Herdr prefers a compatible `herdr` already on the remote `PATH`, then checks common direct, Homebrew, mise, and Nix profile install paths. If no compatible binary exists, interactive runs prompt to install one to `~/.local/bin/herdr`; non-interactive runs fail instead of modifying the host. If `~/.local/bin` is not on the remote `PATH`, Herdr warns after install. Windows hosts must already have a compatible Herdr package with remote host support on `PATH` or in the active managed package; remote attach does not install or update it.
 
 By default, `herdr --remote` runs remote setup and the bridge through a temporary SSH config that includes your SSH config first, then adds fallback keepalive settings. Existing user keepalive settings win. Linux and macOS clients also use a private per-attach control socket for connection reuse; Windows OpenSSH does not. Set `[remote].manage_ssh_config = false` to use plain `ssh` without Herdr's generated config or control socket.
 

--- a/docs/next/website/src/content/docs/persistence-remote.mdx
+++ b/docs/next/website/src/content/docs/persistence-remote.mdx
@@ -50,6 +50,16 @@ herdr --remote ssh://you@server:2222
 
 In this mode, the remote server owns the running panes and sends their terminal content and session state over SSH. Your local Herdr draws the UI, including its sidebar, menus, and theme. Because the client runs locally, Herdr can bridge local desktop features such as image clipboard paste into the remote session by copying the image to a remote temp file and pasting that path.
 
+Windows SSH normally starts processes outside the signed-in desktop. To let agents on a Windows target interact with desktop apps, opt in explicitly:
+
+```bash
+herdr --remote windows-workbox --remote-desktop
+```
+
+Install a Windows Herdr package that supports desktop hosting first. Herdr checks `PATH` and the active managed package, but this option does not install or update the remote binary.
+
+To start a desktop server, Herdr requires exactly one active desktop login for the SSH account. It asks for confirmation, creates a one-time Windows task to launch the server in that login, and removes the task after the server is ready. Automatic reconnects only attach; they do not create tasks or start a server. A server with the same Herdr session name in Windows Session 0 or another login is left running and reported as a conflict. Use a different `--session` or stop that server explicitly. This option does not sign in, unlock Windows, or move existing panes between Windows sessions.
+
 By default, `herdr --remote` uses your local Herdr keybindings for that attach. This keeps local muscle memory even when the remote server has different config. After editing local keybindings, use the UI's `reload config` action to apply them without detaching. Use `--remote-keybindings server` when you want the remote server config instead. Local custom command keybindings are not sent, because those commands would run on the remote host.
 
 For repeat targets, use your SSH config:

--- a/docs/next/website/src/content/docs/windows-beta.mdx
+++ b/docs/next/website/src/content/docs/windows-beta.mdx
@@ -33,7 +33,7 @@ For internal testing, `HERDR_MANIFEST_URL` can point the installer at a custom m
 | Native panes through ConPTY | supported |
 | Windows Terminal / PowerShell app attach | supported |
 | `herdr --remote` and saved SSH machines to Linux/macOS/Windows hosts | supported; Windows requires a compatible package with remote host support on `PATH` |
-| Remote agents in the signed-in Windows desktop | supported with `--remote-desktop`; install a desktop-capable package first |
+| Remote agents in the signed-in Windows desktop | offered during remote setup; install a desktop-capable package first |
 | Remote clipboard images and image-file drops | supported |
 | `cmd.exe` panes | supported |
 | Native keyboard and mouse input | supported |
@@ -50,7 +50,7 @@ For internal testing, `HERDR_MANIFEST_URL` can point the installer at a custom m
 
 Local persistent sessions continue running after the client detaches or its terminal window closes. Servers and pane processes launched through Windows OpenSSH also survive logout; run `herdr` again to reconnect.
 
-Windows OpenSSH starts its normal server in Windows Session 0. Add `--remote-desktop` to a direct remote attach or `machine add` command when agents must interact with apps in the SSH account's active desktop login. Herdr asks before it uses a one-time Windows task for the initial start, removes the task after readiness, and leaves an existing server in another Windows session untouched.
+Windows OpenSSH starts its normal server in Windows Session 0. Normal remote attach and `machine add` offer desktop access before launching when the SSH account has one active desktop login. Choose once, always for this machine/account, or no (the default). Herdr launches through a temporary Task Scheduler task and removes it after readiness. Existing ordinary servers stay running; switching requires an explicit stop or another Herdr session. See [Remote attach over SSH](/docs/persistence-remote/#remote-attach-over-ssh) for remembered approval and reconnect behavior.
 
 Windows agent process detection scans descendants of the pane shell and recognizes direct agents plus common command wrappers, including npm/Node and Git Bash process chains. It follows Git Bash-launched agents across emulated `exec` boundaries, but it is not the same as Unix foreground process-group detection.
 
@@ -133,7 +133,7 @@ From Windows Terminal, use the same remote command as Linux and macOS:
 herdr --remote workbox
 ```
 
-The target host can run Linux, macOS, or Windows. Windows hosts must already have a compatible Herdr package with remote host support on `PATH`; remote attach does not install or update it. Herdr uses the installed Windows OpenSSH client and your SSH configuration. Windows OpenSSH does not use Herdr's Unix control-socket reuse, so key authentication through Windows `ssh-agent` is recommended to avoid repeated prompts during remote setup.
+The target host can run Linux, macOS, or Windows. Windows hosts must already have a compatible Herdr package with remote host support on `PATH` or in the active managed package; remote attach does not install or update it. Herdr uses the installed Windows OpenSSH client and your SSH configuration. Windows OpenSSH does not use Herdr's Unix control-socket reuse, so key authentication through Windows `ssh-agent` is recommended to avoid repeated prompts during remote setup.
 
 Windows updates run through the Windows installer and update the active versioned release path. New terminals and reconnected SSH sessions receive that path; start Herdr there to use the updated client. Compatible running servers keep their panes alive. Restart a server later only when you need server-side changes from the release. Live handoff is Unix-only.
 

--- a/docs/next/website/src/content/docs/windows-beta.mdx
+++ b/docs/next/website/src/content/docs/windows-beta.mdx
@@ -33,6 +33,7 @@ For internal testing, `HERDR_MANIFEST_URL` can point the installer at a custom m
 | Native panes through ConPTY | supported |
 | Windows Terminal / PowerShell app attach | supported |
 | `herdr --remote` and saved SSH machines to Linux/macOS/Windows hosts | supported; Windows requires a compatible package with remote host support on `PATH` |
+| Remote agents in the signed-in Windows desktop | supported with `--remote-desktop`; install a desktop-capable package first |
 | Remote clipboard images and image-file drops | supported |
 | `cmd.exe` panes | supported |
 | Native keyboard and mouse input | supported |
@@ -48,6 +49,8 @@ For internal testing, `HERDR_MANIFEST_URL` can point the installer at a custom m
 | Nested launch override | supported |
 
 Local persistent sessions continue running after the client detaches or its terminal window closes. Servers and pane processes launched through Windows OpenSSH also survive logout; run `herdr` again to reconnect.
+
+Windows OpenSSH starts its normal server in Windows Session 0. Add `--remote-desktop` to a direct remote attach or `machine add` command when agents must interact with apps in the SSH account's active desktop login. Herdr asks before it uses a one-time Windows task for the initial start, removes the task after readiness, and leaves an existing server in another Windows session untouched.
 
 Windows agent process detection scans descendants of the pane shell and recognizes direct agents plus common command wrappers, including npm/Node and Git Bash process chains. It follows Git Bash-launched agents across emulated `exec` boundaries, but it is not the same as Unix foreground process-group detection.
 

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -176,11 +176,15 @@ fn add(args: &[String]) -> std::io::Result<i32> {
             return Ok(2);
         }
     }
-    if let Err(error) = crate::remote::prepare_saved_ssh(&target, &session, windows_desktop) {
-        eprintln!("error: {error}; machine was not saved");
-        crate::remote::print_saved_ssh_error_hint(&error, &target);
-        return Ok(1);
-    }
+    let windows_desktop = match crate::remote::prepare_saved_ssh(&target, &session, windows_desktop)
+    {
+        Ok(desktop) => desktop,
+        Err(error) => {
+            eprintln!("error: {error}; machine was not saved");
+            crate::remote::print_saved_ssh_error_hint(&error, &target);
+            return Ok(1);
+        }
+    };
     // Setup can wait for human approval. Do not overwrite catalog edits made meanwhile.
     let mut catalog = load_catalog().map_err(|error| {
         std::io::Error::other(format!(

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -4,7 +4,7 @@ use crate::client::endpoint::{EndpointCatalog, ProfileId};
 
 const HELP: &str = "Usage:
   herdr machine list [--json]
-  herdr machine add <ssh-target> --label <label> [--remote-session <name>]
+  herdr machine add <ssh-target> --label <label> [--remote-session <name>] [--remote-desktop]
   herdr machine rename <profile-id> --label <label>
   herdr machine remove <profile-id>
   herdr machine enable <profile-id>
@@ -14,7 +14,7 @@ Add prepares the remote Herdr installation and starts its server before saving.
 Missing or incompatible installations require approval in an interactive terminal.
 Changes apply automatically to open local Herdr clients.
 Removing or disabling a machine leaves its remote sessions running.
-Saved machines contain only a label, SSH target, explicit Herdr session, and enabled state.
+Saved machines contain a label, SSH target, explicit Herdr session, enabled state, and desktop hosting choice.
 SSH credentials and key material remain owned by OpenSSH.";
 
 #[derive(Serialize)]
@@ -25,6 +25,7 @@ struct MachineListRow<'a> {
     session: &'a str,
     enabled: bool,
     selected: bool,
+    windows_desktop: bool,
 }
 
 pub(super) fn run_machine_command(args: &[String]) -> std::io::Result<i32> {
@@ -66,6 +67,7 @@ fn list(args: &[String]) -> std::io::Result<i32> {
             session: &profile.session,
             enabled: profile.enabled,
             selected: catalog.selected_profile.as_ref() == Some(&profile.id),
+            windows_desktop: profile.windows_desktop,
         })
         .collect::<Vec<_>>();
     if json {
@@ -94,6 +96,7 @@ struct AddArgs {
     target: String,
     label: String,
     session: String,
+    windows_desktop: bool,
 }
 
 fn parse_add_args(args: &[String]) -> Result<AddArgs, String> {
@@ -101,6 +104,7 @@ fn parse_add_args(args: &[String]) -> Result<AddArgs, String> {
     let mut target = None;
     let mut label = None;
     let mut session = None;
+    let mut windows_desktop = false;
     let mut index = 0;
     while index < args.len() {
         let (name, value) = match args[index].as_str() {
@@ -111,6 +115,12 @@ fn parse_add_args(args: &[String]) -> Result<AddArgs, String> {
                 index += 2;
                 (args[index - 2].as_str(), value.clone())
             }
+            "--remote-desktop" if !windows_desktop => {
+                windows_desktop = true;
+                index += 1;
+                continue;
+            }
+            "--remote-desktop" => return Err("--remote-desktop can only be specified once".into()),
             positional if !positional.starts_with('-') && target.is_none() => {
                 target = Some(positional.to_owned());
                 index += 1;
@@ -141,6 +151,7 @@ fn parse_add_args(args: &[String]) -> Result<AddArgs, String> {
         target,
         label,
         session,
+        windows_desktop,
     })
 }
 
@@ -149,6 +160,7 @@ fn add(args: &[String]) -> std::io::Result<i32> {
         target,
         label,
         session,
+        windows_desktop,
     } = match parse_add_args(args) {
         Ok(args) => args,
         Err(error) => {
@@ -157,14 +169,14 @@ fn add(args: &[String]) -> std::io::Result<i32> {
         }
     };
     let mut catalog = load_catalog()?;
-    match catalog.add_ssh(label.clone(), &target, session.clone()) {
+    match catalog.add_ssh(label.clone(), &target, session.clone(), windows_desktop) {
         Ok(_) => {}
         Err(error) => {
             eprintln!("error: {error}");
             return Ok(2);
         }
     }
-    if let Err(error) = crate::remote::prepare_saved_ssh(&target, &session) {
+    if let Err(error) = crate::remote::prepare_saved_ssh(&target, &session, windows_desktop) {
         eprintln!("error: {error}; machine was not saved");
         crate::remote::print_saved_ssh_error_hint(&error, &target);
         return Ok(1);
@@ -175,7 +187,7 @@ fn add(args: &[String]) -> std::io::Result<i32> {
             "remote prepared, but machine was not saved: {error}"
         ))
     })?;
-    let id = match catalog.add_ssh(label, target, session) {
+    let id = match catalog.add_ssh(label, target, session, windows_desktop) {
         Ok(id) => id,
         Err(error) => {
             eprintln!("error: {error}");
@@ -324,6 +336,7 @@ mod tests {
                     target: "workstation.coder".into(),
                     label: "coder".into(),
                     session: session.into(),
+                    windows_desktop: false,
                 },
                 "{args:?}"
             );
@@ -373,6 +386,7 @@ mod tests {
             session: "agents",
             enabled: true,
             selected: false,
+            windows_desktop: false,
         })
         .unwrap();
         assert!(!encoded.contains("password"));

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -252,6 +252,7 @@ struct ClientStatusJson {
     protocol: u32,
     endpoint_protocol_generation: u32,
     endpoint_capabilities: Vec<&'static str>,
+    remote_desktop_host: bool,
     binary: String,
     session: Option<String>,
 }
@@ -297,6 +298,7 @@ fn client_status_json() -> ClientStatusJson {
             crate::protocol::endpoint::PRESENTATION_EFFECTS_FENCE_CAPABILITY,
             crate::protocol::endpoint::HEALTH_CHECK_CAPABILITY,
         ],
+        remote_desktop_host: cfg!(windows),
         binary: current_exe_label(),
         session: crate::session::active_name(),
     }

--- a/src/cli/target.rs
+++ b/src/cli/target.rs
@@ -79,6 +79,7 @@ pub(super) fn api_client() -> io::Result<ApiClient> {
                     target.profile.id.as_str(),
                     &target.profile.target,
                     &target.profile.session,
+                    target.profile.windows_desktop,
                 )
                 .map_err(|error| {
                     io::Error::new(

--- a/src/client/catalog_reload.rs
+++ b/src/client/catalog_reload.rs
@@ -200,7 +200,7 @@ mod tests {
                 let now = Instant::now();
                 let mut state = state();
                 let mut catalog = EndpointCatalog::default();
-                let id = catalog.add_ssh("Build", "build", "main").unwrap();
+                let id = catalog.add_ssh("Build", "build", "main", false).unwrap();
                 let remote = ClientEndpointId::Ssh(id.clone());
                 catalog.select_ssh(&id);
                 state

--- a/src/client/endpoint/activation_tests.rs
+++ b/src/client/endpoint/activation_tests.rs
@@ -92,6 +92,7 @@ fn shell_and_registry_with_source_failure(source_fail_after_write: bool) -> Test
         target: "dev@example.com".into(),
         session: "main".into(),
         enabled: true,
+        windows_desktop: false,
     };
     let target = ClientEndpointId::Ssh(profile.id.clone());
     shell.set_endpoint_catalog(&[profile]);

--- a/src/client/endpoint/catalog.rs
+++ b/src/client/endpoint/catalog.rs
@@ -23,6 +23,8 @@ pub(crate) struct SavedSshEndpoint {
     pub(crate) target: String,
     pub(crate) session: String,
     pub(crate) enabled: bool,
+    #[serde(default)]
+    pub(crate) windows_desktop: bool,
 }
 
 impl SavedSshEndpoint {
@@ -37,6 +39,7 @@ impl SavedSshEndpoint {
             target: target.into(),
             session: session.into(),
             enabled: true,
+            windows_desktop: false,
         };
         profile.validate()?;
         Ok(profile)
@@ -162,11 +165,13 @@ impl EndpointCatalog {
         label: impl Into<String>,
         target: impl Into<String>,
         session: impl Into<String>,
+        windows_desktop: bool,
     ) -> Result<ProfileId, String> {
         if self.ssh.len() >= MAX_PROFILES {
             return Err(format!("at most {MAX_PROFILES} SSH endpoints can be saved"));
         }
-        let profile = SavedSshEndpoint::new(label, target, session)?;
+        let mut profile = SavedSshEndpoint::new(label, target, session)?;
+        profile.windows_desktop = windows_desktop;
         let id = profile.id.clone();
         self.ssh.push(profile);
         Ok(id)
@@ -397,7 +402,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
         let mut catalog = EndpointCatalog::default();
         let id = catalog
-            .add_ssh("Build", "ssh://dev@build.example:2222", "agents")
+            .add_ssh("Build", "ssh://dev@build.example:2222", "agents", true)
             .unwrap();
         assert!(catalog.select_ssh(&id));
         catalog.store_to_path(&path).unwrap();
@@ -409,14 +414,35 @@ mod tests {
         let loaded = EndpointCatalog::load_from_path(&path).unwrap();
         assert_eq!(loaded, catalog);
         assert_eq!(loaded.ssh[0].id, id);
+        assert!(loaded.ssh[0].windows_desktop);
         std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn catalogs_from_before_desktop_hosting_default_to_normal_ssh() {
+        let catalog: EndpointCatalog = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "ssh": [{
+                "id": "0123456789abcdef0123456789abcdef",
+                "label": "Build",
+                "target": "build",
+                "session": "default",
+                "enabled": true
+              }]
+            }"#,
+        )
+        .unwrap();
+
+        assert!(!catalog.ssh[0].windows_desktop);
+        catalog.validate().unwrap();
     }
 
     #[test]
     fn duplicate_target_and_session_profiles_keep_distinct_opaque_ids() {
         let mut catalog = EndpointCatalog::default();
-        let first = catalog.add_ssh("One", "build", "default").unwrap();
-        let second = catalog.add_ssh("Two", "build", "default").unwrap();
+        let first = catalog.add_ssh("One", "build", "default", false).unwrap();
+        let second = catalog.add_ssh("Two", "build", "default", false).unwrap();
         assert_ne!(first, second);
     }
 
@@ -424,21 +450,21 @@ mod tests {
     fn catalog_rejects_passwords_embedded_in_ssh_targets() {
         let mut catalog = EndpointCatalog::default();
         assert!(catalog
-            .add_ssh("Build", "ssh://dev:secret@build.example", "default")
+            .add_ssh("Build", "ssh://dev:secret@build.example", "default", false)
             .unwrap_err()
             .contains("must not contain a password"));
         assert!(catalog
-            .add_ssh("Build", "dev:secret@build.example", "default")
+            .add_ssh("Build", "dev:secret@build.example", "default", false)
             .is_err());
         assert!(catalog
-            .add_ssh("Build", "ssh://dev@[::1]:2222", "default")
+            .add_ssh("Build", "ssh://dev@[::1]:2222", "default", false)
             .is_ok());
     }
 
     #[test]
     fn interactive_bootstrap_matches_only_enabled_target_and_session() {
         let mut catalog = EndpointCatalog::default();
-        let id = catalog.add_ssh("Build", "build", "agents").unwrap();
+        let id = catalog.add_ssh("Build", "build", "agents", false).unwrap();
         assert!(catalog.contains_enabled_target_session("build", "agents"));
         assert!(!catalog.contains_enabled_target_session("build", "default"));
         assert!(catalog.set_enabled(&id, false));
@@ -448,7 +474,7 @@ mod tests {
     #[test]
     fn rename_changes_only_the_machine_label() {
         let mut catalog = EndpointCatalog::default();
-        let id = catalog.add_ssh("Old", "build", "agents").unwrap();
+        let id = catalog.add_ssh("Old", "build", "agents", false).unwrap();
         let original = catalog.ssh[0].clone();
 
         assert!(catalog.rename_ssh(&id, "New").unwrap());
@@ -463,7 +489,7 @@ mod tests {
     #[test]
     fn removal_and_disable_return_selection_to_local() {
         let mut catalog = EndpointCatalog::default();
-        let first = catalog.add_ssh("One", "one", "default").unwrap();
+        let first = catalog.add_ssh("One", "one", "default", false).unwrap();
         assert!(catalog.select_ssh(&first));
         assert!(catalog.set_enabled(&first, false));
         assert_eq!(catalog.selected_profile, None);
@@ -506,7 +532,7 @@ mod tests {
         let selection_path = catalog_path.with_file_name("selection.json");
         let _ = std::fs::remove_dir_all(catalog_path.parent().unwrap());
         let mut catalog = EndpointCatalog::default();
-        let id = catalog.add_ssh("Build", "build", "agents").unwrap();
+        let id = catalog.add_ssh("Build", "build", "agents", false).unwrap();
         catalog.store_to_path(&catalog_path).unwrap();
         let profiles_before = std::fs::read(&catalog_path).unwrap();
 
@@ -530,7 +556,7 @@ mod tests {
         let selection_path = catalog_path.with_file_name("selection.json");
         let _ = std::fs::remove_dir_all(catalog_path.parent().unwrap());
         let mut catalog = EndpointCatalog::default();
-        let id = catalog.add_ssh("Build", "build", "agents").unwrap();
+        let id = catalog.add_ssh("Build", "build", "agents", false).unwrap();
         catalog.store_to_path(&catalog_path).unwrap();
         std::fs::write(&selection_path, b"not json").unwrap();
 
@@ -547,7 +573,7 @@ mod tests {
         let selection_path = catalog_path.with_file_name("selection.json");
         let _ = std::fs::remove_dir_all(catalog_path.parent().unwrap());
         let mut catalog = EndpointCatalog::default();
-        let saved = catalog.add_ssh("Build", "build", "agents").unwrap();
+        let saved = catalog.add_ssh("Build", "build", "agents", false).unwrap();
         catalog.store_to_path(&catalog_path).unwrap();
         let missing = ProfileId::parse("fedcba9876543210fedcba9876543210").unwrap();
         store_private_json(

--- a/src/client/endpoint/supervisor.rs
+++ b/src/client/endpoint/supervisor.rs
@@ -114,6 +114,7 @@ impl EndpointSupervisors {
                     && profile.enabled
                     && profile.target == previous.target
                     && profile.session == previous.session
+                    && profile.windows_desktop == previous.windows_desktop
             });
             if !keep {
                 retired.push(endpoint_id.clone());
@@ -257,9 +258,9 @@ fn connect_once(
             (stream, Box::new(()))
         }
         ConnectTarget::Ssh(profile) => {
-            let connected = crate::remote::connect_saved_ssh(profile.id.as_str(), &profile.target, &profile.session).map_err(|error| {
+            let connected = crate::remote::connect_saved_ssh(profile.id.as_str(), &profile.target, &profile.session, profile.windows_desktop).map_err(|error| {
                 if failure_needs_attention(&error) {
-                    std::io::Error::new(error.kind(), format!("{error}. Run `{}` interactively to approve setup, then restart this client", crate::remote::saved_ssh_bootstrap_command(&profile.target, &profile.session)))
+                    std::io::Error::new(error.kind(), format!("{error}. Run `{}` interactively to approve setup, then restart this client", crate::remote::saved_ssh_bootstrap_command(&profile.target, &profile.session, profile.windows_desktop)))
                 } else { error }
             })?;
             (connected.stream, Box::new(connected.bridge))
@@ -352,6 +353,7 @@ mod tests {
             target: "build".into(),
             session: "agents".into(),
             enabled: true,
+            windows_desktop: false,
         }
     }
 
@@ -417,6 +419,25 @@ mod tests {
         supervisors.endpoints.get_mut(&id).unwrap().generation = Some(2);
         supervisors.endpoints.get_mut(&other_id).unwrap().generation = Some(3);
         changed.session = "another-session".into();
+        assert_eq!(
+            supervisors.reconcile_profiles(&[changed, other], now),
+            vec![id.clone()]
+        );
+        assert_eq!(supervisors.endpoints[&id].generation, None);
+        assert_eq!(supervisors.endpoints[&other_id].generation, Some(3));
+    }
+
+    #[test]
+    fn live_catalog_desktop_change_retires_only_that_machine() {
+        let now = Instant::now();
+        let mut changed = profile();
+        let other = super::super::SavedSshEndpoint::new("Other", "other", "main").unwrap();
+        let id = ClientEndpointId::Ssh(changed.id.clone());
+        let other_id = ClientEndpointId::Ssh(other.id.clone());
+        let mut supervisors = EndpointSupervisors::new(&[changed.clone(), other.clone()], now);
+        supervisors.endpoints.get_mut(&id).unwrap().generation = Some(2);
+        supervisors.endpoints.get_mut(&other_id).unwrap().generation = Some(3);
+        changed.windows_desktop = true;
         assert_eq!(
             supervisors.reconcile_profiles(&[changed, other], now),
             vec![id.clone()]

--- a/src/client/shell/tests/endpoint_requests.rs
+++ b/src/client/shell/tests/endpoint_requests.rs
@@ -97,6 +97,7 @@ fn add_remote(state: &mut ClientShellState) -> ClientEndpointId {
         target: "dev@build.example".into(),
         session: "agents".into(),
         enabled: true,
+        windows_desktop: false,
     };
     let remote = ClientEndpointId::Ssh(profile.id.clone());
     state.set_endpoint_catalog(&[profile]);

--- a/src/client/shell/tests/endpoints.rs
+++ b/src/client/shell/tests/endpoints.rs
@@ -14,6 +14,7 @@ fn remote_profile() -> SavedSshEndpoint {
         target: "dev@build.example".into(),
         session: "agents".into(),
         enabled: true,
+        windows_desktop: false,
     }
 }
 

--- a/src/client/shell/tests/mobile.rs
+++ b/src/client/shell/tests/mobile.rs
@@ -78,6 +78,7 @@ fn mobile_switcher_can_activate_an_online_saved_machine() {
         target: "build".into(),
         session: "agents".into(),
         enabled: true,
+        windows_desktop: false,
     };
     let endpoint_id = ClientEndpointId::Ssh(profile.id.clone());
     state.set_endpoint_catalog(&[profile]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -511,6 +511,14 @@ fn main() -> io::Result<()> {
     if let Some(outcome) = cli::maybe_run_machine(&raw_args) {
         return finish_cli(outcome);
     }
+    #[cfg(windows)]
+    let raw_args = match platform::apply_desktop_bootstrap_args(&raw_args) {
+        Ok(args) => args,
+        Err(err) => {
+            eprintln!("error: {err}");
+            std::process::exit(2);
+        }
+    };
     let args = match session::configure_from_args(&raw_args) {
         Ok(args) => args,
         Err(err) => {
@@ -550,7 +558,22 @@ fn main() -> io::Result<()> {
 
     // Subcommands and flags (no TUI, no logging needed)
     if args.get(1).map(|s| s.as_str()) == Some("remote-client-bridge") {
-        return remote::run_remote_client_bridge();
+        let require_desktop = match &args[2..] {
+            [] => false,
+            [flag] if flag == "--require-desktop" => true,
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "usage: herdr remote-client-bridge [--require-desktop]",
+                ));
+            }
+        };
+        return remote::run_remote_client_bridge(require_desktop);
+    }
+
+    #[cfg(windows)]
+    if args.get(1).map(|s| s.as_str()) == Some("remote-desktop") {
+        return platform::run_remote_desktop_command(&args[2..]);
     }
 
     if args.get(1).map(|s| s.as_str()) == Some("server") {
@@ -692,6 +715,7 @@ fn main() -> io::Result<()> {
         println!("  --session <name>    Use or create a named persistent session");
         println!("  --machine <label-or-id>  Run an API command on a saved SSH machine");
         println!("  --remote <target>   Attach through SSH to a remote Herdr server");
+        println!("  --remote-desktop    Start a Windows remote server in the signed-in desktop");
         println!("  --remote-keybindings <local|server>");
         println!("                      Keybindings for --remote app attach (default: local)");
         println!("  --handoff           Opt into live handoff for update or remote attach");
@@ -733,6 +757,7 @@ fn main() -> io::Result<()> {
         "--machine",
         "--remote",
         "--remote-keybindings",
+        "--remote-desktop",
         "--version",
         "-V",
         "--default-config",
@@ -752,6 +777,7 @@ fn main() -> io::Result<()> {
                 "server",
                 "client",
                 "remote-client-bridge",
+                "remote-desktop",
                 "update",
                 "status",
                 "config",

--- a/src/main.rs
+++ b/src/main.rs
@@ -777,7 +777,6 @@ fn main() -> io::Result<()> {
                 "server",
                 "client",
                 "remote-client-bridge",
-                "remote-desktop",
                 "update",
                 "status",
                 "config",

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -100,6 +100,16 @@ pub(crate) fn configure_background_command(command: &mut std::process::Command) 
 }
 
 #[cfg(not(windows))]
+pub(crate) fn verify_remote_desktop_stream(
+    _stream: &crate::ipc::LocalStream,
+) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "Windows desktop hosting is unavailable on this platform",
+    ))
+}
+
+#[cfg(not(windows))]
 fn configure_background_command_platform(_command: &mut std::process::Command) {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -14,6 +14,10 @@ use std::{
 };
 
 mod clipboard_image;
+mod desktop_bootstrap;
+pub(crate) use desktop_bootstrap::*;
+mod desktop_host;
+pub(crate) use desktop_host::*;
 
 pub(crate) fn classify_child_exit(status: &portable_pty::ExitStatus) -> super::ChildExitReason {
     // STATUS_CONTROL_C_EXIT is reported without a Unix signal by portable-pty.
@@ -1137,7 +1141,7 @@ pub fn current_process_is_detached_server_daemon() -> bool {
         return false;
     }
 
-    matches!(current_process_is_in_job(), Ok(false))
+    matches!(current_job_kills_processes_on_close(), Ok(false))
 }
 
 pub fn foreground_job(child_pid: u32) -> Option<ForegroundJob> {
@@ -3030,10 +3034,11 @@ mod tests {
             fs::write(
                 capture,
                 format!(
-                    "{}\n{}\n{}",
+                    "{}\n{}\n{}\n{}",
                     cwd.display(),
                     unsafe { GetConsoleWindow() }.is_null(),
-                    !super::current_job_kills_processes_on_close().expect("inspect WMI daemon job")
+                    !super::current_job_kills_processes_on_close().expect("inspect WMI daemon job"),
+                    super::current_process_is_detached_server_daemon()
                 ),
             )
             .expect("write WMI daemon test capture");
@@ -3064,7 +3069,7 @@ mod tests {
             .expect("launch detached process through WMI");
         assert_ne!(pid, 0, "WMI returned an invalid process id");
 
-        let expected = format!("{}\ntrue\ntrue", base.display());
+        let expected = format!("{}\ntrue\ntrue\ntrue", base.display());
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {
             if fs::read_to_string(&capture).is_ok_and(|captured| captured == expected) {

--- a/src/platform/windows/desktop_bootstrap.rs
+++ b/src/platform/windows/desktop_bootstrap.rs
@@ -56,11 +56,15 @@ fn extract_bootstrap_args(
 pub(crate) fn run_remote_desktop_command(args: &[String]) -> io::Result<()> {
     match args {
         [operation] if operation == "inspect" => {
-            println!(
-                "{}",
-                serde_json::to_string(&super::inspect_remote_desktop_host()?)
-                    .map_err(io::Error::other)?
-            );
+            let mut report = serde_json::to_value(super::inspect_remote_desktop_host()?)
+                .map_err(io::Error::other)?;
+            report["account_sid"] = base64::engine::general_purpose::STANDARD
+                .encode(super::desktop_host::desktop_account_sid()?)
+                .into();
+            report["host"] = super::hostname()
+                .ok_or_else(|| io::Error::other("Windows host name is unavailable"))?
+                .into();
+            println!("{report}");
             Ok(())
         }
         [operation, flag, raw_session] if operation == "start" && flag == "--windows-session" => {

--- a/src/platform/windows/desktop_bootstrap.rs
+++ b/src/platform/windows/desktop_bootstrap.rs
@@ -1,0 +1,181 @@
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use std::{io, path::PathBuf};
+
+const BOOTSTRAP_ARG: &str = "--desktop-bootstrap";
+
+#[derive(Serialize, Deserialize)]
+struct DesktopBootstrap {
+    config_path: Option<String>,
+    xdg_config_home: Option<String>,
+    xdg_state_home: Option<String>,
+    startup_cwd: String,
+}
+
+pub(crate) fn apply_desktop_bootstrap_args(args: &[String]) -> Result<Vec<String>, String> {
+    let (cleaned, bootstrap) = extract_bootstrap_args(args)?;
+    if let Some(bootstrap) = bootstrap {
+        apply_bootstrap(&bootstrap)?;
+    }
+    Ok(cleaned)
+}
+
+fn extract_bootstrap_args(
+    args: &[String],
+) -> Result<(Vec<String>, Option<DesktopBootstrap>), String> {
+    let mut cleaned = Vec::with_capacity(args.len());
+    if let Some(program) = args.first() {
+        cleaned.push(program.clone());
+    }
+
+    let mut bootstrap = None;
+    let mut index = 1;
+    while index < args.len() {
+        if args[index] == "--" {
+            cleaned.extend_from_slice(&args[index..]);
+            break;
+        }
+        if args[index] == BOOTSTRAP_ARG {
+            if bootstrap.is_some() {
+                return Err(format!("{BOOTSTRAP_ARG} can only be specified once"));
+            }
+            let value = args
+                .get(index + 1)
+                .ok_or_else(|| format!("missing value for {BOOTSTRAP_ARG}"))?;
+            bootstrap = Some(decode_bootstrap(value)?);
+            index += 2;
+            continue;
+        }
+        cleaned.push(args[index].clone());
+        index += 1;
+    }
+
+    Ok((cleaned, bootstrap))
+}
+
+pub(crate) fn run_remote_desktop_command(args: &[String]) -> io::Result<()> {
+    match args {
+        [operation] if operation == "inspect" => {
+            println!(
+                "{}",
+                serde_json::to_string(&super::inspect_remote_desktop_host()?)
+                    .map_err(io::Error::other)?
+            );
+            Ok(())
+        }
+        [operation, flag, raw_session] if operation == "start" && flag == "--windows-session" => {
+            let windows_session = raw_session.parse::<u32>().map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "--windows-session must be an unsigned integer",
+                )
+            })?;
+            super::start_remote_desktop_server(windows_session, &capture_bootstrap()?)
+        }
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "usage: herdr remote-desktop <inspect|start --windows-session <id>>",
+        )),
+    }
+}
+
+fn capture_bootstrap() -> io::Result<String> {
+    let bootstrap = DesktopBootstrap {
+        config_path: unicode_env(crate::config::CONFIG_PATH_ENV_VAR)?,
+        xdg_config_home: unicode_env("XDG_CONFIG_HOME")?,
+        xdg_state_home: unicode_env("XDG_STATE_HOME")?,
+        startup_cwd: std::env::current_dir()?
+            .into_os_string()
+            .into_string()
+            .map_err(|_| io::Error::other("SSH working directory is not valid Unicode"))?,
+    };
+    let bytes = serde_json::to_vec(&bootstrap).map_err(io::Error::other)?;
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn unicode_env(name: &str) -> io::Result<Option<String>> {
+    std::env::var_os(name)
+        .map(|value| {
+            value.into_string().map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("{name} is not valid Unicode"),
+                )
+            })
+        })
+        .transpose()
+}
+
+fn decode_bootstrap(value: &str) -> Result<DesktopBootstrap, String> {
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|error| format!("invalid {BOOTSTRAP_ARG}: {error}"))?;
+    serde_json::from_slice(&bytes).map_err(|error| format!("invalid {BOOTSTRAP_ARG}: {error}"))
+}
+
+fn apply_bootstrap(bootstrap: &DesktopBootstrap) -> Result<(), String> {
+    crate::platform::detach_remote_desktop_console()
+        .map_err(|error| format!("failed to detach the Windows desktop server console: {error}"))?;
+    apply_env(crate::config::CONFIG_PATH_ENV_VAR, &bootstrap.config_path);
+    apply_env("XDG_CONFIG_HOME", &bootstrap.xdg_config_home);
+    apply_env("XDG_STATE_HOME", &bootstrap.xdg_state_home);
+    std::env::set_var(
+        crate::server::autodetect::STARTUP_CWD_ENV_VAR,
+        &bootstrap.startup_cwd,
+    );
+    std::env::set_current_dir(PathBuf::from(&bootstrap.startup_cwd)).map_err(|error| {
+        format!(
+            "failed to restore desktop server working directory {}: {error}",
+            bootstrap.startup_cwd
+        )
+    })
+}
+
+fn apply_env(name: &str, value: &Option<String>) {
+    match value {
+        Some(value) => std::env::set_var(name, value),
+        None => std::env::remove_var(name),
+    }
+}
+
+pub(crate) fn desktop_server_args(bootstrap: &str) -> Vec<String> {
+    let mut args = vec![BOOTSTRAP_ARG.to_owned(), bootstrap.to_owned()];
+    if let Some(session) = crate::session::active_name() {
+        args.extend(["--session".to_owned(), session]);
+    }
+    args.push("server".to_owned());
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_arguments_are_removed_before_normal_dispatch() {
+        let bootstrap = DesktopBootstrap {
+            config_path: None,
+            xdg_config_home: None,
+            xdg_state_home: None,
+            startup_cwd: std::env::current_dir()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned(),
+        };
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&bootstrap).unwrap());
+        let args = vec![
+            "herdr".into(),
+            BOOTSTRAP_ARG.into(),
+            encoded,
+            "--session".into(),
+            "agents".into(),
+            "server".into(),
+        ];
+
+        assert_eq!(
+            extract_bootstrap_args(&args).unwrap().0,
+            vec!["herdr", "--session", "agents", "server"]
+        );
+    }
+}

--- a/src/platform/windows/desktop_host.rs
+++ b/src/platform/windows/desktop_host.rs
@@ -34,7 +34,10 @@ use windows_sys::Win32::{
         SID_NAME_USE, TOKEN_QUERY, TOKEN_USER,
     },
     System::{
-        Console::{FreeConsole, GetConsoleProcessList},
+        Console::{
+            FreeConsole, GetConsoleProcessList, SetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE,
+            STD_OUTPUT_HANDLE,
+        },
         RemoteDesktop::{
             WTSActive, WTSDomainName, WTSEnumerateSessionsW, WTSFreeMemory,
             WTSQuerySessionInformationW, WTSUserName, WTS_CURRENT_SERVER_HANDLE, WTS_SESSION_INFOW,
@@ -63,6 +66,13 @@ pub(crate) fn detach_remote_desktop_console() -> io::Result<()> {
     if unsafe { FreeConsole() } == 0 {
         return Err(io::Error::last_os_error());
     }
+    // FreeConsole leaves stale handles that can be recycled before the startup banner writes.
+    // Rust treats null standard handles as detached streams and silently accepts writes.
+    for handle in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+        if unsafe { SetStdHandle(handle, std::ptr::null_mut()) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
     Ok(())
 }
 
@@ -80,6 +90,10 @@ pub(crate) enum RemoteDesktopInspection {
     Conflict { pid: u32, windows_session: u32 },
     NoLogin,
     MultipleLogins,
+}
+
+pub(super) fn desktop_account_sid() -> io::Result<Vec<u8>> {
+    Ok(current_process_identity()?.sid)
 }
 
 pub(crate) fn inspect_remote_desktop_host() -> io::Result<RemoteDesktopInspection> {
@@ -154,6 +168,7 @@ fn eligible_desktop_sessions(current_sid: &[u8]) -> io::Result<Vec<u32>> {
     };
     let mut eligible = Vec::new();
     for entry in entries.iter().filter(|entry| entry.State == WTSActive) {
+        // An unreadable session may belong to this account; do not infer a unique login.
         if session_account_sid(entry.SessionId)?.as_deref() == Some(current_sid) {
             eligible.push(entry.SessionId);
         }
@@ -529,7 +544,9 @@ fn token_identity(token: HANDLE) -> io::Result<ProcessIdentity> {
     {
         return Err(io::Error::last_os_error());
     }
-    let sid_ptr = unsafe { (*(user.as_ptr().cast::<TOKEN_USER>())).User.Sid };
+    let sid_ptr = unsafe { std::ptr::read_unaligned(user.as_ptr().cast::<TOKEN_USER>()) }
+        .User
+        .Sid;
     let sid_len = unsafe { GetLengthSid(sid_ptr) } as usize;
     if sid_len == 0 {
         return Err(io::Error::last_os_error());
@@ -560,5 +577,46 @@ impl Drop for WtsMemory {
         if !self.0.is_null() {
             unsafe { WTSFreeMemory(self.0) };
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{io::Write as _, process::Command};
+    use windows_sys::Win32::System::Console::GetStdHandle;
+
+    #[test]
+    fn desktop_console_detach_clears_stale_standard_handles() {
+        const CHILD: &str = "HERDR_TEST_DESKTOP_CONSOLE_CHILD";
+        if std::env::var_os(CHILD).is_some() {
+            let mut process_ids = [0_u32; 2];
+            assert_eq!(
+                unsafe { GetConsoleProcessList(process_ids.as_mut_ptr(), 2) },
+                1
+            );
+            assert_eq!(process_ids[0], std::process::id());
+            detach_remote_desktop_console().expect("detach owned console");
+            assert_eq!(
+                unsafe { GetConsoleProcessList(process_ids.as_mut_ptr(), 2) },
+                0
+            );
+            for handle in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+                assert!(unsafe { GetStdHandle(handle) }.is_null());
+            }
+            std::io::stdout()
+                .write_all(b"ready\n")
+                .expect("detached stdout");
+            std::io::stderr()
+                .write_all(b"ready\n")
+                .expect("detached stderr");
+            return;
+        }
+        let mut child = Command::new(std::env::current_exe().expect("test executable"));
+        child
+            .arg("desktop_console_detach_clears_stale_standard_handles")
+            .env(CHILD, "1");
+        crate::platform::configure_background_command(&mut child);
+        assert!(child.status().expect("console test child").success());
     }
 }

--- a/src/platform/windows/desktop_host.rs
+++ b/src/platform/windows/desktop_host.rs
@@ -1,0 +1,564 @@
+use std::{
+    ffi::c_void,
+    io,
+    mem::size_of,
+    os::windows::{
+        ffi::OsStrExt,
+        io::{AsRawHandle as _, FromRawHandle as _, OwnedHandle},
+    },
+};
+
+use interprocess::local_socket::traits::StreamCommon as _;
+use windows::{
+    core::{Interface as _, BSTR},
+    Win32::{
+        Foundation::{VARIANT_FALSE, VARIANT_TRUE},
+        System::{
+            Com::{
+                CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
+                COINIT_MULTITHREADED,
+            },
+            TaskScheduler::{
+                IExecAction, IRunningTask, ITaskFolder, ITaskService, TaskScheduler,
+                TASK_ACTION_EXEC, TASK_CREATE, TASK_LOGON_INTERACTIVE_TOKEN, TASK_RUNLEVEL_LUA,
+                TASK_RUN_USE_SESSION_ID,
+            },
+            Variant::VARIANT,
+        },
+    },
+};
+use windows_sys::Win32::{
+    Foundation::HANDLE,
+    Security::{
+        GetLengthSid, GetTokenInformation, LookupAccountNameW, TokenSessionId, TokenUser,
+        SID_NAME_USE, TOKEN_QUERY, TOKEN_USER,
+    },
+    System::{
+        Console::{FreeConsole, GetConsoleProcessList},
+        RemoteDesktop::{
+            WTSActive, WTSDomainName, WTSEnumerateSessionsW, WTSFreeMemory,
+            WTSQuerySessionInformationW, WTSUserName, WTS_CURRENT_SERVER_HANDLE, WTS_SESSION_INFOW,
+        },
+        Threading::{
+            GetCurrentProcess, OpenProcess, OpenProcessToken, PROCESS_QUERY_LIMITED_INFORMATION,
+        },
+    },
+};
+
+const DESKTOP_START_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+const DESKTOP_START_POLL: std::time::Duration = std::time::Duration::from_millis(100);
+
+pub(crate) fn detach_remote_desktop_console() -> io::Result<()> {
+    let mut process_ids = [0_u32; 2];
+    let count =
+        unsafe { GetConsoleProcessList(process_ids.as_mut_ptr(), process_ids.len() as u32) };
+    if count == 0 {
+        return Ok(());
+    }
+    if count != 1 || process_ids[0] != std::process::id() {
+        return Err(io::Error::other(
+            "the Windows desktop launch inherited a shared console",
+        ));
+    }
+    if unsafe { FreeConsole() } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ProcessIdentity {
+    sid: Vec<u8>,
+    session_id: u32,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(crate) enum RemoteDesktopInspection {
+    Ready { pid: u32, windows_session: u32 },
+    Start { windows_session: u32 },
+    Conflict { pid: u32, windows_session: u32 },
+    NoLogin,
+    MultipleLogins,
+}
+
+pub(crate) fn inspect_remote_desktop_host() -> io::Result<RemoteDesktopInspection> {
+    let current = current_process_identity()?;
+    let eligible = eligible_desktop_sessions(&current.sid)?;
+    if crate::server::autodetect::is_server_listening() {
+        let socket_path = crate::server::socket_paths::client_socket_path();
+        let stream = crate::ipc::connect_local_stream(&socket_path)?;
+        let (pid, peer) = peer_identity(&stream)?;
+        return Ok(
+            if peer.sid == current.sid && eligible.contains(&peer.session_id) {
+                RemoteDesktopInspection::Ready {
+                    pid,
+                    windows_session: peer.session_id,
+                }
+            } else {
+                RemoteDesktopInspection::Conflict {
+                    pid,
+                    windows_session: peer.session_id,
+                }
+            },
+        );
+    }
+    Ok(match eligible.as_slice() {
+        [] => RemoteDesktopInspection::NoLogin,
+        [windows_session] => RemoteDesktopInspection::Start {
+            windows_session: *windows_session,
+        },
+        _ => RemoteDesktopInspection::MultipleLogins,
+    })
+}
+
+pub(crate) fn verify_remote_desktop_stream(stream: &crate::ipc::LocalStream) -> io::Result<()> {
+    let (pid, peer) = peer_identity(stream)?;
+    let current = current_process_identity()?;
+    if peer.sid != current.sid {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("remote Herdr server process {pid} belongs to a different Windows account"),
+        ));
+    }
+    if !eligible_desktop_sessions(&current.sid)?.contains(&peer.session_id) {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!(
+                "remote Herdr server process {pid} is not in an active desktop login for this Windows account; use another --session or stop it explicitly"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn peer_identity(stream: &crate::ipc::LocalStream) -> io::Result<(u32, ProcessIdentity)> {
+    let pid = stream
+        .peer_creds()?
+        .pid()
+        .ok_or_else(|| io::Error::other("Windows named pipe did not report its server PID"))?;
+    Ok((pid, process_identity(pid)?))
+}
+
+fn eligible_desktop_sessions(current_sid: &[u8]) -> io::Result<Vec<u32>> {
+    let mut sessions = std::ptr::null_mut();
+    let mut count = 0_u32;
+    if unsafe { WTSEnumerateSessionsW(WTS_CURRENT_SERVER_HANDLE, 0, 1, &mut sessions, &mut count) }
+        == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    let sessions = WtsMemory(sessions.cast::<c_void>());
+    let entries = unsafe {
+        std::slice::from_raw_parts(sessions.0.cast::<WTS_SESSION_INFOW>(), count as usize)
+    };
+    let mut eligible = Vec::new();
+    for entry in entries.iter().filter(|entry| entry.State == WTSActive) {
+        if session_account_sid(entry.SessionId)?.as_deref() == Some(current_sid) {
+            eligible.push(entry.SessionId);
+        }
+    }
+    eligible.sort_unstable();
+    eligible.dedup();
+    Ok(eligible)
+}
+
+fn session_account_sid(session_id: u32) -> io::Result<Option<Vec<u8>>> {
+    let user = wts_session_string(session_id, WTSUserName)?;
+    if user.is_empty() {
+        return Ok(None);
+    }
+    let domain = wts_session_string(session_id, WTSDomainName)?;
+    let account = if domain.is_empty() {
+        user
+    } else {
+        format!(r"{domain}\{user}")
+    };
+    lookup_account_sid(&account).map(Some)
+}
+
+fn wts_session_string(session_id: u32, class: i32) -> io::Result<String> {
+    let mut value = std::ptr::null_mut();
+    let mut bytes = 0_u32;
+    if unsafe {
+        WTSQuerySessionInformationW(
+            WTS_CURRENT_SERVER_HANDLE,
+            session_id,
+            class,
+            &mut value,
+            &mut bytes,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    let value = WtsMemory(value.cast::<c_void>());
+    let units = unsafe { std::slice::from_raw_parts(value.0.cast::<u16>(), bytes as usize / 2) };
+    let units = units
+        .iter()
+        .position(|unit| *unit == 0)
+        .map(|end| &units[..end])
+        .unwrap_or(units);
+    String::from_utf16(units).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+fn lookup_account_sid(account: &str) -> io::Result<Vec<u8>> {
+    let account = std::ffi::OsStr::new(account)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let mut sid_bytes = 0_u32;
+    let mut domain_units = 0_u32;
+    let mut sid_type: SID_NAME_USE = 0;
+    unsafe {
+        LookupAccountNameW(
+            std::ptr::null(),
+            account.as_ptr(),
+            std::ptr::null_mut(),
+            &mut sid_bytes,
+            std::ptr::null_mut(),
+            &mut domain_units,
+            &mut sid_type,
+        );
+    }
+    if sid_bytes == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut sid = vec![0_u8; sid_bytes as usize];
+    let mut domain = vec![0_u16; domain_units as usize];
+    if unsafe {
+        LookupAccountNameW(
+            std::ptr::null(),
+            account.as_ptr(),
+            sid.as_mut_ptr().cast(),
+            &mut sid_bytes,
+            domain.as_mut_ptr(),
+            &mut domain_units,
+            &mut sid_type,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    let sid_len = unsafe { GetLengthSid(sid.as_mut_ptr().cast()) } as usize;
+    sid.truncate(sid_len);
+    Ok(sid)
+}
+
+pub(crate) fn start_remote_desktop_server(windows_session: u32, bootstrap: &str) -> io::Result<()> {
+    if !selected_login_is_unique(windows_session)? {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "the selected Windows desktop login is no longer the only active login for this account",
+        ));
+    }
+    let windows_session_i32 = i32::try_from(windows_session).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "the selected Windows session identifier is too large",
+        )
+    })?;
+
+    let _com = ComApartment::initialize()?;
+    let service: ITaskService = unsafe {
+        CoCreateInstance(&TaskScheduler, None, CLSCTX_INPROC_SERVER)
+            .map_err(|error| task_error("create Task Scheduler service", error))?
+    };
+    let empty = VARIANT::default();
+    unsafe {
+        service
+            .Connect(&empty, &empty, &empty, &empty)
+            .map_err(|error| task_error("connect to Task Scheduler", error))?;
+    }
+    let root = unsafe {
+        service
+            .GetFolder(&BSTR::from(r"\"))
+            .map_err(|error| task_error("open the Task Scheduler root", error))?
+    };
+    let definition = unsafe {
+        service
+            .NewTask(0)
+            .map_err(|error| task_error("create a Task Scheduler definition", error))?
+    };
+    let user = unsafe {
+        service
+            .ConnectedUser()
+            .map_err(|error| task_error("read the Task Scheduler account", error))?
+    };
+    let principal = unsafe {
+        definition
+            .Principal()
+            .map_err(|error| task_error("configure the Task Scheduler principal", error))?
+    };
+    unsafe {
+        principal
+            .SetUserId(&user)
+            .and_then(|()| principal.SetLogonType(TASK_LOGON_INTERACTIVE_TOKEN))
+            .and_then(|()| principal.SetRunLevel(TASK_RUNLEVEL_LUA))
+            .map_err(|error| task_error("configure the desktop task account", error))?;
+    }
+
+    let settings = unsafe {
+        definition
+            .Settings()
+            .map_err(|error| task_error("configure desktop task settings", error))?
+    };
+    unsafe {
+        settings
+            .SetAllowDemandStart(VARIANT_TRUE)
+            .and_then(|()| settings.SetDisallowStartIfOnBatteries(VARIANT_FALSE))
+            .and_then(|()| settings.SetStopIfGoingOnBatteries(VARIANT_FALSE))
+            .and_then(|()| settings.SetExecutionTimeLimit(&BSTR::from("PT0S")))
+            .and_then(|()| settings.SetHidden(VARIANT_TRUE))
+            .map_err(|error| task_error("configure desktop task settings", error))?;
+    }
+
+    let executable = std::env::current_exe()?;
+    let executable = executable
+        .to_str()
+        .ok_or_else(|| io::Error::other("Herdr executable path is not valid Unicode"))?;
+    let working_directory = std::env::current_dir()?;
+    let working_directory = working_directory
+        .to_str()
+        .ok_or_else(|| io::Error::other("SSH working directory is not valid Unicode"))?;
+    let arguments = super::desktop_server_args(bootstrap)
+        .iter()
+        .map(|arg| crate::platform::quote_windows_command_line_arg(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let actions = unsafe {
+        definition
+            .Actions()
+            .map_err(|error| task_error("configure the desktop task action", error))?
+    };
+    let action: IExecAction = unsafe {
+        actions
+            .Create(TASK_ACTION_EXEC)
+            .and_then(|action| action.cast())
+            .map_err(|error| task_error("create the desktop task action", error))?
+    };
+    unsafe {
+        action
+            .SetPath(&BSTR::from(executable))
+            .and_then(|()| action.SetArguments(&BSTR::from(arguments)))
+            .and_then(|()| action.SetWorkingDirectory(&BSTR::from(working_directory)))
+            .map_err(|error| task_error("configure the desktop task executable", error))?;
+    }
+
+    let task_name = BSTR::from(format!(
+        "Herdr Desktop Launch {}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    let registered = unsafe {
+        root.RegisterTaskDefinition(
+            &task_name,
+            &definition,
+            TASK_CREATE.0,
+            &empty,
+            &empty,
+            TASK_LOGON_INTERACTIVE_TOKEN,
+            &empty,
+        )
+        .map_err(|error| task_error("register the one-time desktop task", error))?
+    };
+
+    // Recheck after registration, immediately before selecting the RunEx session.
+    let recheck = selected_login_is_unique(windows_session);
+    if !matches!(recheck, Ok(true)) {
+        unsafe { root.DeleteTask(&task_name, 0) }
+            .map_err(|error| task_error("remove the one-time desktop task", error))?;
+        return match recheck {
+            Ok(false) => Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "the selected Windows desktop login changed before Herdr could start",
+            )),
+            Err(error) => Err(error),
+            Ok(true) => unreachable!("handled above"),
+        };
+    }
+    let running = match unsafe {
+        registered.RunEx(
+            &empty,
+            TASK_RUN_USE_SESSION_ID.0,
+            windows_session_i32,
+            &BSTR::default(),
+        )
+    } {
+        Ok(running) => running,
+        Err(error) => {
+            unsafe { root.DeleteTask(&task_name, 0) }
+                .map_err(|cleanup| task_error("remove the one-time desktop task", cleanup))?;
+            return Err(task_error("run the one-time desktop task", error));
+        }
+    };
+    let mut cleanup = TaskLaunchCleanup {
+        root,
+        task_name,
+        running,
+        stop_owned_process: true,
+        task_deleted: false,
+    };
+    let deadline = std::time::Instant::now() + DESKTOP_START_TIMEOUT;
+    loop {
+        let _ = unsafe { cleanup.running.Refresh() };
+        let owned_pid = unsafe { cleanup.running.EnginePID() }.unwrap_or(0);
+        match inspect_remote_desktop_host() {
+            Ok(RemoteDesktopInspection::Ready {
+                pid,
+                windows_session: actual,
+            }) if actual == windows_session && owned_pid != 0 => {
+                cleanup.stop_owned_process = pid != owned_pid;
+                unsafe { cleanup.root.DeleteTask(&cleanup.task_name, 0) }
+                    .map_err(|error| task_error("remove the one-time desktop task", error))?;
+                cleanup.task_deleted = true;
+                return Ok(());
+            }
+            Ok(RemoteDesktopInspection::Conflict { pid, .. }) if pid == owned_pid => {
+                return Err(io::Error::other(
+                    "the launched Herdr server did not enter the selected Windows desktop",
+                ));
+            }
+            Ok(_) | Err(_) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(DESKTOP_START_POLL);
+            }
+            Ok(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "the Windows desktop Herdr server did not become ready",
+                ));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn selected_login_is_unique(windows_session: u32) -> io::Result<bool> {
+    Ok(
+        eligible_desktop_sessions(&current_process_identity()?.sid)?.as_slice()
+            == [windows_session],
+    )
+}
+
+fn task_error(context: &str, error: windows::core::Error) -> io::Error {
+    io::Error::other(format!("failed to {context}: {error}"))
+}
+
+struct ComApartment;
+
+impl ComApartment {
+    fn initialize() -> io::Result<Self> {
+        unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) }
+            .ok()
+            .map_err(|error| task_error("initialize COM", error))?;
+        Ok(Self)
+    }
+}
+
+impl Drop for ComApartment {
+    fn drop(&mut self) {
+        unsafe { CoUninitialize() };
+    }
+}
+
+struct TaskLaunchCleanup {
+    root: ITaskFolder,
+    task_name: BSTR,
+    running: IRunningTask,
+    stop_owned_process: bool,
+    task_deleted: bool,
+}
+
+impl Drop for TaskLaunchCleanup {
+    fn drop(&mut self) {
+        unsafe {
+            if self.stop_owned_process {
+                let _ = self.running.Stop();
+            }
+            if !self.task_deleted {
+                let _ = self.root.DeleteTask(&self.task_name, 0);
+            }
+        }
+    }
+}
+
+fn current_process_identity() -> io::Result<ProcessIdentity> {
+    let mut token = std::ptr::null_mut();
+    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let token = unsafe { OwnedHandle::from_raw_handle(token) };
+    token_identity(token.as_raw_handle())
+}
+
+fn process_identity(pid: u32) -> io::Result<ProcessIdentity> {
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if process.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let process = unsafe { OwnedHandle::from_raw_handle(process) };
+    let mut token = std::ptr::null_mut();
+    if unsafe { OpenProcessToken(process.as_raw_handle(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let token = unsafe { OwnedHandle::from_raw_handle(token) };
+    token_identity(token.as_raw_handle())
+}
+
+fn token_identity(token: HANDLE) -> io::Result<ProcessIdentity> {
+    let mut required = 0;
+    unsafe {
+        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut required);
+    }
+    if required == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut user = vec![0_u8; required as usize];
+    if unsafe {
+        GetTokenInformation(
+            token,
+            TokenUser,
+            user.as_mut_ptr().cast(),
+            required,
+            &mut required,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    let sid_ptr = unsafe { (*(user.as_ptr().cast::<TOKEN_USER>())).User.Sid };
+    let sid_len = unsafe { GetLengthSid(sid_ptr) } as usize;
+    if sid_len == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let sid = unsafe { std::slice::from_raw_parts(sid_ptr.cast::<u8>(), sid_len) }.to_vec();
+
+    let mut session_id = 0_u32;
+    let mut returned = 0_u32;
+    if unsafe {
+        GetTokenInformation(
+            token,
+            TokenSessionId,
+            (&mut session_id as *mut u32).cast(),
+            size_of::<u32>() as u32,
+            &mut returned,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(ProcessIdentity { sid, session_id })
+}
+
+struct WtsMemory(*mut c_void);
+
+impl Drop for WtsMemory {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { WTSFreeMemory(self.0) };
+        }
+    }
+}

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -11,29 +11,42 @@ pub(crate) use host::run_remote_client_bridge;
 pub(crate) use saved::*;
 
 pub(crate) fn run_remote_api_bridge(args: &[String]) -> std::io::Result<()> {
-    match args {
-        [] => {
-            let path = crate::api::socket_path();
-            let stream = crate::ipc::connect_local_stream(&path).map_err(|error| {
-                std::io::Error::new(
-                    error.kind(),
-                    format!(
-                        "failed to connect to remote Herdr API socket {}: {error}",
-                        path.display()
-                    ),
-                )
-            })?;
-            crate::platform::forward_remote_bridge_stdio(stream)
+    let (check, require_desktop) = match args {
+        [] => (false, false),
+        [flag] if flag == "--check" => (true, false),
+        [flag] if flag == "--require-desktop" => (false, true),
+        [desktop, check] if desktop == "--require-desktop" && check == "--check" => (true, true),
+        _ => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "usage: herdr remote-api-bridge [--require-desktop] [--check]",
+            ))
         }
-        [flag] if flag == "--check" => {
-            println!("herdr-api-bridge-v1");
-            Ok(())
+    };
+    if check {
+        if require_desktop && !cfg!(windows) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "Windows desktop hosting is unavailable on this platform",
+            ));
         }
-        _ => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "usage: herdr remote-api-bridge [--check]",
-        )),
+        println!("herdr-api-bridge-v1");
+        return Ok(());
     }
+    let path = crate::api::socket_path();
+    let stream = crate::ipc::connect_local_stream(&path).map_err(|error| {
+        std::io::Error::new(
+            error.kind(),
+            format!(
+                "failed to connect to remote Herdr API socket {}: {error}",
+                path.display()
+            ),
+        )
+    })?;
+    if require_desktop {
+        crate::platform::verify_remote_desktop_stream(&stream)?;
+    }
+    crate::platform::forward_remote_bridge_stdio(stream)
 }
 
 pub(crate) fn print_saved_ssh_error_hint(err: &std::io::Error, target: &str) {

--- a/src/remote/args.rs
+++ b/src/remote/args.rs
@@ -29,6 +29,7 @@ pub(crate) struct RemoteLaunch {
     pub(crate) target: String,
     pub(crate) keybindings: RemoteKeybindings,
     pub(crate) live_handoff: bool,
+    pub(crate) windows_desktop: bool,
 }
 
 pub(crate) fn extract_remote_args(
@@ -43,6 +44,7 @@ pub(crate) fn extract_remote_args(
     let mut keybindings = RemoteKeybindings::Local;
     let mut keybindings_seen = false;
     let mut live_handoff = false;
+    let mut windows_desktop = false;
     let mut index = 1;
     while index < args.len() {
         let arg = &args[index];
@@ -52,6 +54,14 @@ pub(crate) fn extract_remote_args(
         }
         if arg == "--handoff" {
             live_handoff = true;
+            index += 1;
+            continue;
+        }
+        if arg == "--remote-desktop" {
+            if windows_desktop {
+                return Err("--remote-desktop can only be specified once".to_string());
+            }
+            windows_desktop = true;
             index += 1;
             continue;
         }
@@ -104,12 +114,19 @@ pub(crate) fn extract_remote_args(
         target,
         keybindings,
         live_handoff,
+        windows_desktop,
     });
     if remote.is_none() && keybindings_seen {
         return Err("--remote-keybindings requires --remote".to_string());
     }
     if remote.is_none() && live_handoff {
         cleaned.push("--handoff".to_string());
+    }
+    if remote.is_none() && windows_desktop {
+        if cleaned.get(1).map(String::as_str) != Some("machine") {
+            return Err("--remote-desktop requires --remote".to_string());
+        }
+        cleaned.push("--remote-desktop".to_string());
     }
 
     Ok((cleaned, remote))

--- a/src/remote/attach.rs
+++ b/src/remote/attach.rs
@@ -45,14 +45,6 @@ pub(crate) fn run_remote(remote: RemoteLaunch) -> io::Result<()> {
     let program = std::env::args()
         .next()
         .unwrap_or_else(|| "herdr".to_string());
-    let reattach_command = reattach_command(
-        &program,
-        &remote.target,
-        &session_name,
-        remote.keybindings,
-        remote.live_handoff,
-        remote.windows_desktop,
-    );
     let manage_ssh_config = crate::config::Config::load()
         .config
         .remote
@@ -72,6 +64,15 @@ pub(crate) fn run_remote(remote: RemoteLaunch) -> io::Result<()> {
         remote.windows_desktop,
     )?;
 
+    let reattach_command = reattach_command(
+        &program,
+        &remote.target,
+        &session_name,
+        remote.keybindings,
+        remote.live_handoff,
+        remote_herdr.require_desktop,
+    );
+
     let _bridge = SshStdioBridge::start(
         remote.target,
         remote_herdr,
@@ -88,7 +89,7 @@ pub(crate) fn prepare_saved_ssh(
     target: &str,
     session_name: &str,
     windows_desktop: bool,
-) -> io::Result<()> {
+) -> io::Result<bool> {
     super::validate_remote_target(target)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
     crate::session::validate_name(session_name)
@@ -125,7 +126,7 @@ pub(crate) fn prepare_saved_ssh(
         )
         .is_none() =>
         {
-            Ok(())
+            Ok(remote_herdr.require_desktop)
         }
         _ => Err(io::Error::other(
             "remote server is not ready for saved machines",
@@ -881,16 +882,13 @@ impl InstallSource {
     }
 }
 
-pub(super) fn prepare_remote_herdr(
+fn prepare_remote_herdr(
     ssh: &RemoteSsh,
     live_handoff_enabled: bool,
     require_surface_interest: bool,
+    platform: RemotePlatform,
 ) -> io::Result<PreparedRemoteHerdr> {
-    let platform = detect_remote_platform(ssh)?;
     let remote_herdr = RemoteHerdr::for_platform(platform);
-    if remote_herdr.platform.is_windows() {
-        return prepare_windows_remote_herdr(ssh, remote_herdr, require_surface_interest);
-    }
     let override_binary = remote_binary_override_path()?;
     let remote_binary_candidates = remote_binary_candidates(ssh, &remote_herdr)?;
 
@@ -960,15 +958,14 @@ pub(super) fn find_installed_remote_herdr(
     ssh: &RemoteSsh,
     require_desktop: bool,
 ) -> io::Result<RemoteHerdr> {
-    if require_desktop {
-        return find_desktop_remote_herdr(ssh, true);
-    }
     let platform = detect_remote_platform(ssh)?;
-    let remote_herdr = RemoteHerdr::for_platform(platform);
-    if remote_herdr.platform.is_windows() {
-        return prepare_windows_remote_herdr(ssh, remote_herdr, true)
-            .map(|prepared| prepared.remote_herdr);
+    if platform.is_windows() {
+        let mut remote = find_windows_remote_host(ssh, platform, true, require_desktop)?;
+        // Capability discovery does not change a saved profile's placement requirement.
+        remote.require_desktop = require_desktop;
+        return Ok(remote);
     }
+    let remote_herdr = remote_host_for_platform(platform, require_desktop)?;
     let candidates = remote_binary_candidates(ssh, &remote_herdr)?;
     for candidate in candidates {
         if remote_binary_supports_endpoint_requirement(ssh, &candidate, true)? {
@@ -985,33 +982,6 @@ pub(super) fn find_installed_remote_herdr(
     ))
 }
 
-fn prepare_windows_remote_herdr(
-    ssh: &RemoteSsh,
-    remote_herdr: RemoteHerdr,
-    require_surface_interest: bool,
-) -> io::Result<PreparedRemoteHerdr> {
-    if !remote_binary_exists(ssh, &remote_herdr)? {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            format!(
-                "herdr.exe is not installed or is not on PATH on Windows host {}; install a compatible Windows package with remote host support and retry",
-                ssh.target()
-            ),
-        ));
-    }
-    if !remote_binary_supports_endpoint_requirement(ssh, &remote_herdr, require_surface_interest)? {
-        return Err(io::Error::other(format!(
-            "herdr.exe on Windows host {} does not support saved SSH endpoint federation; install a compatible Windows package with remote host support and retry",
-            ssh.target()
-        )));
-    }
-
-    Ok(PreparedRemoteHerdr {
-        remote_herdr,
-        stop_after_install_approved: false,
-    })
-}
-
 pub(super) fn find_installed_remote_api_herdr(
     ssh: &RemoteSsh,
     session: &str,
@@ -1019,10 +989,8 @@ pub(super) fn find_installed_remote_api_herdr(
 ) -> io::Result<RemoteHerdr> {
     let platform = detect_remote_platform(ssh)?;
     let remote_herdr = remote_host_for_platform(platform, require_desktop)?;
-    let candidates = if require_desktop {
+    let candidates = if remote_herdr.platform.is_windows() {
         desktop_binary_candidates(ssh, &remote_herdr)?
-    } else if remote_herdr.platform.is_windows() {
-        vec![remote_herdr]
     } else {
         remote_binary_candidates(ssh, &remote_herdr)?
     };

--- a/src/remote/attach.rs
+++ b/src/remote/attach.rs
@@ -1,5 +1,8 @@
 //! Remote thin-client launcher over SSH command stdio.
 
+mod desktop;
+use desktop::*;
+
 use super::{args::*, process::wait_with_output_timeout, restart_policy::*, shell_quote};
 use base64::Engine as _;
 use std::collections::BTreeMap;
@@ -48,6 +51,7 @@ pub(crate) fn run_remote(remote: RemoteLaunch) -> io::Result<()> {
         &session_name,
         remote.keybindings,
         remote.live_handoff,
+        remote.windows_desktop,
     );
     let manage_ssh_config = crate::config::Config::load()
         .config
@@ -61,19 +65,16 @@ pub(crate) fn run_remote(remote: RemoteLaunch) -> io::Result<()> {
         manage_ssh_config,
         session_name.clone(),
     );
-    let prepared_remote =
-        prepare_remote_herdr(&remote_ssh, remote.live_handoff, require_surface_interest)?;
-    ensure_remote_server_ready(
+    let remote_herdr = prepare_remote_host(
         &remote_ssh,
-        &prepared_remote.remote_herdr,
-        prepared_remote.stop_after_install_approved,
         remote.live_handoff,
         require_surface_interest,
+        remote.windows_desktop,
     )?;
 
     let _bridge = SshStdioBridge::start(
         remote.target,
-        prepared_remote.remote_herdr,
+        remote_herdr,
         local_socket.clone(),
         session_name,
         remote_ssh.options(),
@@ -83,7 +84,11 @@ pub(crate) fn run_remote(remote: RemoteLaunch) -> io::Result<()> {
     run_client_process(&local_socket, &reattach_command, remote.keybindings)
 }
 
-pub(crate) fn prepare_saved_ssh(target: &str, session_name: &str) -> io::Result<()> {
+pub(crate) fn prepare_saved_ssh(
+    target: &str,
+    session_name: &str,
+    windows_desktop: bool,
+) -> io::Result<()> {
     super::validate_remote_target(target)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
     crate::session::validate_name(session_name)
@@ -97,26 +102,14 @@ pub(crate) fn prepare_saved_ssh(target: &str, session_name: &str) -> io::Result<
         manage_ssh_config,
         session_name.to_owned(),
     );
-    let prepared = prepare_remote_herdr(&ssh, false, true)?;
-    ensure_remote_server_ready(
-        &ssh,
-        &prepared.remote_herdr,
-        prepared.stop_after_install_approved,
-        false,
-        true,
-    )?;
-
-    // The bridge already owns daemon startup. EOF closes only this temporary attachment,
-    // leaving the named server running even when no local TUI is open yet.
-    let command = prepared
-        .remote_herdr
-        .executable
-        .saved_bridge_command(session_name);
-    let output = ssh.shell_output(&prepared.remote_herdr.platform, &command)?;
+    let remote_herdr = prepare_remote_host(&ssh, false, true, windows_desktop)?;
+    // EOF ends only this temporary attachment; the named server stays running.
+    let command = remote_herdr.saved_bridge_command(session_name);
+    let output = ssh.shell_output(&remote_herdr.platform, &command)?;
     if !output.status.success() {
         return Err(command_failed("remote server startup failed", &output));
     }
-    match remote_server_status(&ssh, &prepared.remote_herdr, true)? {
+    match remote_server_status(&ssh, &remote_herdr, true)? {
         RemoteServerStatus::Running {
             endpoint_protocol_generation,
             surface_interest,
@@ -304,6 +297,7 @@ impl RemoteExecutable {
 
 #[derive(Debug, Clone)]
 pub(super) struct RemoteHerdr {
+    require_desktop: bool,
     install_suffix: String,
     executable: RemoteExecutable,
     platform: RemotePlatform,
@@ -322,6 +316,7 @@ impl RemoteHerdr {
             (install_suffix, RemoteExecutable::PosixShellPath(shell_path))
         };
         Self {
+            require_desktop: false,
             install_suffix,
             executable,
             platform,
@@ -961,7 +956,13 @@ pub(super) fn prepare_remote_herdr(
     })
 }
 
-pub(super) fn find_installed_remote_herdr(ssh: &RemoteSsh) -> io::Result<RemoteHerdr> {
+pub(super) fn find_installed_remote_herdr(
+    ssh: &RemoteSsh,
+    require_desktop: bool,
+) -> io::Result<RemoteHerdr> {
+    if require_desktop {
+        return find_desktop_remote_herdr(ssh, true);
+    }
     let platform = detect_remote_platform(ssh)?;
     let remote_herdr = RemoteHerdr::for_platform(platform);
     if remote_herdr.platform.is_windows() {
@@ -1014,10 +1015,13 @@ fn prepare_windows_remote_herdr(
 pub(super) fn find_installed_remote_api_herdr(
     ssh: &RemoteSsh,
     session: &str,
+    require_desktop: bool,
 ) -> io::Result<RemoteHerdr> {
     let platform = detect_remote_platform(ssh)?;
-    let remote_herdr = RemoteHerdr::for_platform(platform);
-    let candidates = if remote_herdr.platform.is_windows() {
+    let remote_herdr = remote_host_for_platform(platform, require_desktop)?;
+    let candidates = if require_desktop {
+        desktop_binary_candidates(ssh, &remote_herdr)?
+    } else if remote_herdr.platform.is_windows() {
         vec![remote_herdr]
     } else {
         remote_binary_candidates(ssh, &remote_herdr)?
@@ -1643,6 +1647,8 @@ struct RemoteClientStatusJson {
     endpoint_protocol_generation: Option<u32>,
     #[serde(default)]
     endpoint_capabilities: Vec<String>,
+    #[serde(default)]
+    remote_desktop_host: bool,
 }
 
 impl RemoteClientStatusJson {
@@ -2104,6 +2110,9 @@ pub(super) fn remote_api_bridge_command(
     check: bool,
 ) -> String {
     let mut args = vec!["--session", session_name, "remote-api-bridge"];
+    if remote_herdr.require_desktop {
+        args.push("--require-desktop");
+    }
     if check {
         args.push("--check");
     }
@@ -2122,6 +2131,7 @@ fn reattach_command(
     session_name: &str,
     keybindings: RemoteKeybindings,
     live_handoff: bool,
+    windows_desktop: bool,
 ) -> String {
     let program = crate::platform::remote_reattach_program(program);
     let target = crate::platform::remote_reattach_argument(target);
@@ -2132,6 +2142,9 @@ fn reattach_command(
     }
     if live_handoff {
         command.push_str(" --handoff");
+    }
+    if windows_desktop {
+        command.push_str(" --remote-desktop");
     }
     if session_name != crate::session::DEFAULT_SESSION_NAME {
         command.push_str(" --session ");
@@ -2169,7 +2182,7 @@ impl SshStdioBridge {
     ) -> io::Result<Self> {
         Self::start_command(
             target,
-            remote_herdr.executable.bridge_command(&session_name),
+            remote_herdr.bridge_command(&session_name),
             local_socket,
             ssh_options,
             noninteractive,
@@ -3304,6 +3317,7 @@ mod tests {
             endpoint_protocol_generation: Some(
                 crate::protocol::endpoint::ENDPOINT_PROTOCOL_GENERATION,
             ),
+            remote_desktop_host: false,
             endpoint_capabilities: vec![
                 crate::protocol::endpoint::SURFACE_INTEREST_CAPABILITY.into(),
                 crate::protocol::endpoint::PRESENTATION_EFFECTS_FENCE_CAPABILITY.into(),
@@ -3468,6 +3482,47 @@ mod tests {
         let remote = remote.unwrap();
         assert_eq!(remote.target, "dev");
         assert!(remote.live_handoff);
+    }
+
+    #[test]
+    fn extract_remote_args_preserves_desktop_intent_for_direct_and_machine_add() {
+        let direct = vec![
+            "herdr".into(),
+            "--remote=dev".into(),
+            "--remote-desktop".into(),
+        ];
+        let (cleaned, remote) = extract_remote_args(&direct).unwrap();
+        assert_eq!(cleaned, vec!["herdr"]);
+        assert!(remote.unwrap().windows_desktop);
+
+        let machine = vec![
+            "herdr".into(),
+            "machine".into(),
+            "add".into(),
+            "dev".into(),
+            "--remote-desktop".into(),
+        ];
+        let (cleaned, remote) = extract_remote_args(&machine).unwrap();
+        assert_eq!(cleaned, machine);
+        assert!(remote.is_none());
+    }
+
+    #[test]
+    fn extract_remote_args_rejects_unowned_or_duplicate_desktop_options() {
+        assert_eq!(
+            extract_remote_args(&["herdr".into(), "--remote-desktop".into()]).unwrap_err(),
+            "--remote-desktop requires --remote"
+        );
+        assert_eq!(
+            extract_remote_args(&[
+                "herdr".into(),
+                "--remote=dev".into(),
+                "--remote-desktop".into(),
+                "--remote-desktop".into(),
+            ])
+            .unwrap_err(),
+            "--remote-desktop can only be specified once"
+        );
     }
 
     #[test]
@@ -3803,6 +3858,7 @@ mod tests {
                 "work",
                 RemoteKeybindings::Local,
                 false,
+                false,
             ),
             "target/release/herdr --remote user@host --session work"
         );
@@ -3812,6 +3868,7 @@ mod tests {
                 "host name",
                 crate::session::DEFAULT_SESSION_NAME,
                 RemoteKeybindings::Local,
+                false,
                 false,
             ),
             "herdr --remote 'host name'"
@@ -3823,6 +3880,7 @@ mod tests {
                 crate::session::DEFAULT_SESSION_NAME,
                 RemoteKeybindings::Server,
                 false,
+                false,
             ),
             "herdr --remote host --remote-keybindings server"
         );
@@ -3833,6 +3891,7 @@ mod tests {
                 crate::session::DEFAULT_SESSION_NAME,
                 RemoteKeybindings::Local,
                 true,
+                false,
             ),
             "herdr --remote host --handoff"
         );
@@ -3848,6 +3907,7 @@ mod tests {
                 "host'name",
                 "work'name",
                 RemoteKeybindings::Local,
+                false,
                 false,
             ),
             format!(

--- a/src/remote/attach/desktop.rs
+++ b/src/remote/attach/desktop.rs
@@ -21,41 +21,173 @@ pub(super) fn prepare_remote_host(
     require_surface_interest: bool,
     require_desktop: bool,
 ) -> io::Result<RemoteHerdr> {
-    let prepared = if require_desktop {
-        PreparedRemoteHerdr {
-            remote_herdr: find_desktop_remote_herdr(ssh, require_surface_interest)?,
-            stop_after_install_approved: false,
-        }
-    } else {
-        prepare_remote_herdr(ssh, live_handoff, require_surface_interest)?
-    };
-    let remote = prepared.remote_herdr;
-    if require_desktop {
-        // Refuse a server in another login before offering to stop or hand it off.
-        inspect_desktop_placement(ssh, &remote)?;
+    let platform = detect_remote_platform(ssh)?;
+    if platform.is_windows() {
+        return prepare_windows_desktop_offer(
+            ssh,
+            platform,
+            require_surface_interest,
+            require_desktop,
+        );
     }
+    remote_host_for_platform(platform.clone(), require_desktop)?;
+    let prepared = prepare_remote_herdr(ssh, live_handoff, require_surface_interest, platform)?;
     ensure_remote_server_ready(
         ssh,
-        &remote,
+        &prepared.remote_herdr,
         prepared.stop_after_install_approved,
         live_handoff,
         require_surface_interest,
     )?;
-    if require_desktop {
-        ensure_desktop_server_ready(ssh, &remote)?;
+    Ok(prepared.remote_herdr)
+}
+
+fn prepare_windows_desktop_offer(
+    ssh: &RemoteSsh,
+    platform: RemotePlatform,
+    require_surface_interest: bool,
+    require_desktop: bool,
+) -> io::Result<RemoteHerdr> {
+    let mut remote =
+        find_windows_remote_host(ssh, platform, require_surface_interest, require_desktop)?;
+    if remote.require_desktop {
+        let report = remote_desktop_inspection(ssh, &remote)?;
+        match report.placement {
+            RemoteDesktopInspection::Ready { .. } => {
+                check_existing_server(
+                    remote_server_status(ssh, &remote, require_surface_interest)?,
+                    require_surface_interest,
+                )?;
+                return Ok(remote);
+            }
+            RemoteDesktopInspection::Conflict { .. } => {
+                if require_desktop {
+                    desktop_inspection_error(report.placement)?;
+                }
+                eprintln!("Herdr is already running outside the signed-in desktop. Continuing without desktop access. To switch, stop that server explicitly or choose another --session.");
+                remote.require_desktop = false;
+                // Inspect compatibility without offering to stop the existing server.
+                check_existing_server(
+                    remote_server_status(ssh, &remote, require_surface_interest)?,
+                    require_surface_interest,
+                )?;
+                return Ok(remote);
+            }
+            RemoteDesktopInspection::Start { windows_session } => {
+                let consent_path =
+                    desktop_consent_path(&crate::config::state_dir(), ssh.target(), &report);
+                let choice = if !io::stdin().is_terminal() {
+                    DesktopChoice::No
+                } else if consent_path.is_file() {
+                    DesktopChoice::Always
+                } else {
+                    eprintln!("Allow agents to use apps in your signed-in Windows desktop? Herdr uses a temporary Task Scheduler task to start there.");
+                    eprintln!(
+                        "  y - Yes, once
+  a - Yes, always for this machine and account
+  n - No, continue without desktop access"
+                    );
+                    eprint!("[y/a/N] ");
+                    io::stderr().flush()?;
+                    read_desktop_choice(&mut io::stdin().lock())?
+                };
+                if choice == DesktopChoice::No {
+                    if require_desktop {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "Windows desktop server start cancelled",
+                        ));
+                    }
+                    remote.require_desktop = false;
+                } else {
+                    start_desktop_server(ssh, &remote, windows_session)?;
+                    if choice == DesktopChoice::Always {
+                        remember_desktop_consent(&consent_path)?;
+                    }
+                }
+            }
+            inspection => {
+                if require_desktop {
+                    desktop_inspection_error(inspection)?;
+                }
+                eprintln!("No unique signed-in Windows desktop is available. Continuing without desktop access.");
+                remote.require_desktop = false;
+            }
+        }
     }
+    ensure_remote_server_ready(ssh, &remote, false, false, require_surface_interest)?;
     Ok(remote)
 }
 
-fn remote_binary_supports_host_requirement(
-    ssh: &RemoteSsh,
-    remote: &RemoteHerdr,
+fn check_existing_server(
+    status: RemoteServerStatus,
     require_surface_interest: bool,
-) -> io::Result<bool> {
-    Ok(remote_client_status(ssh, remote)?.is_some_and(|status| {
-        status.supports_endpoint_requirement(require_surface_interest)
-            && (!remote.require_desktop || status.remote_desktop_host)
-    }))
+) -> io::Result<()> {
+    let RemoteServerStatus::Running {
+        endpoint_protocol_generation,
+        surface_interest,
+        health_check,
+        detached_server_daemon,
+        ..
+    } = status
+    else {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "the remote Herdr server stopped before attachment; reconnect to prepare it",
+        ));
+    };
+    if remote_server_restart_reason(
+        endpoint_protocol_generation,
+        detached_server_daemon,
+        require_surface_interest,
+        surface_interest,
+        health_check,
+    )
+    .is_some()
+    {
+        return Err(io::Error::new(io::ErrorKind::Unsupported, "the existing remote Herdr server is incompatible and was left running; stop it explicitly or choose another --session"));
+    }
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum DesktopChoice {
+    Once,
+    Always,
+    No,
+}
+
+fn read_desktop_choice(input: &mut impl io::BufRead) -> io::Result<DesktopChoice> {
+    let mut answer = String::new();
+    input.read_line(&mut answer)?;
+    Ok(match answer.trim().to_ascii_lowercase().as_str() {
+        "y" => DesktopChoice::Once,
+        "a" => DesktopChoice::Always,
+        _ => DesktopChoice::No,
+    })
+}
+
+fn desktop_consent_path(state: &Path, target: &str, report: &RemoteDesktopReport) -> PathBuf {
+    use sha2::{Digest as _, Sha256};
+    let mut hash = Sha256::new();
+    for part in [target, &report.host, &report.account_sid] {
+        hash.update((part.len() as u64).to_le_bytes());
+        hash.update(part.as_bytes());
+    }
+    state
+        .join("remote-desktop-approvals")
+        .join(format!("{:x}", hash.finalize()))
+}
+
+fn remember_desktop_consent(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    match crate::platform::create_private_state_file(path) {
+        Ok(file) => file.sync_all(),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists && path.is_file() => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 impl RemoteHerdr {
@@ -99,10 +231,18 @@ enum RemoteDesktopInspection {
     MultipleLogins,
 }
 
+#[derive(Debug, Deserialize)]
+struct RemoteDesktopReport {
+    #[serde(flatten)]
+    placement: RemoteDesktopInspection,
+    account_sid: String,
+    host: String,
+}
+
 fn remote_desktop_inspection(
     ssh: &RemoteSsh,
     remote_herdr: &RemoteHerdr,
-) -> io::Result<RemoteDesktopInspection> {
+) -> io::Result<RemoteDesktopReport> {
     let command = remote_herdr
         .executable
         .desktop_inspect_command(&ssh.session_name);
@@ -125,41 +265,11 @@ fn remote_desktop_inspection(
         })
 }
 
-pub(super) fn inspect_desktop_placement(
+fn start_desktop_server(
     ssh: &RemoteSsh,
     remote_herdr: &RemoteHerdr,
+    windows_session: u32,
 ) -> io::Result<()> {
-    match remote_desktop_inspection(ssh, remote_herdr)? {
-        RemoteDesktopInspection::Ready { .. } | RemoteDesktopInspection::Start { .. } => Ok(()),
-        inspection => desktop_inspection_error(inspection),
-    }
-}
-
-pub(super) fn ensure_desktop_server_ready(
-    ssh: &RemoteSsh,
-    remote_herdr: &RemoteHerdr,
-) -> io::Result<()> {
-    let windows_session = match remote_desktop_inspection(ssh, remote_herdr)? {
-        RemoteDesktopInspection::Ready { .. } => return Ok(()),
-        RemoteDesktopInspection::Start { windows_session } => windows_session,
-        inspection => return desktop_inspection_error(inspection),
-    };
-    if !io::stdin().is_terminal() {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "starting Herdr in the signed-in Windows desktop requires approval in an interactive terminal",
-        ));
-    }
-    eprint!(
-        "Start Herdr in your signed-in Windows desktop? Agents can interact with desktop apps. A one-time Windows task will launch Herdr and be removed once it's ready. [y/N] "
-    );
-    io::stderr().flush()?;
-    if !read_remote_confirmation(&mut io::stdin().lock(), false)? {
-        return Err(io::Error::new(
-            io::ErrorKind::Interrupted,
-            "Windows desktop server start cancelled",
-        ));
-    }
     let command = remote_herdr
         .executable
         .desktop_start_command(&ssh.session_name, windows_session);
@@ -170,7 +280,7 @@ pub(super) fn ensure_desktop_server_ready(
             &output,
         ));
     }
-    match remote_desktop_inspection(ssh, remote_herdr)? {
+    match remote_desktop_inspection(ssh, remote_herdr)?.placement {
         RemoteDesktopInspection::Ready {
             windows_session: actual,
             ..
@@ -274,22 +384,103 @@ pub(super) fn desktop_binary_candidates(
     ))
 }
 
-pub(super) fn find_desktop_remote_herdr(
+pub(super) fn find_windows_remote_host(
     ssh: &RemoteSsh,
+    platform: RemotePlatform,
     require_surface_interest: bool,
+    require_desktop: bool,
 ) -> io::Result<RemoteHerdr> {
-    let remote = remote_host_for_platform(detect_remote_platform(ssh)?, true)?;
-    for candidate in desktop_binary_candidates(ssh, &remote)? {
-        if remote_binary_supports_host_requirement(ssh, &candidate, require_surface_interest)? {
-            return Ok(candidate);
+    let remote = remote_host_for_platform(platform, true)?;
+    let mut ordinary = None;
+    for mut candidate in desktop_binary_candidates(ssh, &remote)? {
+        if let Some(status) = remote_client_status(ssh, &candidate)? {
+            if status.supports_endpoint_requirement(require_surface_interest) {
+                if status.remote_desktop_host {
+                    return Ok(candidate);
+                }
+                candidate.require_desktop = false;
+                ordinary.get_or_insert(candidate);
+            }
         }
     }
-    Err(io::Error::new(io::ErrorKind::Unsupported, format!("no desktop-capable Herdr package is installed on {}; install or update the Windows package before retrying --remote-desktop", ssh.target())))
+    if !require_desktop {
+        if let Some(remote) = ordinary {
+            return Ok(remote);
+        }
+    }
+    Err(io::Error::new(io::ErrorKind::Unsupported, format!("no compatible {}Herdr package is installed on {}; install or update the Windows package before retrying", if require_desktop { "desktop-capable " } else { "" }, ssh.target())))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn existing_server_reuse_requires_capabilities_and_detached_lifecycle() {
+        let generation = Some(crate::protocol::endpoint::ENDPOINT_PROTOCOL_GENERATION);
+        for (protocol, detached, surface, health, saved, ready) in [
+            (generation, true, true, true, true, true),
+            (generation, true, false, false, false, true),
+            (None, true, true, true, true, false),
+            (generation, false, true, true, true, false),
+            (generation, true, false, true, true, false),
+            (generation, true, true, false, true, false),
+        ] {
+            let status = RemoteServerStatus::Running {
+                version: None,
+                endpoint_protocol_generation: protocol,
+                surface_interest: surface,
+                health_check: health,
+                live_handoff: false,
+                detached_server_daemon: detached,
+            };
+            assert_eq!(check_existing_server(status, saved).is_ok(), ready);
+        }
+        assert_eq!(
+            check_existing_server(RemoteServerStatus::NotRunning, false)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn desktop_consent_defaults_to_no_and_remembers_only_the_matching_account() {
+        for (answer, expected) in [
+            ("y\n", DesktopChoice::Once),
+            ("A\n", DesktopChoice::Always),
+            ("n\n", DesktopChoice::No),
+            ("\n", DesktopChoice::No),
+            ("", DesktopChoice::No),
+            ("yes please\n", DesktopChoice::No),
+        ] {
+            assert_eq!(
+                read_desktop_choice(&mut answer.as_bytes()).unwrap(),
+                expected
+            );
+        }
+        let root =
+            std::env::temp_dir().join(format!("herdr-desktop-consent-{}", std::process::id()));
+        let mut report = RemoteDesktopReport {
+            placement: RemoteDesktopInspection::Start { windows_session: 1 },
+            host: "workbox".into(),
+            account_sid: "account-one".into(),
+        };
+        let path = desktop_consent_path(&root, "work", &report);
+        remember_desktop_consent(&path).unwrap();
+        assert!(desktop_consent_path(&root, "work", &report).is_file());
+        report.placement = RemoteDesktopInspection::Start { windows_session: 3 };
+        assert_eq!(desktop_consent_path(&root, "work", &report), path);
+        assert_ne!(desktop_consent_path(&root, "other-target", &report), path);
+        report.host = "other-host".into();
+        assert_ne!(desktop_consent_path(&root, "work", &report), path);
+        report.host = "workbox".into();
+        report.account_sid = "account-two".into();
+        assert_ne!(desktop_consent_path(&root, "work", &report), path);
+        std::fs::remove_file(&path).unwrap();
+        std::fs::remove_dir(path.parent().unwrap()).unwrap();
+        std::fs::remove_dir(root).unwrap();
+    }
 
     #[test]
     fn desktop_selection_rejects_unix_and_preserves_intent_across_discovery() {

--- a/src/remote/attach/desktop.rs
+++ b/src/remote/attach/desktop.rs
@@ -1,0 +1,336 @@
+use super::*;
+
+pub(super) fn remote_host_for_platform(
+    platform: RemotePlatform,
+    require_desktop: bool,
+) -> io::Result<RemoteHerdr> {
+    if require_desktop && !platform.is_windows() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "--remote-desktop requires a Windows SSH target",
+        ));
+    }
+    let mut remote = RemoteHerdr::for_platform(platform);
+    remote.require_desktop = require_desktop;
+    Ok(remote)
+}
+
+pub(super) fn prepare_remote_host(
+    ssh: &RemoteSsh,
+    live_handoff: bool,
+    require_surface_interest: bool,
+    require_desktop: bool,
+) -> io::Result<RemoteHerdr> {
+    let prepared = if require_desktop {
+        PreparedRemoteHerdr {
+            remote_herdr: find_desktop_remote_herdr(ssh, require_surface_interest)?,
+            stop_after_install_approved: false,
+        }
+    } else {
+        prepare_remote_herdr(ssh, live_handoff, require_surface_interest)?
+    };
+    let remote = prepared.remote_herdr;
+    if require_desktop {
+        // Refuse a server in another login before offering to stop or hand it off.
+        inspect_desktop_placement(ssh, &remote)?;
+    }
+    ensure_remote_server_ready(
+        ssh,
+        &remote,
+        prepared.stop_after_install_approved,
+        live_handoff,
+        require_surface_interest,
+    )?;
+    if require_desktop {
+        ensure_desktop_server_ready(ssh, &remote)?;
+    }
+    Ok(remote)
+}
+
+fn remote_binary_supports_host_requirement(
+    ssh: &RemoteSsh,
+    remote: &RemoteHerdr,
+    require_surface_interest: bool,
+) -> io::Result<bool> {
+    Ok(remote_client_status(ssh, remote)?.is_some_and(|status| {
+        status.supports_endpoint_requirement(require_surface_interest)
+            && (!remote.require_desktop || status.remote_desktop_host)
+    }))
+}
+
+impl RemoteHerdr {
+    pub(super) fn bridge_command(&self, session: &str) -> String {
+        if self.require_desktop {
+            self.desktop_bridge_command(session)
+        } else {
+            self.executable.bridge_command(session)
+        }
+    }
+
+    pub(super) fn saved_bridge_command(&self, session: &str) -> String {
+        if self.require_desktop {
+            self.desktop_bridge_command(session)
+        } else {
+            self.executable.saved_bridge_command(session)
+        }
+    }
+
+    fn desktop_bridge_command(&self, session: &str) -> String {
+        let args =
+            RemoteExecutable::session_args(session, &["remote-client-bridge", "--require-desktop"]);
+        match &self.executable {
+            RemoteExecutable::WindowsPath(path) => {
+                windows_powershell_streaming_application_command(path, &args)
+            }
+            RemoteExecutable::PosixShellPath(_) => {
+                posix_remote_output_command(&format!("exec {}", self.executable.command(&args)))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+enum RemoteDesktopInspection {
+    Ready { pid: u32, windows_session: u32 },
+    Start { windows_session: u32 },
+    Conflict { pid: u32, windows_session: u32 },
+    NoLogin,
+    MultipleLogins,
+}
+
+fn remote_desktop_inspection(
+    ssh: &RemoteSsh,
+    remote_herdr: &RemoteHerdr,
+) -> io::Result<RemoteDesktopInspection> {
+    let command = remote_herdr
+        .executable
+        .desktop_inspect_command(&ssh.session_name);
+    let output = ssh.shell_output(&remote_herdr.platform, &command)?;
+    if !output.status.success() {
+        return Err(command_failed(
+            "remote Windows desktop inspection failed",
+            &output,
+        ));
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .next_back()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "remote Herdr did not report Windows desktop placement",
+            )
+        })
+}
+
+pub(super) fn inspect_desktop_placement(
+    ssh: &RemoteSsh,
+    remote_herdr: &RemoteHerdr,
+) -> io::Result<()> {
+    match remote_desktop_inspection(ssh, remote_herdr)? {
+        RemoteDesktopInspection::Ready { .. } | RemoteDesktopInspection::Start { .. } => Ok(()),
+        inspection => desktop_inspection_error(inspection),
+    }
+}
+
+pub(super) fn ensure_desktop_server_ready(
+    ssh: &RemoteSsh,
+    remote_herdr: &RemoteHerdr,
+) -> io::Result<()> {
+    let windows_session = match remote_desktop_inspection(ssh, remote_herdr)? {
+        RemoteDesktopInspection::Ready { .. } => return Ok(()),
+        RemoteDesktopInspection::Start { windows_session } => windows_session,
+        inspection => return desktop_inspection_error(inspection),
+    };
+    if !io::stdin().is_terminal() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "starting Herdr in the signed-in Windows desktop requires approval in an interactive terminal",
+        ));
+    }
+    eprint!(
+        "Start Herdr in your signed-in Windows desktop? Agents can interact with desktop apps. A one-time Windows task will launch Herdr and be removed once it's ready. [y/N] "
+    );
+    io::stderr().flush()?;
+    if !read_remote_confirmation(&mut io::stdin().lock(), false)? {
+        return Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "Windows desktop server start cancelled",
+        ));
+    }
+    let command = remote_herdr
+        .executable
+        .desktop_start_command(&ssh.session_name, windows_session);
+    let output = ssh.shell_output(&remote_herdr.platform, &command)?;
+    if !output.status.success() {
+        return Err(command_failed(
+            "remote Windows desktop start failed",
+            &output,
+        ));
+    }
+    match remote_desktop_inspection(ssh, remote_herdr)? {
+        RemoteDesktopInspection::Ready {
+            windows_session: actual,
+            ..
+        } if actual == windows_session => Ok(()),
+        inspection => desktop_inspection_error(inspection),
+    }
+}
+
+fn desktop_inspection_error(inspection: RemoteDesktopInspection) -> io::Result<()> {
+    match inspection {
+        RemoteDesktopInspection::Conflict {
+            pid,
+            windows_session,
+        } => Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!(
+                "remote Herdr server process {pid} is running in nonqualifying Windows session {windows_session}; use another --session or stop it explicitly"
+            ),
+        )),
+        RemoteDesktopInspection::NoLogin => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "no active desktop login exists for this Windows account; sign in to Windows first",
+        )),
+        RemoteDesktopInspection::MultipleLogins => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "more than one active desktop login exists for this Windows account; disconnect the extra login before starting Herdr",
+        )),
+        RemoteDesktopInspection::Start { .. } => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "the Windows desktop Herdr server did not become ready",
+        )),
+        RemoteDesktopInspection::Ready { .. } => Err(io::Error::other(
+            "the Windows desktop Herdr server started in a different login",
+        )),
+    }
+}
+
+impl RemoteExecutable {
+    fn desktop_inspect_command(&self, session_name: &str) -> String {
+        self.session_command(session_name, &["remote-desktop", "inspect"])
+    }
+
+    fn desktop_start_command(&self, session_name: &str, windows_session: u32) -> String {
+        let windows_session = windows_session.to_string();
+        self.session_command(
+            session_name,
+            &[
+                "remote-desktop",
+                "start",
+                "--windows-session",
+                &windows_session,
+            ],
+        )
+    }
+}
+
+const WINDOWS_REMOTE_PATH_MARKER: &str = "herdr-remote-path:1:";
+fn windows_remote_binary_candidate_command() -> String {
+    windows_powershell_script_command(&format!(
+        r#"function Emit-HerdrPath([string]$CandidatePath) {{ if ([string]::IsNullOrWhiteSpace($CandidatePath) -or -not (Test-Path -LiteralPath $CandidatePath -PathType Leaf)) {{ return }}; $candidateFullPath = [System.IO.Path]::GetFullPath($CandidatePath); $encodedCandidate = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($candidateFullPath)); [Console]::Out.WriteLine('{WINDOWS_REMOTE_PATH_MARKER}' + $encodedCandidate) }}; $pathCommand = Get-Command herdr.exe -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1; if ($null -ne $pathCommand) {{ Emit-HerdrPath $pathCommand.Source }}; $herdrHome = if ([string]::IsNullOrWhiteSpace($env:HERDR_HOME)) {{ Join-Path $env:USERPROFILE '.herdr' }} else {{ $env:HERDR_HOME }}; $activeJunction = Get-Item -LiteralPath (Join-Path $herdrHome 'packages\standalone\current') -Force -ErrorAction SilentlyContinue; if ($null -ne $activeJunction -and -not [string]::IsNullOrWhiteSpace([string]$activeJunction.Target)) {{ Emit-HerdrPath (Join-Path ([string]$activeJunction.Target) 'herdr.exe') }}; exit 0"#
+    ))
+}
+
+fn windows_remote_binary_candidates(remote_herdr: &RemoteHerdr, stdout: &str) -> Vec<RemoteHerdr> {
+    let mut candidates = Vec::new();
+    for path in stdout.lines().filter_map(|line| {
+        line.trim()
+            .strip_prefix(WINDOWS_REMOTE_PATH_MARKER)
+            .and_then(decode_windows_remote_path)
+    }) {
+        push_if_new_remote_binary_candidate(
+            &mut candidates,
+            RemoteHerdr {
+                executable: RemoteExecutable::WindowsPath(path),
+                ..remote_herdr.clone()
+            },
+        );
+    }
+    candidates
+}
+
+fn decode_windows_remote_path(encoded: &str) -> Option<String> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()?;
+    let path = String::from_utf8(bytes).ok()?;
+    (!path.is_empty()).then_some(path)
+}
+
+pub(super) fn desktop_binary_candidates(
+    ssh: &RemoteSsh,
+    remote: &RemoteHerdr,
+) -> io::Result<Vec<RemoteHerdr>> {
+    let output = ssh.framed_user_shell_output(&windows_remote_binary_candidate_command())?;
+    if !output.status.success() {
+        return Err(command_failed("remote binary discovery failed", &output));
+    }
+    Ok(windows_remote_binary_candidates(
+        remote,
+        &String::from_utf8_lossy(&output.stdout),
+    ))
+}
+
+pub(super) fn find_desktop_remote_herdr(
+    ssh: &RemoteSsh,
+    require_surface_interest: bool,
+) -> io::Result<RemoteHerdr> {
+    let remote = remote_host_for_platform(detect_remote_platform(ssh)?, true)?;
+    for candidate in desktop_binary_candidates(ssh, &remote)? {
+        if remote_binary_supports_host_requirement(ssh, &candidate, require_surface_interest)? {
+            return Ok(candidate);
+        }
+    }
+    Err(io::Error::new(io::ErrorKind::Unsupported, format!("no desktop-capable Herdr package is installed on {}; install or update the Windows package before retrying --remote-desktop", ssh.target())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desktop_selection_rejects_unix_and_preserves_intent_across_discovery() {
+        let unix = RemotePlatform {
+            os: "linux",
+            arch: "x86_64",
+        };
+        assert_eq!(
+            remote_host_for_platform(unix, true).unwrap_err().kind(),
+            io::ErrorKind::Unsupported
+        );
+        let host = remote_host_for_platform(
+            RemotePlatform {
+                os: "windows",
+                arch: "x86_64",
+            },
+            true,
+        )
+        .unwrap();
+        let path = base64::engine::general_purpose::STANDARD.encode("C:\\Herdr Test\\herdr.exe");
+        let hosts =
+            windows_remote_binary_candidates(&host, &format!("{WINDOWS_REMOTE_PATH_MARKER}{path}"));
+        let host = &hosts[0];
+        for command in [
+            host.bridge_command("agents"),
+            host.saved_bridge_command("agents"),
+            remote_api_bridge_command(host, "agents", false),
+            remote_api_bridge_command(host, "agents", true),
+        ] {
+            let encoded = command.split_whitespace().last().unwrap();
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .unwrap();
+            let units = bytes
+                .chunks_exact(2)
+                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                .collect::<Vec<_>>();
+            let script = String::from_utf16(&units).unwrap();
+            assert!(script.contains("--session agents"), "{script}");
+            assert!(script.contains("--require-desktop"), "{script}");
+            assert!(script.contains("C:\\Herdr Test\\herdr.exe"), "{script}");
+        }
+    }
+}

--- a/src/remote/host.rs
+++ b/src/remote/host.rs
@@ -3,8 +3,8 @@
 use std::io;
 use std::time::Duration;
 
-pub(crate) fn run_remote_client_bridge() -> io::Result<()> {
-    ensure_remote_server_running()?;
+pub(crate) fn run_remote_client_bridge(require_desktop: bool) -> io::Result<()> {
+    ensure_remote_server_running(require_desktop)?;
 
     let socket_path = crate::server::socket_paths::client_socket_path();
     let stream = crate::ipc::connect_local_stream(&socket_path).map_err(|err| {
@@ -16,11 +16,14 @@ pub(crate) fn run_remote_client_bridge() -> io::Result<()> {
             ),
         )
     })?;
+    if require_desktop {
+        crate::platform::verify_remote_desktop_stream(&stream)?;
+    }
 
     crate::platform::forward_remote_bridge_stdio(stream)
 }
 
-fn ensure_remote_server_running() -> io::Result<()> {
+fn ensure_remote_server_running(require_desktop: bool) -> io::Result<()> {
     let socket_path = crate::server::socket_paths::client_socket_path();
     if crate::server::autodetect::is_server_listening() {
         let status = crate::api::read_runtime_status_at(
@@ -41,6 +44,12 @@ fn ensure_remote_server_running() -> io::Result<()> {
         ));
     }
 
+    if require_desktop {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "the Windows desktop Herdr server is not running; run the interactive remote command to prepare it",
+        ));
+    }
     crate::server::autodetect::spawn_server_daemon()?;
     crate::server::autodetect::wait_for_server_socket(&socket_path, Duration::from_secs(5))
 }

--- a/src/remote/saved.rs
+++ b/src/remote/saved.rs
@@ -16,9 +16,10 @@ pub(crate) fn connect_saved_ssh(
     profile_id: &str,
     target: &str,
     session: &str,
+    windows_desktop: bool,
 ) -> io::Result<SavedSshStream> {
     let ssh = validated_saved_ssh(profile_id, target, session)?;
-    let remote_herdr = find_installed_remote_herdr(&ssh)?;
+    let remote_herdr = find_installed_remote_herdr(&ssh, windows_desktop)?;
     let path = saved_bridge_path(profile_id);
     let bridge = SshStdioBridge::start(
         target.to_owned(),
@@ -41,9 +42,15 @@ pub(crate) struct SavedSshApiBridge {
 }
 
 impl SavedSshApiBridge {
-    pub(crate) fn start(profile_id: &str, target: &str, session: &str) -> io::Result<Self> {
+    pub(crate) fn start(
+        profile_id: &str,
+        target: &str,
+        session: &str,
+        windows_desktop: bool,
+    ) -> io::Result<Self> {
         let ssh = validated_saved_ssh(profile_id, target, session)?;
-        let remote_herdr = super::attach::find_installed_remote_api_herdr(&ssh, session)?;
+        let remote_herdr =
+            super::attach::find_installed_remote_api_herdr(&ssh, session, windows_desktop)?;
         let command = super::attach::remote_api_bridge_command(&remote_herdr, session, false);
         let path = crate::platform::remote_bridge_endpoint_path(
             &format!("herdr-api-ssh-{}-{profile_id}.sock", std::process::id()),
@@ -72,11 +79,20 @@ impl SavedSshApiBridge {
     }
 }
 
-pub(crate) fn saved_ssh_bootstrap_command(target: &str, session: &str) -> String {
+pub(crate) fn saved_ssh_bootstrap_command(
+    target: &str,
+    session: &str,
+    windows_desktop: bool,
+) -> String {
     format!(
-        "herdr --remote {} --session {}",
+        "herdr --remote {} --session {}{}",
         super::shell_quote(target),
-        super::shell_quote(session)
+        super::shell_quote(session),
+        if windows_desktop {
+            " --remote-desktop"
+        } else {
+            ""
+        }
     )
 }
 
@@ -152,7 +168,7 @@ mod tests {
     #[test]
     fn bootstrap_command_preserves_the_explicit_remote_session() {
         assert_eq!(
-            saved_ssh_bootstrap_command("build host", "agent work"),
+            saved_ssh_bootstrap_command("build host", "agent work", false),
             "herdr --remote 'build host' --session 'agent work'"
         );
     }

--- a/src/server/headless/tests/surface_interest.rs
+++ b/src/server/headless/tests/surface_interest.rs
@@ -555,6 +555,7 @@ async fn two_headless_servers_drive_atomic_endpoint_handoff() {
         target: "dev@example.com".into(),
         session: "main".into(),
         enabled: true,
+        windows_desktop: false,
     };
     let target_id = ClientEndpointId::Ssh(profile.id.clone());
     let mut shell = crate::client::ClientShellState::new(


### PR DESCRIPTION
Windows SSH normally launches outside the signed-in desktop, preventing agents from using desktop apps. Normal remote attach and saved-machine setup now offer desktop access before launching: **y** once, **a** always for this SSH target and Windows host/account, or **n** (default) for ordinary mode. Existing ordinary servers remain running; switching requires an explicit stop or another Herdr session.

Desktop launches use a temporary same-account Task Scheduler task. Saved TUI/API reconnects verify the actual connected server account and desktop session and never start a desktop server in the background, even with remembered approval. Saved placement requirements and remembered start approval are separate.

This PR targets master independently of #3687. Windows packages must already be installed; setup and reconnect share read-only PATH/managed-package discovery. Windows scheduling, bootstrap, and identity checks live under `src/platform/windows/`; desktop client orchestration lives in `src/remote/attach/desktop.rs`. Unix installation retains its existing flow. No endpoint codec changes.

Validation:
- `just check`: 2,949 Rust tests passed, 4 skipped, plus maintenance checks.
- Local FAST review clean; one deslop pass completed for the follow-up.
- Real SSH: default-No ordinary launch, existing ordinary PID preserved, once prompts again after shutdown, always survives a new interactive connection, saved API access, and no background restart after shutdown.
- Managed-package-only ordinary reconnect: reproduced API failure before the fix; the same saved profile/server passed with the repaired client.
- Native filtered administrator token (not a separate standard-user account): desktop launch, TUI/API access, process reuse and cleanup. Repeated startup failure was traced with a temporary panic hook to stale standard handles after console detachment. Desktop bootstrap now clears those handles; an isolated native child regression covers detachment and output writes. Eight consecutive native starts then passed, and real SSH desktop start, existing-PID reuse, and saved API access passed on the fixed build.
- Existing-server reuse checks live compatibility and detached lifecycle without stopping incompatible servers.

Desktop discovery requires readable active-session identities and fails when it cannot establish them. Desktop hosting does not sign in, unlock Windows, or move existing panes. A brief console flash before process initialization remains possible.

refs #3651
