### PR TITLE
fix: keep windows endpoint writes progressing

### DIFF
--- a/src/client/endpoint/writer.rs
+++ b/src/client/endpoint/writer.rs
@@ -163,11 +163,23 @@ fn write_frame(
     stopped: &AtomicBool,
 ) -> io::Result<()> {
     let deadline = Instant::now() + WRITE_TIMEOUT;
+    #[cfg(windows)]
+    let mut deadline = deadline;
     while !frame.is_empty() && !stopped.load(Ordering::Acquire) {
-        match writer.write(frame) {
+        // Match interprocess's 512-byte pipe buffer hint: larger nonblocking Windows
+        // writes can make no progress when the peer polls instead of blocking on read.
+        #[cfg(windows)]
+        let chunk = &frame[..frame.len().min(512)];
+        #[cfg(not(windows))]
+        let chunk = frame;
+        match writer.write(chunk) {
             Ok(0) => {}
             Ok(written) => {
                 frame = &frame[written..];
+                #[cfg(windows)]
+                {
+                    deadline = Instant::now() + WRITE_TIMEOUT;
+                }
                 continue;
             }
             Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
@@ -276,7 +288,24 @@ mod tests {
 
     #[test]
     fn native_endpoint_flush_drains_large_frames_before_detach() {
-        let (stream, mut peer, path) = streams();
+        // The SSH bridge polls for available bytes instead of posting a blocking read.
+        struct PollingPeer(LocalStream);
+        impl io::Read for PollingPeer {
+            fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+                loop {
+                    match crate::ipc::poll_local_stream_read_count(&mut self.0, buffer)? {
+                        crate::ipc::LocalStreamReadCount::Data(count) => return Ok(count),
+                        crate::ipc::LocalStreamReadCount::Closed => return Ok(0),
+                        crate::ipc::LocalStreamReadCount::Pending => {
+                            std::thread::sleep(IO_POLL_INTERVAL);
+                        }
+                    }
+                }
+            }
+        }
+        let (stream, peer, path) = streams();
+        peer.set_nonblocking(true).unwrap();
+        let mut peer = PollingPeer(peer);
         let mut transport = NativeEndpointTransport::with_lifetime(stream, ()).unwrap();
         let (done, received) = mpsc::channel();
         let reader = std::thread::spawn(move || {


### PR DESCRIPTION
Windows endpoint writes can stop making progress when a large frame meets a polling named-pipe reader, causing the client connection to fail. Write Windows frames in 512-byte chunks and reset the five-second stall deadline when bytes advance.

This standalone change touches only `src/client/endpoint/writer.rs`. Both production changes are Windows-only; Unix keeps its existing full-frame writes and deadline behavior. No unmerged stack prerequisites are included.

Validation:
- The existing large-frame/detach test, using a polling peer like the SSH bridge, failed on unchanged master after five seconds. It passes with this fix and verifies a complete 1 MiB input frame followed by detach.
- All 448 client tests passed.
- Native `just check` passed: 2,938 Rust tests passed, 4 skipped; maintenance checks and build passed.
- Local FAST review (two reviewers) and deslop completed with no findings.

#3833 is being handled separately: its reported queue overflow from many unbracketed key events is distinct from this single-frame pipe stall. This change does not alter queue limits or input handling.

refs #3651

