### PR TITLE
fix: keep pi panes working while extension-reported work runs

### DIFF
--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -109,6 +109,15 @@ Herdr writes the bundled extension to:
 
 If `PI_CODING_AGENT_DIR` is set, Herdr writes to `$PI_CODING_AGENT_DIR/extensions/herdr-agent-state.ts` instead. Herdr creates the extensions directory when the Pi agent directory already exists. Uninstall removes only that extension file.
 
+The extension reports `working` while Pi's agent loop is running a turn. Other Pi extensions can fold activity that happens outside that loop into the same pane state by emitting events on `pi.events`:
+
+| Event | Payload | Effect |
+| --- | --- | --- |
+| `herdr:busy`, `herdr:working` | `{ active: boolean }` | While at least one activation is outstanding, the pane stays `working` after the agent turn settles. Sub-agent and workflow extensions whose children keep running use this; both names count into the same total. |
+| `herdr:blocked` | `{ active: boolean, label?: string }` | While at least one activation is outstanding, the pane reports `blocked` with the label as its message. Confirmation prompts use this. |
+
+Each `active: true` must be paired with a later `active: false`. Blocked takes precedence over working. Events emitted before Pi's `session_start` are ignored.
+
 ## OMP
 
 Install the OMP integration:

--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -315,6 +315,76 @@ test("Pi settlement preserves explicit blocked-state precedence", async () => {
   expect(requestStates(requests)).toEqual(["idle", "working", "blocked", "idle"]);
 });
 
+test("Pi stays working while extension-reported work outlives the agent turn", async () => {
+  const requests = await startRecordingServer("pi-extension-working");
+  const { eventHandlers, handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  let idle = true;
+  const context = piContext(() => idle);
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+
+  eventHandlers.get("herdr:working")?.({ active: true, runId: "run-1" }, context);
+  await waitFor(() => requestStates(requests).length === 2);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  idle = false;
+  handlers.get("agent_start")?.({}, context);
+  idle = true;
+  handlers.get("agent_settled")?.({}, context);
+  await Bun.sleep(25);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  eventHandlers.get("herdr:working")?.({ active: false, runId: "run-1" }, context);
+  await waitFor(() => requestStates(requests).length === 3);
+  expect(requestStates(requests)).toEqual(["idle", "working", "idle"]);
+});
+
+test("Pi keeps working across a herdr:busy relabel and returns idle once every activation is lowered", async () => {
+  const requests = await startRecordingServer("pi-extension-busy");
+  const { eventHandlers, handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  const context = piContext(() => true);
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+
+  eventHandlers.get("herdr:busy")?.({ active: true, label: "1 subagent" }, context);
+  await waitFor(() => requestStates(requests).length === 2);
+  eventHandlers.get("herdr:working")?.({ active: true, runId: "run-1" }, context);
+  eventHandlers.get("herdr:busy")?.({ active: false }, context);
+  eventHandlers.get("herdr:busy")?.({ active: true, label: "2 subagents" }, context);
+  await Bun.sleep(25);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  eventHandlers.get("herdr:busy")?.({ active: false }, context);
+  await Bun.sleep(25);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  eventHandlers.get("herdr:working")?.({ active: false, runId: "run-1" }, context);
+  await waitFor(() => requestStates(requests).length === 3);
+  expect(requestStates(requests)).toEqual(["idle", "working", "idle"]);
+});
+
+test("Pi ignores extension work events before the root session starts", async () => {
+  const requests = await startRecordingServer("pi-extension-working-early");
+  const { eventHandlers, handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  const context = piContext(() => true);
+  eventHandlers.get("herdr:working")?.({ active: true, runId: "run-1" }, context);
+  await Bun.sleep(25);
+  expect(requests).toEqual([]);
+
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+  expect(requestStates(requests)).toEqual(["idle"]);
+});
+
 test("Pi reports the session replacement source", async () => {
   const requests = await startRecordingServer("pi-session-source");
   const { handlers, pi } = createExtensionHarness();

--- a/src/integration/assets/pi/herdr-agent-state.ts
+++ b/src/integration/assets/pi/herdr-agent-state.ts
@@ -2,7 +2,7 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=pi
-// HERDR_INTEGRATION_VERSION=8
+// HERDR_INTEGRATION_VERSION=9
 // @ts-nocheck
 
 import net from "node:net";
@@ -178,6 +178,9 @@ export default function (pi) {
   }
 
   let agentActive = false;
+  // Work that extensions run outside the agent loop, such as background
+  // workflows whose sub-agents keep going after the root turn settles.
+  let extensionWorkCount = 0;
   let blockedCount = 0;
   let blockedMessage: string | undefined;
   let lastState: AgentState | undefined;
@@ -188,7 +191,7 @@ export default function (pi) {
     if (blockedCount > 0) {
       return { state: "blocked" as const, message: blockedMessage };
     }
-    if (agentActive) {
+    if (agentActive || extensionWorkCount > 0) {
       return { state: "working" as const, message: undefined };
     }
     return { state: "idle" as const, message: undefined };
@@ -203,6 +206,24 @@ export default function (pi) {
     lastMessage = next.message;
     queueState(next.state, next.message);
   }
+
+  function onExtensionWork(data) {
+    if (!rootSession) {
+      return;
+    }
+    if (!data?.active) {
+      extensionWorkCount = Math.max(0, extensionWorkCount - 1);
+      publishState();
+      return;
+    }
+
+    extensionWorkCount += 1;
+    publishState();
+  }
+
+  // pi-subagents emits herdr:busy; pi-extensible-workflows emits herdr:working.
+  pi.events.on("herdr:busy", onExtensionWork);
+  pi.events.on("herdr:working", onExtensionWork);
 
   pi.events.on("herdr:blocked", (data) => {
     if (!rootSession) {

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use types::{IntegrationRecommendation, IntegrationStatus, Integration
 
 const PI_EXTENSION_INSTALL_NAME: &str = "herdr-agent-state.ts";
 const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
-const PI_INTEGRATION_VERSION: u32 = 8;
+const PI_INTEGRATION_VERSION: u32 = 9;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
 const OMP_INTEGRATION_VERSION: u32 = 9;


### PR DESCRIPTION
The Pi integration reports `working` only between `agent_start` and `agent_settled`. Extensions that run children outside that loop return control immediately... Both known producers already emit an event on `pi.events` for exactly this, mirroring the `herdr:blocked` event the integration consumes: pi-subagents emits `herdr:busy` and pi-extensible-workflows emits `herdr:working`. Nothing listened to either. Because the integration holds full lifecycle authority for the pane, no other source can correct the state: a `working` report from another source is accepted and ignored.

Verified on Herdr 0.9.0 / Pi 0.85.1 / macOS / Ghostty: with a background pi-extensible-workflows run active, `herdr agent get` reported `idle` with `screen_detection_skip_reason: full_lifecycle_hook_authority`; with this listener the same pane reports `working` until the run ends.

refs #3323
refs #3796