### PR TITLE
fix: stop pane link spans at box-drawing border cells

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1220,7 +1220,7 @@ fn url_spans(cells: &[TextCell]) -> Vec<CellSpan> {
             || starts_with_chars(&cells[start..], "https://")
         {
             let mut end = start;
-            while end + 1 < cells.len() && !cells[end + 1].ch.is_whitespace() {
+            while end + 1 < cells.len() && !is_url_boundary_char(cells[end + 1].ch) {
                 end += 1;
             }
             if let Some(span) = trim_url_edges(cells, CellSpan { start, end }) {
@@ -1377,7 +1377,7 @@ fn url_span_at_column(cells: &[TextCell], clicked_idx: usize) -> Option<CellSpan
             || starts_with_chars(&cells[start..], "https://")
         {
             let mut end = start;
-            while end + 1 < cells.len() && !cells[end + 1].ch.is_whitespace() {
+            while end + 1 < cells.len() && !is_url_boundary_char(cells[end + 1].ch) {
                 end += 1;
             }
             if clicked_idx >= start && clicked_idx <= end {
@@ -1404,7 +1404,17 @@ fn trim_url_edges(cells: &[TextCell], span: CellSpan) -> Option<CellSpan> {
     (start <= end).then_some(CellSpan { start, end })
 }
 
+/// Cells that end a URL span: whitespace, plus the box-drawing and block glyphs
+/// pane apps draw as panel borders. Those borders can sit right after a link once
+/// the unwritten padding cells between them are dropped from the extracted row.
+fn is_url_boundary_char(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, '\u{2500}'..='\u{259F}')
+}
+
 fn should_trim_trailing_url_cell(cells: &[TextCell], start: usize, end: usize) -> bool {
+    if is_url_boundary_char(cells[end].ch) {
+        return true;
+    }
     match cells[end].ch {
         '"' | '\'' | '`' | '.' | ',' | ';' | ':' | '!' | '?' => true,
         ')' => !trailing_url_closer_is_balanced(cells, start, end, '(', ')'),
@@ -2486,6 +2496,27 @@ mod tests {
             None
         );
         assert_eq!(selected_url("open file:///tmp/report", "file"), None);
+    }
+
+    #[test]
+    fn url_at_column_stops_at_box_drawing_border_cells() {
+        // A bordered panel row whose blank padding was dropped on extraction
+        // leaves the right border glyphs directly after the link.
+        assert_eq!(
+            selected_url(
+                "│ Draft PR is up: https://example.com/pull/721││ next",
+                "example"
+            ),
+            Some("https://example.com/pull/721")
+        );
+        assert_eq!(
+            selected_url("┃https://example.com/docs┃", "example"),
+            Some("https://example.com/docs")
+        );
+        assert_eq!(
+            selected_url("https://example.com/a▌", "example"),
+            Some("https://example.com/a")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Potential fix for #3860. Opened as a draft so a maintainer can take it or discard it; not asking for review.

## Problem

Cmd/ctrl-clicking a URL that shares a row with a pane app's panel border opens the URL with the border glyphs appended, e.g. `.../pull/721%E2%94%82%E2%94%82` (`%E2%94%82` is U+2502 `│`). Every URL inside a Codex CLI result panel or a Claude Code message block is affected.

## Root cause

`url_span_at_column` and `url_spans` in `src/app/actions.rs` extend a link from `http(s)://` until the next cell whose `ch.is_whitespace()`, and `should_trim_trailing_url_cell` only trims quotes, sentence punctuation, and unbalanced closers. Box-drawing glyphs pass both checks.

Two things make the border adjacent to the link in the extracted row text:

- The blank padding cells between the link and the right border are unwritten cells, and they do not survive `extract_selection`, so the row reads `...pull/721│`.
- Panel rows are written at the full pane width, which marks them as soft-wrapped, so the following row (starting with the panel's left border `│`) is joined onto the same logical line. That is where the second `│` comes from.

History:

- 6c4a9472 (#296, tmux-style double-click copy) introduced the whitespace-only terminator in `url_span_at_column`.
- 4f22e9a7 (#1099, "preserve wrapped pane links", refs #1098) added `url_spans` with the same terminator and started scanning across joined wrapped rows, which is what lets the next row's border reach the link.

## Change

- Add `is_url_boundary_char`: whitespace plus U+2500 to U+259F (Box Drawing and Block Elements), and use it to end both span loops.
- Trim those glyphs as trailing cells too, so a border cell directly after a link never survives.
- Add `url_at_column_stops_at_box_drawing_border_cells` covering the reported `││` case, heavy borders, and a block glyph.

Emitting spaces for unwritten cells in the extraction used for link detection would be a more general fix, but this keeps the change local to the scanner.

## Test plan

`cargo test url_at_column` covers the new test plus the existing `url_at_column_returns_safe_visible_url_only`. The vendored libghostty-vt zig build does not link on this macOS machine (missing libSystem symbols with the installed SDK), so I verified the scanner functions in an extracted crate instead: both tests pass with the change, and the new test fails without it. CI should confirm on the real build.
