### PR TITLE
agents panel: label by callsign/pane, not bare kind; hide stale records

### DIFF
--- a/src/client/shell/agent_sidebar.rs
+++ b/src/client/shell/agent_sidebar.rs
@@ -251,10 +251,13 @@ pub(super) fn agent_rows(
                 .iter()
                 .find(|workspace| workspace.workspace_id == agent.workspace_id)?;
             let tab = snapshot.tabs.iter().find(|tab| tab.tab_id == agent.tab_id);
+            // A pane-less agent record is stale (restored from an old session
+            // or a skewed snapshot): it cannot be focused, so hide the row
+            // instead of showing a dead entry.
             let pane = snapshot
                 .panes
                 .iter()
-                .find(|pane| pane.pane_id == agent.pane_id);
+                .find(|pane| pane.pane_id == agent.pane_id)?;
             let tab_count = snapshot
                 .tabs
                 .iter()
@@ -263,12 +266,18 @@ pub(super) fn agent_rows(
             let tab_label = tab
                 .filter(|tab| tab_count > 1 || tab.custom_label)
                 .map(|tab| tab.label.as_str());
+            // Identify agents by the most human-meaningful label available:
+            // the pane-provided display agent, then the callsign, then the
+            // pane title/manual label. The detected kind ("pi") is only a last
+            // resort so null-named agents never collapse into rows that all
+            // read "pi".
             let agent_label = agent
                 .display_agent
                 .as_deref()
                 .or(agent.name.as_deref())
-                .or(agent.agent.as_deref())
-                .or(agent.title.as_deref());
+                .or(agent.title.as_deref())
+                .or(pane.label.as_deref())
+                .or(agent.agent.as_deref());
             let labels = agent
                 .state_labels
                 .iter()
@@ -289,10 +298,7 @@ pub(super) fn agent_rows(
                     machine,
                     workspace: &workspace.label,
                     tab: tab_label,
-                    pane: agent
-                        .title
-                        .as_deref()
-                        .or_else(|| pane.and_then(|pane| pane.label.as_deref())),
+                    pane: agent.title.as_deref().or(pane.label.as_deref()),
                     agent_label,
                     terminal_title: agent.terminal_title.as_deref(),
                     terminal_title_stripped: agent.terminal_title_stripped.as_deref(),

--- a/src/client/shell/mobile.rs
+++ b/src/client/shell/mobile.rs
@@ -644,10 +644,20 @@ fn mobile_items(
                 .tabs
                 .iter()
                 .find(|tab| tab.tab_id == agent.tab_id);
+            // Same precedence as the desktop sidebar: human-meaningful labels
+            // first, the detected kind ("pi") only as a last resort.
+            let pane_label = endpoint
+                .snapshot
+                .panes
+                .iter()
+                .find(|pane| pane.pane_id == agent.pane_id)
+                .and_then(|pane| pane.label.as_deref());
             let agent_label = agent
                 .display_agent
                 .as_deref()
                 .or(agent.name.as_deref())
+                .or(agent.title.as_deref())
+                .or(pane_label)
                 .or(agent.agent.as_deref())
                 .unwrap_or("agent");
             let primary = workspace

--- a/src/client/shell/tests/agents_worktrees_notifications.rs
+++ b/src/client/shell/tests/agents_worktrees_notifications.rs
@@ -1294,3 +1294,81 @@ fn semantic_notifications_use_client_policy_and_stable_navigation_targets() {
     assert!(state.visible_notification.is_none());
     assert_eq!(state.pending_notifications.len(), 1);
 }
+
+#[test]
+fn agent_sidebar_labels_null_named_agents_by_pane_and_hides_stale_records() {
+    let mut projected = snapshot();
+    let mut labeled_pane = projected.panes[0].clone();
+    labeled_pane.pane_id = "pane_2".into();
+    labeled_pane.label = Some("shoplite".into());
+    labeled_pane.focused = false;
+    projected.panes.push(labeled_pane);
+    projected.agents = vec![
+        // Null-named agent: the row label must fall back to the pane label
+        // (callsign), never the bare detected kind "pi".
+        ClientShellAgent {
+            pane_id: "pane_2".into(),
+            workspace_id: "ws_1".into(),
+            tab_id: "tab_1".into(),
+            name: None,
+            display_agent: None,
+            agent: Some("pi".into()),
+            title: None,
+            terminal_title: None,
+            terminal_title_stripped: None,
+            agent_status: AgentStatus::Working,
+            state_change_seq: 1,
+            state_labels: Vec::new(),
+            tokens: Vec::new(),
+            focused: false,
+        },
+        // Stale record with no live pane in the snapshot: hidden instead of
+        // rendered as a dead row.
+        ClientShellAgent {
+            pane_id: "pane_ghost".into(),
+            workspace_id: "ws_1".into(),
+            tab_id: "tab_1".into(),
+            name: Some("ghost".into()),
+            display_agent: None,
+            agent: Some("pi".into()),
+            title: None,
+            terminal_title: None,
+            terminal_title_stripped: None,
+            agent_status: AgentStatus::Blocked,
+            state_change_seq: 2,
+            state_labels: Vec::new(),
+            tokens: Vec::new(),
+            focused: false,
+        },
+    ];
+    let mut state = ClientShellState::new(ClientShellConfig::from_config(&Config::default()));
+    state.set_snapshot(Box::new(projected));
+    state.set_pane_surface(surface());
+
+    let frame = state.compose(106, 30).expect("agent sidebar frame");
+    let text = frame
+        .cells
+        .chunks(frame.width as usize)
+        .map(|row| {
+            row.iter()
+                .map(|cell| cell.symbol.as_str())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("shoplite"), "frame: {text}");
+    assert!(!text.contains("ghost"), "frame: {text}");
+    assert!(
+        !text.lines().any(|line| line.trim() == "pi"),
+        "frame: {text}"
+    );
+    assert_eq!(
+        state
+            .hits
+            .agents
+            .iter()
+            .map(|(_, pane_id)| pane_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["pane_2"]
+    );
+}


### PR DESCRIPTION
## Problem

Auto-detected agent terminals that have no explicit name all render in the agents panel as duplicate rows labeled with only their detected kind (e.g. several rows that just say "pi"), making them indistinguishable. In addition, agent records whose pane is no longer present in the snapshot still render as rows that look like errors and cannot be focused.

## Fix

- Row labels now resolve in precedence order: display agent, then name, then title, then pane label; the detected kind is only a last resort, so unnamed sessions no longer collapse into duplicate bare-kind rows.
- Agent records whose pane is missing from the snapshot are hidden instead of rendering dead, un-focusable rows.
- The same label precedence is applied to the mobile clients list.

## Testing

- Added a regression test covering the null-name label fallback and the hiding of stale pane-less records.