### PR TITLE
feat: support Pi busy activity reports

### DIFF
--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -109,6 +109,8 @@ Herdr writes the bundled extension to:
 
 If `PI_CODING_AGENT_DIR` is set, Herdr writes to `$PI_CODING_AGENT_DIR/extensions/herdr-agent-state.ts` instead. Herdr creates the extensions directory when the Pi agent directory already exists. Uninstall removes only that extension file.
 
+Pi extensions can emit `herdr:busy` while background work continues. Herdr keeps the pane `working` until every active busy report is released; an active `herdr:blocked` report still takes precedence.
+
 ## OMP
 
 Install the OMP integration:

--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -311,6 +311,117 @@ test("Pi ignores RPC sessions even when UI APIs are available", async () => {
   expect(requests).toEqual([]);
 });
 
+test("Pi busy state holds working after the root agent settles", async () => {
+  const requests = await startRecordingServer("pi-settled-busy");
+  const { eventHandlers, handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  let idle = true;
+  const context = piContext(() => idle);
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+
+  idle = false;
+  handlers.get("agent_start")?.({}, context);
+  await waitFor(() => requestStates(requests).length === 2);
+  eventHandlers.get("herdr:busy")?.({ active: true }, context);
+
+  idle = true;
+  handlers.get("agent_settled")?.({}, context);
+  await Bun.sleep(25);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  eventHandlers.get("herdr:busy")?.({ active: false }, context);
+  await waitFor(() => requestStates(requests).length === 3);
+  expect(requestStates(requests)).toEqual(["idle", "working", "idle"]);
+});
+
+test("Pi releases overlapping busy owners only after the final inactive event", async () => {
+  const requests = await startRecordingServer("pi-overlapping-busy");
+  const { eventHandlers, handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  const context = piContext(() => true);
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+
+  eventHandlers.get("herdr:busy")?.({ active: true, label: "first" }, context);
+  await waitFor(() => requestStates(requests).length === 2);
+  eventHandlers.get("herdr:busy")?.({ active: true, label: "second" }, context);
+  eventHandlers.get("herdr:busy")?.({ active: false }, context);
+  await Bun.sleep(25);
+  expect(requestStates(requests)).toEqual(["idle", "working"]);
+
+  eventHandlers.get("herdr:busy")?.({ active: false }, context);
+  await waitFor(() => requestStates(requests).length === 3);
+  expect(requestStates(requests)).toEqual(["idle", "working", "idle"]);
+});
+
+test("Pi blocked state overrides busy and restores working when released", async () => {
+  const requests = await startRecordingServer("pi-blocked-busy");
+  const { eventHandlers, handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  const context = piContext(() => true);
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+
+  eventHandlers.get("herdr:busy")?.({ active: true }, context);
+  await waitFor(() => requestStates(requests).length === 2);
+  eventHandlers.get("herdr:blocked")?.({ active: true, label: "approval" }, context);
+  await waitFor(() => requestStates(requests).length === 3);
+  eventHandlers.get("herdr:blocked")?.({ active: false }, context);
+  await waitFor(() => requestStates(requests).length === 4);
+  expect(requestStates(requests)).toEqual(["idle", "working", "blocked", "working"]);
+
+  eventHandlers.get("herdr:busy")?.({ active: false }, context);
+  await waitFor(() => requestStates(requests).length === 5);
+  expect(requestStates(requests)).toEqual(["idle", "working", "blocked", "working", "idle"]);
+});
+
+test("Pi ignores unmatched busy inactive events", async () => {
+  const requests = await startRecordingServer("pi-unmatched-busy");
+  const { eventHandlers, handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  const context = piContext(() => true);
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+
+  eventHandlers.get("herdr:busy")?.({ active: false }, context);
+  await Bun.sleep(25);
+  expect(requestStates(requests)).toEqual(["idle"]);
+
+  eventHandlers.get("herdr:busy")?.({ active: true }, context);
+  await waitFor(() => requestStates(requests).length === 2);
+  eventHandlers.get("herdr:busy")?.({ active: false }, context);
+  await waitFor(() => requestStates(requests).length === 3);
+  expect(requestStates(requests)).toEqual(["idle", "working", "idle"]);
+});
+
+test("Pi replays busy events received before the root session starts", async () => {
+  const requests = await startRecordingServer("pi-pre-root-busy");
+  const { eventHandlers, handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
+  install(pi);
+
+  const context = piContext(() => true);
+  eventHandlers.get("herdr:busy")?.({ active: true }, context);
+  expect(requestStates(requests)).toEqual([]);
+
+  await handlers.get("session_start")?.({ reason: "startup" }, context);
+  await waitFor(() => requestStates(requests).length === 1);
+  expect(requestStates(requests)).toEqual(["working"]);
+
+  eventHandlers.get("herdr:busy")?.({ active: false }, context);
+  await waitFor(() => requestStates(requests).length === 2);
+  expect(requestStates(requests)).toEqual(["working", "idle"]);
+});
+
 test("Pi settlement preserves explicit blocked-state precedence", async () => {
   const requests = await startRecordingServer("pi-settled-blocked");
   const { eventHandlers, handlers, pi } = createExtensionHarness();
@@ -372,7 +483,7 @@ test("Pi reports the session replacement source", async () => {
     .toBe("new");
 });
 
-test("Pi waits for a replacement session report before publishing state", async () => {
+test("Pi buffers busy state until a replacement session report is acknowledged", async () => {
   const recordingSocketPath = join(tmpdir(), `herdr-pi-session-order-${process.pid}.sock`);
   socketPath = recordingSocketPath;
   await rm(recordingSocketPath, { force: true });
@@ -404,7 +515,7 @@ test("Pi waits for a replacement session report before publishing state", async 
   });
 
   configureIntegrationEnvironment(recordingSocketPath);
-  const { handlers, pi } = createExtensionHarness();
+  const { eventHandlers, handlers, pi } = createExtensionHarness();
   const { default: install } = await importFresh("./pi/herdr-agent-state.ts");
   install(pi);
 
@@ -415,7 +526,7 @@ test("Pi waits for a replacement session report before publishing state", async 
     {
       hasUI: true,
       mode: "tui",
-      isIdle: () => false,
+      isIdle: () => true,
       sessionManager: {
         getSessionFile: () => "/tmp/pi-new.jsonl",
         getSessionId: () => "pi-new",
@@ -428,9 +539,11 @@ test("Pi waits for a replacement session report before publishing state", async 
     await Bun.sleep(5);
   }
   expect(acknowledgeSessionReport).toBeDefined();
-  expect(
-    requests.some((request) => isRecord(request) && request.method === "pane.report_agent"),
-  ).toBe(false);
+  eventHandlers.get("herdr:busy")?.({ active: true });
+  await Bun.sleep(25);
+  expect(requests.map((request) => (isRecord(request) ? request.method : undefined))).toEqual([
+    "pane.report_agent_session",
+  ]);
 
   acknowledgeSessionReport?.();
   await sessionStartResult;
@@ -446,6 +559,7 @@ test("Pi waits for a replacement session report before publishing state", async 
     "pane.report_agent_session",
     "pane.report_agent",
   ]);
+  expect(requestState(requests[1])).toBe("working");
 });
 
 async function startDroppedFirstResponseServer(name: string) {

--- a/src/integration/assets/pi/herdr-agent-state.ts
+++ b/src/integration/assets/pi/herdr-agent-state.ts
@@ -183,16 +183,18 @@ export default function (pi) {
 
   let agentActive = false;
   let blockedCount = 0;
+  let busyCount = 0;
   let blockedMessage: string | undefined;
   let lastState: AgentState | undefined;
   let lastMessage: string | undefined;
   let rootSession = false;
+  let stateReportingReady = false;
 
   function desiredState() {
     if (blockedCount > 0) {
       return { state: "blocked" as const, message: blockedMessage };
     }
-    if (agentActive) {
+    if (agentActive || busyCount > 0) {
       return { state: "working" as const, message: undefined };
     }
     return { state: "idle" as const, message: undefined };
@@ -207,6 +209,18 @@ export default function (pi) {
     lastMessage = next.message;
     queueState(next.state, next.message);
   }
+
+  pi.events.on("herdr:busy", (data) => {
+    if (!data?.active) {
+      busyCount = Math.max(0, busyCount - 1);
+    } else {
+      busyCount += 1;
+    }
+
+    if (rootSession && stateReportingReady) {
+      publishState();
+    }
+  });
 
   pi.events.on("herdr:blocked", (data) => {
     if (!rootSession) {
@@ -232,11 +246,13 @@ export default function (pi) {
     if (ctx?.mode !== "tui") {
       return;
     }
+    stateReportingReady = false;
     rootSession = true;
     updateSessionRef(ctx);
     await reportSession(event?.reason);
     // A reload can replace this extension mid-run without emitting another agent_start.
     agentActive = ctx?.isIdle?.() === false;
+    stateReportingReady = true;
     publishState(true);
   });
 


### PR DESCRIPTION
## Summary

Adds native support for Pi extensions emitting `herdr:busy` events while background work continues. The primary use case is detached subagents and workflows: the parent Pi pane should remain `working` while they are still running, even after the root agent has settled.

- Keeps the parent pane `working` while subagents, workflows, or other background activity remain
- Counts overlapping busy reports and returns to `idle` only after the final release
- Preserves state precedence: `blocked` → `working` → `idle`
- Buffers busy events received before root-session initialization
- Delays busy-state publication until the session report is acknowledged, preserving request ordering
- Treats unmatched inactive events as harmless
- Documents the event behavior for Pi extension authors
- Keeps the Pi integration version at `9`, since the unreleased integration was already bumped on `master`

## Event contract

```ts
pi.events.emit("herdr:busy", { active: true, label: "background work" });
pi.events.emit("herdr:busy", { active: false });
```

## Validation

- `just ci`
  - 3,349 Rust tests passed
  - 4 skipped
  - Maintenance, architecture, and integration asset suites passed
- Pi integration asset tests: 22 passed
- Documentation contract tests: 7 passed
- Mutation checks confirmed coverage of busy-state selection and session-acknowledgement ordering
