### PR TITLE
fix: explain zig version requirement on build failure

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -100,7 +100,9 @@ fn main() {
         });
     assert!(
         status.success(),
-        "zig build for vendored libghostty-vt failed: {status}"
+        "zig build for vendored libghostty-vt failed: {status}. \
+         Building Herdr requires Zig 0.16.0; check `zig version` \
+         or set ZIG to the path of a Zig 0.16.0 binary, then retry"
     );
 
     let lib_dir = vendored_dir.join("zig-out/lib");


### PR DESCRIPTION
When `just build` fails with an incompatible Zig installation, the final error now states that Herdr requires Zig 0.16.0 and suggests checking `zig version` or setting `ZIG` to the correct binary. This only extends the existing failure message (one file, +3/-1); it also appears for other Zig build failures.

Validation: `just build` passes on Windows with Zig 0.16.0; `cargo fmt --check` and `git diff --check` pass. A directly compiled build script with a deliberately failing compiler invocation confirms the hint is printed. Full `just check` is unnecessary for this message-only change; no build logic changes.
