### PR TITLE
perf: compress kitty forwarding when png is supported

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -35,7 +35,8 @@ use std::io;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-const MIN_RENDER_INTERVAL: Duration = Duration::from_millis(16);
+// Local high-refresh graphics candidate: permit presentation above 60 Hz.
+const MIN_RENDER_INTERVAL: Duration = Duration::from_millis(8);
 const GIT_REMOTE_STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(1500);
 const GIT_REPO_DISCOVERY_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const AUTO_UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -486,6 +486,16 @@ async fn run_client_loop(
         query_host_cell_size();
     }
 
+    // Invisible 1x1 RGB PNG query; raw forwarding remains enabled until OK.
+    #[cfg(unix)]
+    let mut png_probe_pending = state.kitty_graphics_enabled
+        && state.attach_escape.is_none()
+        && state.shell.is_some()
+        && io::stdout().write_all(concat!(
+            "\x1b_Ga=q,t=d,f=100,q=0,i=4294967294;",
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC\x1b\\"
+        ).as_bytes()).and_then(|()| io::stdout().flush()).is_ok();
+
     // Spawn the resize poller thread.
     let resize_quit = should_quit.clone();
     let resize_tx = event_tx.clone();
@@ -720,6 +730,15 @@ async fn run_client_loop(
             ClientLoopEvent::EndpointCatalog(reload) => pending_catalog = Some(reload),
             #[cfg(unix)]
             ClientLoopEvent::StdinInput(data) => {
+                if let Some(reply) = data.strip_prefix(b"\x1b_Gi=4294967294;") {
+                    if png_probe_pending {
+                        if let Some(shell) = state.shell.as_mut() {
+                            shell.set_graphics_png_supported(reply == b"OK\x1b\\");
+                        }
+                        png_probe_pending = false;
+                    }
+                    continue;
+                }
                 let image_bridge_active = endpoint_accepts_local_images(
                     is_remote_client,
                     write_stream.active_id(),

--- a/src/client/shell/graphics.rs
+++ b/src/client/shell/graphics.rs
@@ -2,6 +2,11 @@ use super::*;
 
 impl ClientShellState {
     #[cfg(unix)]
+    pub(crate) fn set_graphics_png_supported(&mut self, supported: bool) {
+        self.graphics.set_png_supported(supported);
+    }
+
+    #[cfg(unix)]
     pub(crate) fn graphics_scope(&self) -> &str {
         self.graphics.scope()
     }

--- a/src/kitty_graphics.rs
+++ b/src/kitty_graphics.rs
@@ -105,6 +105,7 @@ struct ClippedPlacement {
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct HostGraphicsCache {
+    png_supported: bool,
     images: HashMap<u32, ImageSignature>,
     placements: HashMap<(u32, u32), PlacementSignature>,
     /// Host image currently backing each (pane, source image id) pair.
@@ -210,9 +211,9 @@ fn encode_placement_update(
                 &mut bytes,
                 placement,
                 clipped,
-                format_code,
                 host_id,
                 placement_id,
+                cache.png_supported,
             ) {
                 return None;
             }
@@ -223,7 +224,7 @@ fn encode_placement_update(
                 cache.placements.retain(|(id, _), _| *id != host_id);
                 cache.replayed_placements.retain(|(id, _)| *id != host_id);
             }
-            if !encode_upload_image(&mut bytes, placement, format_code, host_id) {
+            if !encode_upload_image(&mut bytes, placement, host_id, cache.png_supported) {
                 return None;
             }
         }
@@ -768,18 +769,18 @@ fn encode_delete_placement(out: &mut Vec<u8>, host_id: u32, host_placement_id: u
 fn encode_upload_image(
     out: &mut Vec<u8>,
     placement: &HostPlacement,
-    format_code: u32,
     host_id: u32,
+    png_supported: bool,
 ) -> bool {
     if placement.placement.data.is_empty() {
         return false;
     }
 
     let control = format!(
-        "a=t,t=d,f={format_code},s={},v={},i={host_id},q=2",
+        "a=t,t=d,s={},v={},i={host_id},q=2",
         placement.placement.image_width, placement.placement.image_height,
     );
-    encode_kitty_data(out, &control, &placement.placement.data);
+    encode_kitty_data(out, &control, &placement.placement, png_supported);
     true
 }
 
@@ -787,16 +788,16 @@ fn encode_transmit_and_display(
     out: &mut Vec<u8>,
     placement: &HostPlacement,
     clipped: ClippedPlacement,
-    format_code: u32,
     host_id: u32,
     host_placement_id: u32,
+    png_supported: bool,
 ) -> bool {
     if placement.placement.data.is_empty() {
         return false;
     }
     let _ = write!(out, "\x1b[{};{}H", clipped.y + 1, clipped.x + 1);
     let mut control = format!(
-        "a=T,t=d,f={format_code},s={},v={},i={host_id},p={host_placement_id},c={},r={},z={},C=1,q=2",
+        "a=T,t=d,s={},v={},i={host_id},p={host_placement_id},c={},r={},z={},C=1,q=2",
         placement.placement.image_width,
         placement.placement.image_height,
         clipped.cols,
@@ -804,7 +805,7 @@ fn encode_transmit_and_display(
         placement.placement.z,
     );
     append_placement_controls(&mut control, clipped);
-    encode_kitty_data(out, &control, &placement.placement.data);
+    encode_kitty_data(out, &control, &placement.placement, png_supported);
     true
 }
 
@@ -1055,7 +1056,38 @@ fn kitty_format_code(format: KittyImageFormat) -> u32 {
     }
 }
 
-fn encode_kitty_data(out: &mut Vec<u8>, control: &str, data: &[u8]) {
+fn encode_forward_png(image: &KittyImagePlacement) -> Option<Vec<u8>> {
+    let color = match image.format {
+        KittyImageFormat::Rgb => png::ColorType::Rgb,
+        KittyImageFormat::Rgba => png::ColorType::Rgba,
+        _ => return None,
+    };
+    let mut bytes = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut bytes, image.image_width, image.image_height);
+        encoder.set_color(color);
+        encoder.set_depth(png::BitDepth::Eight);
+        encoder.set_compression(png::Compression::Fast);
+        encoder.set_filter(png::FilterType::Sub);
+        let mut writer = encoder.write_header().ok()?;
+        writer.write_image_data(&image.data).ok()?;
+        writer.finish().ok()?;
+    }
+    Some(bytes)
+}
+
+fn encode_kitty_data(
+    out: &mut Vec<u8>,
+    control: &str,
+    image: &KittyImagePlacement,
+    png_supported: bool,
+) {
+    let format_code = kitty_format_code(image.format);
+    let png = png_supported.then(|| encode_forward_png(image)).flatten();
+    let (format_code, data) = png
+        .as_deref()
+        .map_or((format_code, image.data.as_slice()), |bytes| (100, bytes));
+    let control = format!("{control},f={format_code}");
     let mut chunks = data.chunks(KITTY_CHUNK_BYTES).peekable();
     let Some(first) = chunks.next() else {
         return;
@@ -1486,15 +1518,15 @@ mod tests {
         placement.placement.image_height = 1;
         placement.placement.data = vec![1_u8; crate::api::schema::PANE_GRAPHICS_STREAM_MAX_BYTES];
         placement.placement.data_len = placement.placement.data.len();
-        let (clipped, format_code) = clipped_placement(&placement).expect("visible placement");
+        let (clipped, _) = clipped_placement(&placement).expect("visible placement");
         let host_id = host_image_id(placement.pane_id, &placement.placement);
         let mut encoded = Vec::new();
 
         assert!(encode_upload_image(
             &mut encoded,
             &placement,
-            format_code,
             host_id,
+            false,
         ));
         encode_display_placement(&mut encoded, clipped, host_id, 1, 0);
 

--- a/src/kitty_graphics/surface.rs
+++ b/src/kitty_graphics/surface.rs
@@ -50,6 +50,11 @@ pub(crate) struct ClientState {
 }
 
 impl ClientState {
+    #[cfg(unix)]
+    pub(crate) fn set_png_supported(&mut self, supported: bool) {
+        self.host.png_supported = supported;
+    }
+
     pub(crate) fn scope(&self) -> &str {
         &self.scope
     }


### PR DESCRIPTION
Herdr decodes pane images into raw pixels before forwarding them to the host terminal. For continuously updated graphics, the resulting output traffic can delay visible responses to input.

This change queries the host terminal's Kitty PNG support during Unix client startup. A successful response enables lossless PNG forwarding for RGB/RGBA images through the existing encoder dependency. Rejection, silence, or an encoding error preserves raw forwarding. The asynchronous query uses the existing input framing and does not block startup.

The minimum render interval also changes from 16 ms to 8 ms to permit presentation above 60 FPS. This affects all actively redrawing panes and may increase CPU usage.

Validation:

- `just ci` passed: formatting, Clippy, 3,354 Rust tests, 107 Python tests, and 29 integration tests. `XDG_RUNTIME_DIR` was unset because it pointed to a nonexistent directory in the local environment.
- Real client/server tests covered successful, rejected, unanswered, and delayed PNG replies, including mouse/reset interaction.
- Four rendering benchmarks passed, including 1- and 15-pane configurations.
- Continuous 800×600 image updates at a 120 FPS target delivered approximately 77 complete images per second to the outer terminal stream. This measures data delivery, not monitor refresh.
