### PR TITLE
fix: recognize claude unicode spinner during active turns

### DIFF
--- a/distribution/agent-detection/claude.toml
+++ b/distribution/agent-detection/claude.toml
@@ -1,7 +1,7 @@
 id = "claude"
-version = "2026.09.04.1"
+version = "2026.09.11.1"
 min_engine_version = 2
-updated_at = "2026-09-04T00:00:00Z"
+updated_at = "2026-09-11T00:00:00Z"
 aliases = ["claude-code"]
 
 [[rules]]
@@ -21,7 +21,7 @@ region = "bottom_non_empty_lines(12)"
 visible_working = true
 any = [
   { line_regex = ['^\s*[⏸⏵].*esc to interrupt(?:\s|·|$)'] },
-  { line_regex = ['^\s*[\x{002A}\x{00B7}\x{2722}\x{2736}\x{273B}\x{273D}]\s+\S.*…(?:\s+\(\d+[smh](?:\s|·)|\s*$)'] },
+  { line_regex = ['^\s*[\x{002A}\x{00B7}\x{2722}\x{2733}\x{2736}\x{273B}\x{273D}]\s+\S.*…(?:\s+\(\d+[smh](?:\s|·)|\s*$)'] },
 ]
 
 [[rules]]

--- a/src/detect/manifests/claude.toml
+++ b/src/detect/manifests/claude.toml
@@ -1,7 +1,7 @@
 id = "claude"
-version = "2026.09.04.1"
+version = "2026.09.11.1"
 min_engine_version = 2
-updated_at = "2026-09-04T00:00:00Z"
+updated_at = "2026-09-11T00:00:00Z"
 aliases = ["claude-code"]
 
 [[rules]]
@@ -21,7 +21,7 @@ region = "bottom_non_empty_lines(12)"
 visible_working = true
 any = [
   { line_regex = ['^\s*[⏸⏵].*esc to interrupt(?:\s|·|$)'] },
-  { line_regex = ['^\s*[\x{002A}\x{00B7}\x{2722}\x{2736}\x{273B}\x{273D}]\s+\S.*…(?:\s+\(\d+[smh](?:\s|·)|\s*$)'] },
+  { line_regex = ['^\s*[\x{002A}\x{00B7}\x{2722}\x{2733}\x{2736}\x{273B}\x{273D}]\s+\S.*…(?:\s+\(\d+[smh](?:\s|·)|\s*$)'] },
 ]
 
 [[rules]]


### PR DESCRIPTION
## Summary

Recognize `✳` (U+2733) in Claude's existing active-turn screen rule. With a custom status line, Claude hides `esc to interrupt`; without a usable OSC title, the missed spinner frame lets the visible prompt box incorrectly report idle.

Updates bundled and published manifests to `2026.09.11.1`. OSC rules, priorities, background rules, and wait behavior are unchanged.

refs #3949

## Verification

Live test on Herdr 0.9.0 / Claude Code 2.1.268, `--model sonnet --effort low` (Sonnet 5), custom three-line status line, and `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1`. Explicitly used `TERM=xterm-ghostty` to select the Unicode spinner; this does not establish why the reporter's environment selects it.

Same foreground `sleep 25` prompt before and after a manifest hot reload:
- Before: `--wait` returned after **803ms**. All 19 sampled `✳` frames explained idle via `live_prompt_box`; status repeatedly flipped mid-turn.
- After: `--wait` returned after **28068ms**, once finished. All 18 sampled `✳` frames explained working via `live_turn_working`; no mid-turn idle flips.
- Confirmed completed turn returned to idle. Temporary override and disposable session removed.
- `just check` passed, including Windows cross-target lint, 3,359 Rust tests, and maintenance/docs/integration checks.
- Published/bundled manifest validation passed.

The Windows cross-check setup is already on master and is not part of this PR.
