### PR TITLE
fix: preserve local direct kitty graphics transport

### DIFF
--- a/src/client/shell/state.rs
+++ b/src/client/shell/state.rs
@@ -1304,11 +1304,11 @@ impl ClientShellState {
         snapshot
             .commands
             .retain(|command| command.action != crate::protocol::ClientShellCommandAction::Unknown);
-        let graphics_scope = format!(
-            "{}:{}",
-            self.active_endpoint_id.storage_key(),
-            snapshot.boot_id
-        );
+        let graphics_scope = match &self.active_endpoint_id {
+            // Local direct uploads use image IDs authored by the server from its boot ID.
+            ClientEndpointId::Local => snapshot.boot_id.clone(),
+            endpoint_id => format!("{}:{}", endpoint_id.storage_key(), snapshot.boot_id),
+        };
         let endpoint_boot_changed =
             self.snapshot.is_some() && self.graphics.scope() != graphics_scope;
         if !endpoint_boot_changed

--- a/src/client/shell/tests/endpoints.rs
+++ b/src/client/shell/tests/endpoints.rs
@@ -975,6 +975,52 @@ fn graphics_scope_qualifies_colliding_boot_ids_by_endpoint() {
     assert!(remote_scope.starts_with("ssh:0123456789abcdef0123456789abcdef:"));
 }
 
+#[cfg(unix)]
+#[test]
+fn local_direct_graphics_accept_server_ids_across_endpoint_switches_and_restarts() {
+    use crate::kitty_graphics::surface::{direct_upload_control, host_image_id};
+    use crate::protocol::{SurfaceGraphicsAssetKey, SurfaceGraphicsFormat, SurfaceGraphicsSource};
+
+    let (mut state, remote_id) = state_with_remote();
+    let asset = SurfaceGraphicsAssetKey {
+        source: SurfaceGraphicsSource::PaneLayer {
+            pane_id: "pane_1".into(),
+            layer_id: "primary".into(),
+        },
+        image_width: 2,
+        image_height: 2,
+        format: SurfaceGraphicsFormat::Rgba,
+        data_len: 16,
+        data_fingerprint: 17,
+    };
+    let (server_image_id, _) = direct_upload_control("boot-1", &asset);
+    assert_eq!(
+        host_image_id(state.graphics_scope(), &asset),
+        server_image_id
+    );
+    assert!(state.trust_direct_graphics_asset(&asset, server_image_id));
+    assert!(!state.trust_direct_graphics_asset(&asset, server_image_id + 1));
+
+    let mut remote = snapshot();
+    remote.boot_id = "boot-1".into();
+    state.set_endpoint_snapshot(&remote_id, Box::new(remote));
+    assert!(state.activate_endpoint_projection(&remote_id));
+    assert!(!state.trust_direct_graphics_asset(&asset, server_image_id));
+    assert!(state.activate_endpoint_projection(&ClientEndpointId::Local));
+    assert!(state.trust_direct_graphics_asset(&asset, server_image_id));
+
+    let mut restarted = snapshot();
+    restarted.boot_id = "replacement-boot".into();
+    state.set_snapshot(Box::new(restarted));
+    let (restarted_image_id, _) = direct_upload_control("replacement-boot", &asset);
+    assert!(!state.trust_direct_graphics_asset(&asset, server_image_id));
+    assert_eq!(
+        host_image_id(state.graphics_scope(), &asset),
+        restarted_image_id
+    );
+    assert!(state.trust_direct_graphics_asset(&asset, restarted_image_id));
+}
+
 #[test]
 fn navigator_uses_machine_parents_only_for_federated_clients() {
     let (mut state, _) = state_with_remote();


### PR DESCRIPTION
## Summary

Local browser panes lose the fast file-frame transport after their first valid image in Herdr 0.9.0. Restore the server boot ID as the Local client's graphics scope, while keeping remote endpoint scopes separate.

#3670 qualified client graphics scopes with the endpoint key, but server-authored direct image IDs still use only the boot ID. The client therefore rejects valid local frames before sending them to Ghostty. The server disables direct transport for that connection and acknowledges inline fallback instead.

This restores ID agreement without weakening validation, changing the protocol, or changing remote transport behavior.

Refs #3785. Related lag reports: https://github.com/zenbu-labs/terminal-browser/issues/89#issuecomment-5612710522. This does not claim to fix that issue's older 0.8.2 configuration/blank-screen reports, remote rendering, or Terminal Browser's separate FPS throttling issue.

## Validation

- TDD: regression fails before the fix and passes afterward. Covers server-generated image IDs, incorrect-ID rejection, colliding remote boot IDs, switching back to Local, and server restarts.
- `just check` passes, including 3,360 Rust tests, Linux and Windows cross-target lint, maintenance, integration and docs checks.
- Stock 0.9.0, standalone Ghostty 1.3.1 on Linux: a single 2x2 RGBA file gets an ACK and immediately removes `direct-kitty` from graphics info.
- Patched release: 60 frames across 2x2, 640x480, 1096x1344 and 2208x2040 retain direct transport after every ACK. Largest frame is 18 MB, above the ordinary 16 MiB fallback limit.
- Official Terminal Browser 0.8.1, finite 20 Hz animation in separate Ghostty windows: stock Ghostty CPU around 91–110%, patched around 2–4%; Herdr client around 19–26% vs 1–2%. These are short local smoke samples, not a controlled frame-pacing benchmark.
- Ordinary Kitty inline RGBA upload still receives `OK`. Existing graphics composition tests pass.
- Maintainer manually confirmed smooth browsing with the patched release build; its direct transport remains advertised after use.

Live validation was Linux-only; macOS confirmation remains useful. All agent-created test windows, sessions and browser processes were cleaned up.
