### PR TITLE
fix(config): keep utf8 bom from breaking config reads and writes

### DIFF
--- a/src/config/io.rs
+++ b/src/config/io.rs
@@ -98,23 +98,23 @@ fn platform_state_dir() -> PathBuf {
 /// TOML tolerates a single BOM at the very start of the document, but a BOM at
 /// the start of a later line makes the parser reject the whole file. A
 /// line-oriented edit can displace a leading BOM into the middle of the file,
-/// so drop such line-start BOMs when the document no longer parses. When the
-/// document is valid, a line-start BOM can only be string data inside a
-/// multiline value, which is preserved.
+/// so drop line-start BOMs that the TOML parser actually rejects. A U+FEFF that
+/// is valid string data is kept, because its parse error would not point at it.
 fn normalize_utf8_bom(content: &str) -> String {
     let content = content.strip_prefix('\u{feff}').unwrap_or(content);
-    if !content.contains("\n\u{feff}") || content.parse::<toml::Value>().is_ok() {
+    if !content.contains('\u{feff}') {
         return content.to_owned();
     }
 
-    let mut normalized = String::with_capacity(content.len());
-    let mut at_line_start = true;
-    for character in content.chars() {
-        if character == '\u{feff}' && at_line_start {
-            continue;
+    let mut normalized = content.to_owned();
+    while let Err(error) = normalized.parse::<toml::Value>() {
+        let Some(span) = error.span() else {
+            break;
+        };
+        if normalized.get(span.clone()) != Some("\u{feff}") {
+            break;
         }
-        at_line_start = character == '\n';
-        normalized.push(character);
+        normalized.replace_range(span, "");
     }
     normalized
 }
@@ -1166,6 +1166,13 @@ mouse_capture = false
     fn normalize_utf8_bom_preserves_boms_in_multiline_literal_strings() {
         let content = "[theme]\nname = '''\nfirst\n\u{feff}second\n'''\n";
         assert!(content.parse::<toml::Value>().is_ok());
+        assert_eq!(normalize_utf8_bom(content), content);
+    }
+
+    #[test]
+    fn normalize_utf8_bom_preserves_string_boms_despite_other_errors() {
+        let content = "[theme]\nname = \"\"\"\nfirst\n\u{feff}second\n\"\"\"\nbroken = \n";
+        assert!(content.parse::<toml::Value>().is_err());
         assert_eq!(normalize_utf8_bom(content), content);
     }
 

--- a/src/config/io.rs
+++ b/src/config/io.rs
@@ -93,15 +93,17 @@ fn platform_state_dir() -> PathBuf {
     }
 }
 
-/// Remove UTF-8 byte-order marks from config text.
+/// Normalize UTF-8 byte-order marks in config text.
 ///
-/// TOML tolerates a BOM only at the very start of the document. Windows editors
-/// commonly add one, and a line-oriented config edit can otherwise move it to
-/// the start of a later line, where the TOML parser rejects the whole file.
-/// Dropping BOMs at the start of the file and of each line keeps both loading
-/// and editing working, and repairs files that were already corrupted.
-fn strip_utf8_bom(content: &str) -> String {
-    if !content.contains('\u{feff}') {
+/// TOML tolerates a single BOM at the very start of the document, but a BOM at
+/// the start of a later line makes the parser reject the whole file. A
+/// line-oriented edit can displace a leading BOM into the middle of the file,
+/// so drop such line-start BOMs when the document no longer parses. When the
+/// document is valid, a line-start BOM can only be string data inside a
+/// multiline value, which is preserved.
+fn normalize_utf8_bom(content: &str) -> String {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    if !content.contains("\n\u{feff}") || content.parse::<toml::Value>().is_ok() {
         return content.to_owned();
     }
 
@@ -119,7 +121,7 @@ fn strip_utf8_bom(content: &str) -> String {
 
 pub(super) fn read_optional_config(path: &Path) -> std::io::Result<Option<String>> {
     match std::fs::read_to_string(path) {
-        Ok(content) => Ok(Some(strip_utf8_bom(&content))),
+        Ok(content) => Ok(Some(normalize_utf8_bom(&content))),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(err) => Err(err),
     }
@@ -1134,19 +1136,37 @@ mouse_capture = false
     }
 
     #[test]
-    fn strip_utf8_bom_removes_leading_and_line_start_boms() {
-        let content =
-            "\u{feff}onboarding = false\n\u{feff}[terminal]\ndefault_shell = \"pwsh.exe\"\n";
+    fn normalize_utf8_bom_removes_a_leading_bom() {
+        let content = "\u{feff}onboarding = false\n[terminal]\n";
         assert_eq!(
-            strip_utf8_bom(content),
-            "onboarding = false\n[terminal]\ndefault_shell = \"pwsh.exe\"\n"
+            normalize_utf8_bom(content),
+            "onboarding = false\n[terminal]\n"
         );
     }
 
     #[test]
-    fn strip_utf8_bom_preserves_boms_inside_values() {
-        let content = "default_shell = \"\u{feff}pwsh.exe\"\n";
-        assert_eq!(strip_utf8_bom(content), content);
+    fn normalize_utf8_bom_recovers_from_a_displaced_mid_file_bom() {
+        let content = "onboarding = false\n\u{feff}[terminal]\ndefault_shell = \"pwsh.exe\"\n";
+        let normalized = normalize_utf8_bom(content);
+        assert_eq!(
+            normalized,
+            "onboarding = false\n[terminal]\ndefault_shell = \"pwsh.exe\"\n"
+        );
+        assert!(normalized.parse::<toml::Value>().is_ok());
+    }
+
+    #[test]
+    fn normalize_utf8_bom_preserves_boms_in_multiline_basic_strings() {
+        let content = "[theme]\nname = \"\"\"\nfirst\n\u{feff}second\n\"\"\"\n";
+        assert!(content.parse::<toml::Value>().is_ok());
+        assert_eq!(normalize_utf8_bom(content), content);
+    }
+
+    #[test]
+    fn normalize_utf8_bom_preserves_boms_in_multiline_literal_strings() {
+        let content = "[theme]\nname = '''\nfirst\n\u{feff}second\n'''\n";
+        assert!(content.parse::<toml::Value>().is_ok());
+        assert_eq!(normalize_utf8_bom(content), content);
     }
 
     #[test]

--- a/src/config/io.rs
+++ b/src/config/io.rs
@@ -93,9 +93,33 @@ fn platform_state_dir() -> PathBuf {
     }
 }
 
-fn read_optional_config(path: &Path) -> std::io::Result<Option<String>> {
+/// Remove UTF-8 byte-order marks from config text.
+///
+/// TOML tolerates a BOM only at the very start of the document. Windows editors
+/// commonly add one, and a line-oriented config edit can otherwise move it to
+/// the start of a later line, where the TOML parser rejects the whole file.
+/// Dropping BOMs at the start of the file and of each line keeps both loading
+/// and editing working, and repairs files that were already corrupted.
+fn strip_utf8_bom(content: &str) -> String {
+    if !content.contains('\u{feff}') {
+        return content.to_owned();
+    }
+
+    let mut normalized = String::with_capacity(content.len());
+    let mut at_line_start = true;
+    for character in content.chars() {
+        if character == '\u{feff}' && at_line_start {
+            continue;
+        }
+        at_line_start = character == '\n';
+        normalized.push(character);
+    }
+    normalized
+}
+
+pub(super) fn read_optional_config(path: &Path) -> std::io::Result<Option<String>> {
     match std::fs::read_to_string(path) {
-        Ok(content) => Ok(Some(content)),
+        Ok(content) => Ok(Some(strip_utf8_bom(&content))),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(err) => Err(err),
     }
@@ -1107,5 +1131,44 @@ mouse_capture = false
         let (updated, removed) = remove_keybinding_config_sections(content);
         assert!(!removed);
         assert_eq!(updated, content);
+    }
+
+    #[test]
+    fn strip_utf8_bom_removes_leading_and_line_start_boms() {
+        let content =
+            "\u{feff}onboarding = false\n\u{feff}[terminal]\ndefault_shell = \"pwsh.exe\"\n";
+        assert_eq!(
+            strip_utf8_bom(content),
+            "onboarding = false\n[terminal]\ndefault_shell = \"pwsh.exe\"\n"
+        );
+    }
+
+    #[test]
+    fn strip_utf8_bom_preserves_boms_inside_values() {
+        let content = "default_shell = \"\u{feff}pwsh.exe\"\n";
+        assert_eq!(strip_utf8_bom(content), content);
+    }
+
+    #[test]
+    fn config_load_recovers_from_a_mid_file_bom() {
+        let _guard = crate::config::test_config_env_lock().lock().unwrap();
+        let path = std::env::temp_dir().join(format!(
+            "herdr-config-mid-file-bom-{}.toml",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            b"onboarding = false\n\xEF\xBB\xBF[terminal]\ndefault_shell = \"pwsh.exe\"\n",
+        )
+        .unwrap();
+        std::env::set_var(CONFIG_PATH_ENV_VAR, &path);
+
+        let loaded = Config::load();
+
+        std::env::remove_var(CONFIG_PATH_ENV_VAR);
+        let _ = std::fs::remove_file(path);
+
+        assert!(loaded.diagnostics.is_empty(), "{:?}", loaded.diagnostics);
+        assert_eq!(loaded.config.terminal.default_shell, "pwsh.exe");
     }
 }

--- a/src/config/write.rs
+++ b/src/config/write.rs
@@ -55,9 +55,9 @@ pub(crate) fn update_file_at(
         std::fs::create_dir_all(parent)
             .map_err(|error| format!("failed to create config directory: {error}"))?;
     }
-    let content = match std::fs::read_to_string(path) {
-        Ok(content) => content,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+    let content = match super::io::read_optional_config(path) {
+        Ok(Some(content)) => content,
+        Ok(None) => String::new(),
         Err(error) => {
             return Err(format!(
                 "failed to read config before saving {description}: {error}"
@@ -72,4 +72,38 @@ pub(crate) fn write_edit(edit: ConfigEdit<'_>) -> Result<(), String> {
     update_file_at(&super::config_path(), edit.description(), |content| {
         edit.apply(content)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_file_at_does_not_move_a_leading_bom_into_the_file() {
+        let dir = std::env::temp_dir().join(format!("herdr-config-bom-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        std::fs::write(
+            &path,
+            b"\xEF\xBB\xBF[terminal]\ndefault_shell = \"pwsh.exe\"\n",
+        )
+        .unwrap();
+
+        update_file_at(&path, "onboarding setting", |content| {
+            crate::config::upsert_top_level_bool(content, "onboarding", false)
+        })
+        .unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert!(
+            !written.contains('\u{feff}'),
+            "unexpected BOM in {written:?}"
+        );
+        assert!(
+            toml::from_str::<toml::Value>(&written).is_ok(),
+            "written config is not valid TOML: {written:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3678.

Windows editors can write `config.toml` with a leading UTF-8 BOM. TOML tolerates a BOM only at the very start of the document, so herdr could read such a file at first. But completing onboarding calls `upsert_top_level_bool`, which prepends `onboarding = false` ahead of the raw file content, moving the BOM to the start of line 2. From then on every parse failed with `config parse error ... at line 2` and the server silently used defaults forever.

## Root cause

`update_file_at` read the config with `std::fs::read_to_string` without normalizing the BOM. The line-oriented upsert then treated the BOM as part of the first line and prepended text before it, relocating the BOM into the middle of the file where TOML rejects it.

## Fix

- Add `normalize_utf8_bom` in `src/config/io.rs`. It drops a leading BOM and then removes line-start BOMs that the TOML parser actually rejects, using the parse error's span. BOMs that are valid string data are preserved even when the document has an unrelated parse error.
- Apply it in `read_optional_config` so `Config::load` and `load_live_config` recover from an already-displaced BOM.
- Route `update_file_at` through `read_optional_config` so edits always write BOM-free, parseable content.

## Validation

- `just check` passes (2907 tests, 4 skipped).
- Added coverage for: leading-BOM removal, displaced mid-file BOM recovery on load and edit, multiline basic/literal string BOM preservation, and preservation despite an unrelated parse error.