### PR TITLE
fix: lint all targets on windows

### DIFF
--- a/scripts/windows_check.ps1
+++ b/scripts/windows_check.ps1
@@ -32,8 +32,7 @@ function Invoke-CargoWithZigCacheRecovery {
 Invoke-Checked cargo @("fmt", "--check")
 Invoke-CargoWithZigCacheRecovery @(
     "clippy",
-    "--bin",
-    "herdr",
+    "--all-targets",
     "--locked",
     "--",
     "-D",

--- a/src/api/server/pane_graphics_stream.rs
+++ b/src/api/server/pane_graphics_stream.rs
@@ -662,6 +662,7 @@ mod tests {
         line
     }
 
+    #[cfg(unix)]
     fn assert_server_stream_owner(owner: &str) {
         assert!(owner.starts_with("pane.graphics.stream:"));
     }

--- a/src/client/terminal_geometry.rs
+++ b/src/client/terminal_geometry.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-#[cfg(any(unix, test))]
+#[cfg(unix)]
 use tracing::debug;
 
 use super::ClientLoopEvent;
@@ -177,7 +177,7 @@ pub(super) fn resize_poll_loop(
     }
 }
 
-#[cfg(any(not(windows), test))]
+#[cfg(not(windows))]
 pub(super) fn query_host_terminal_appearance() {
     let _ = write_host_terminal_appearance_query(io::stdout());
 }
@@ -223,7 +223,7 @@ pub(super) fn write_host_cell_size_query(mut writer: impl io::Write) -> io::Resu
     writer.flush()
 }
 
-#[cfg(any(unix, test))]
+#[cfg(unix)]
 pub(super) fn store_reported_cell_size(
     reported_cell_size: &AtomicU64,
     width_px: u32,

--- a/src/client/tests/mod.rs
+++ b/src/client/tests/mod.rs
@@ -218,10 +218,12 @@ fn clipboard_image_paste_bridge_triggers_on_configured_key_and_empty_paste() {
     ));
 }
 
+#[cfg(unix)]
 struct TempImageFile {
     path: std::path::PathBuf,
 }
 
+#[cfg(unix)]
 impl TempImageFile {
     fn new(extension: &str, bytes: &[u8]) -> Self {
         Self::with_name_fragment("test", extension, bytes)
@@ -241,6 +243,7 @@ impl TempImageFile {
     }
 }
 
+#[cfg(unix)]
 impl Drop for TempImageFile {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.path);

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -40,7 +40,7 @@ use self::agent_detection::{
     DetectionScreenReadInput, PendingIdleConfirmation, ScreenDetectionPublishInput,
     AGENT_PENDING_IDLE_RECHECK, AGENT_STARTUP_GRACE_WINDOW,
 };
-#[cfg(any(unix, test))]
+#[cfg(unix)]
 pub use self::terminal::InputState;
 use self::terminal::{GhosttyPaneTerminal, PaneTerminal};
 pub(crate) use self::terminal::{
@@ -1075,7 +1075,7 @@ impl TerminalCompressionWake {
 /// Drives libghostty-vt's caller-owned compression after terminal activity settles.
 struct TerminalCompressionTask {
     wake: TerminalCompressionWake,
-    #[cfg(test)]
+    #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
     completed_passes: Arc<AtomicU64>,
     handle: tokio::task::AbortHandle,
 }
@@ -1094,9 +1094,9 @@ impl TerminalCompressionTask {
         };
         let task_notify = wake.notify.clone();
         let task_generation = wake.generation.clone();
-        #[cfg(test)]
+        #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
         let completed_passes = Arc::new(AtomicU64::new(0));
-        #[cfg(test)]
+        #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
         let task_completed_passes = completed_passes.clone();
         let handle = tokio::spawn(async move {
             run_terminal_compression_task(
@@ -1104,7 +1104,7 @@ impl TerminalCompressionTask {
                 terminal,
                 task_notify,
                 task_generation,
-                #[cfg(test)]
+                #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
                 task_completed_passes,
             )
             .await;
@@ -1112,7 +1112,7 @@ impl TerminalCompressionTask {
         .abort_handle();
         Self {
             wake,
-            #[cfg(test)]
+            #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
             completed_passes,
             handle,
         }
@@ -1130,7 +1130,7 @@ impl TerminalCompressionTask {
         self.handle.abort();
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
     fn completed_passes(&self) -> u64 {
         self.completed_passes.load(Ordering::Acquire)
     }
@@ -1141,7 +1141,9 @@ async fn run_terminal_compression_task(
     terminal: Arc<PaneTerminal>,
     notify: Arc<Notify>,
     generation: Arc<AtomicU64>,
-    #[cfg(test)] completed_passes: Arc<AtomicU64>,
+    #[cfg(all(test, any(target_os = "linux", target_os = "macos")))] completed_passes: Arc<
+        AtomicU64,
+    >,
 ) {
     let mut observed_generation = generation.load(Ordering::Acquire);
     let mut activity = loop {
@@ -1224,7 +1226,7 @@ async fn run_terminal_compression_task(
                 TerminalCompressionStep::Compressed(
                     crate::ghostty::TerminalCompressionResult::Complete,
                 ) => {
-                    #[cfg(test)]
+                    #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
                     completed_passes.fetch_add(1, Ordering::Release);
                     loop {
                         notify.notified().await;
@@ -2979,7 +2981,7 @@ impl PaneRuntime {
         result
     }
 
-    #[cfg(any(unix, test))]
+    #[cfg(unix)]
     pub fn input_state(&self) -> Option<InputState> {
         self.terminal.input_state()
     }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3125,7 +3125,8 @@ mod tests {
 
         let parent_pid = std::process::id().to_string();
         let test_exe = std::env::current_exe().expect("resolve test executable");
-        let configurations: [(&str, fn(&mut Command)); 2] = [
+        type ConfigureCommand = fn(&mut Command);
+        let configurations: [(&str, ConfigureCommand); 2] = [
             ("background", super::configure_background_command_platform),
             ("server daemon", super::detach_server_daemon_command),
         ];
@@ -3172,7 +3173,7 @@ mod tests {
     }
 
     fn argv_strings(argv: &[std::ffi::OsString]) -> Vec<String> {
-        argv.into_iter()
+        argv.iter()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect()
     }

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -19,9 +19,9 @@ use crate::terminal_theme::{
 };
 
 const ESC: u8 = 0x1b;
-#[cfg(any(unix, test))]
+#[cfg(unix)]
 pub(crate) const RAW_INPUT_IDLE_FLUSH_TIMEOUT_MS: i32 = 10;
-#[cfg(any(unix, test))]
+#[cfg(unix)]
 pub(crate) const MOUSE_ACTIVE_ESCAPE_SEQUENCE_FLUSH_TIMEOUT_MS: i32 = 150;
 pub(crate) const GHOSTTY_COLOR_SCHEME_DARK_REPORT: &[u8] = b"\x1b[?997;1n";
 pub(crate) const GHOSTTY_COLOR_SCHEME_LIGHT_REPORT: &[u8] = b"\x1b[?997;2n";
@@ -207,12 +207,12 @@ impl RawInputByteFramer {
         !self.buffer.is_empty()
     }
 
-    #[cfg(any(not(windows), test))]
+    #[cfg(unix)]
     pub(crate) fn has_pending_lone_escape(&self) -> bool {
         self.buffer.as_slice() == [ESC]
     }
 
-    #[cfg(any(unix, test))]
+    #[cfg(unix)]
     pub(crate) fn has_pending_incomplete_mouse_sequence(&self) -> bool {
         starts_with_incomplete_sgr_mouse_sequence(&self.buffer)
             || starts_with_incomplete_default_mouse_sequence(&self.buffer)


### PR DESCRIPTION
Native Windows `just lint`/`just check` clippy-checked only the `herdr` binary, while macOS/Linux run `cargo clippy --all-targets`. That left Windows-only test and helper code unlinted.

`just test` already runs the full applicable suite on Windows (see #3660), so the remaining local parity gap was the lint target scope.

- Switch native Windows lint to `cargo clippy --all-targets --locked -- -D warnings`.
- Gate the Unix-only test helpers/imports that `--all-targets` exposed so the command passes on Windows.

Validation (native Windows):
- `just check` passes: `--all-targets` clippy, 2900 nextest tests, maintenance/architecture/integration/docs contract tests, and the debug build.