### PR TITLE
fix: ignore nested OMP session reports

### DIFF
--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -11,6 +11,7 @@ const originalEnvironment = {
   HERDR_OMP_IDLE_DEBOUNCE_MS: process.env.HERDR_OMP_IDLE_DEBOUNCE_MS,
   HERDR_PANE_ID: process.env.HERDR_PANE_ID,
   HERDR_SOCKET_PATH: process.env.HERDR_SOCKET_PATH,
+  OMPCODE: process.env.OMPCODE,
 };
 
 let server: Server | undefined;
@@ -228,6 +229,33 @@ for (const integration of integrations) {
     expect(reportedState()).toBe("working");
   });
 }
+
+test("OMP ignores nested sessions launched inside another OMP shell", async () => {
+  const requests = await startRecordingServer("omp-nested");
+  process.env.OMPCODE = "1";
+  const { handlers, pi } = createExtensionHarness();
+
+  const { default: install } = await importFresh("./omp/herdr-agent-state.ts");
+  install(pi);
+
+  // OMP sets OMPCODE on every shell it spawns. A nested `omp` inherits it and
+  // must not claim the pane's session for its short-lived conversation.
+  expect(handlers.size).toBe(0);
+  await handlers.get("session_start")?.(
+    { reason: "startup" },
+    {
+      hasUI: true,
+      isIdle: () => true,
+      sessionManager: {
+        getSessionFile: () => "/tmp/omp-nested.jsonl",
+        getSessionId: () => "omp-nested",
+      },
+    },
+  );
+  await Bun.sleep(25);
+
+  expect(requests).toEqual([]);
+});
 
 test("OMP accepts POSIX and Windows session paths", async () => {
   const { isAbsoluteSessionPath } = await importFresh("./omp/herdr-agent-state.ts");

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -2,7 +2,7 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=omp
-// HERDR_INTEGRATION_VERSION=9
+// HERDR_INTEGRATION_VERSION=10
 // @ts-nocheck
 
 import net from "node:net";
@@ -14,9 +14,13 @@ const socketEndpoint =
   process.platform === "win32" && socketPath ? `\\\\.\\pipe\\${socketPath}` : socketPath;
 const paneId = process.env.HERDR_PANE_ID;
 const source = "herdr:omp";
+// OMP marks every shell it spawns with OMPCODE=1. A nested `omp` launched from
+// a parent session's shell inherits it, so that process is not the pane's root
+// agent and must not report its short-lived session over the parent's.
+const nestedOmpSession = process.env.OMPCODE === "1";
 
 function enabled() {
-  return HERDR_ENV === "1" && !!socketPath && !!paneId;
+  return HERDR_ENV === "1" && !!socketPath && !!paneId && !nestedOmpSession;
 }
 
 let requestQueue = Promise.resolve();

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -27,7 +27,7 @@ const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
 const PI_INTEGRATION_VERSION: u32 = 9;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
-const OMP_INTEGRATION_VERSION: u32 = 9;
+const OMP_INTEGRATION_VERSION: u32 = 10;
 const CLAUDE_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
     "herdr-agent-state.ps1"
 } else {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -147,6 +147,9 @@ impl PaneLaunchEnv {
 
 fn apply_pane_launch_env(cmd: &mut CommandBuilder, launch_env: &PaneLaunchEnv) {
     cmd.env_remove("CODEX_THREAD_ID");
+    // OMP sets OMPCODE for shells it spawns. A pane launched from inside OMP
+    // must not inherit it or its root agent would look like a nested session.
+    cmd.env_remove("OMPCODE");
     for (key, value) in &launch_env.extra {
         cmd.env(key, value);
     }
@@ -3555,6 +3558,16 @@ mod tests {
         apply_pane_launch_env(&mut cmd, &PaneLaunchEnv::default());
 
         assert!(cmd.get_env("CODEX_THREAD_ID").is_none());
+    }
+
+    #[test]
+    fn pane_launch_env_removes_outer_ompcode_marker() {
+        let mut cmd = CommandBuilder::new("shell");
+        cmd.env("OMPCODE", "1");
+
+        apply_pane_launch_env(&mut cmd, &PaneLaunchEnv::default());
+
+        assert!(cmd.get_env("OMPCODE").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2593. A nested interactive `omp` launched from a parent OMP session's shell inherited `HERDR_PANE_ID`/`HERDR_SOCKET_PATH`, registered the bundled integration, and reported its own session with `session_start_source: "startup"`. That replaced the pane's resumable session. Because the integration's `seq` base is captured at process start (`Date.now() * 1000`), the nested process's sequence stayed permanently ahead of the parent's, so the parent could never re-anchor after the nested command exited.

## Root cause

OMP's integration only filtered nested sessions with `ctx.hasUI`. A nested interactive `omp` has `hasUI === true`, so it reported normally.

OMP sets `OMPCODE=1` in the environment of every shell it spawns (`packages/utils/src/procmgr.ts`). A nested `omp` inherits that marker; the pane's root OMP does not.

## Fix

- OMP integration: treat `OMPCODE=1` as a nested session and disable reporting, mirroring the existing Codex `CODEX_THREAD_ID` nested-session guard. Bumps `HERDR_INTEGRATION_VERSION` to `10`.
- Pane launch: strip an inherited `OMPCODE` when Herdr spawns a pane, so a root OMP pane never inherits a stale marker when Herdr itself was started from an OMP shell.

## Validation

- `bun test src/integration/assets/herdr-agent-state.test.ts` (18 pass), including a new test asserting the OMP integration registers no handlers and sends no requests when `OMPCODE=1`.
- `cargo nextest run -E "test(integration::tests) | test(pane::tests::pane_launch_env) | test(pane::tests::pane_terminal_identity)"` (137 pass), including a new pane env test.
- `just integration-assets-test`, `cargo fmt --check`, and `cargo clippy --all-targets --locked -- -D warnings` are clean.

## Notes

No protocol/API changes. The integration version bump makes `herdr integration status` report existing OMP installs as outdated so they get the fix.
