### PR TITLE
fix: recognize codex composer sparkles

### DIFF
--- a/distribution/agent-detection/codex.toml
+++ b/distribution/agent-detection/codex.toml
@@ -1,7 +1,7 @@
 id = "codex"
-version = "2026.09.05.1"
+version = "2026.09.12.1"
 min_engine_version = 3
-updated_at = "2026-09-05T00:00:00Z"
+updated_at = "2026-09-12T00:00:00Z"
 
 [[rules]]
 id = "osc_title_blocked"
@@ -69,6 +69,8 @@ id = "weak_blocker"
 state = "blocked"
 priority = 600
 region = "whole_recent_without_current_prompt_marker"
+# Sparkles can replace the space after ›. A later response marker makes that prompt stale.
+not = [{ regex = ['(?m)^›[⠁⠂⠄⠈⠐⠠⡀⢀][^\n]*(?:\n(?:[^•■✗✓\n][^\n]*)?)*\z'] }]
 any = [
   { contains = ["[y/n]"] },
   { contains = ["yes (y)"] },

--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -1195,6 +1195,46 @@ fn codex_weak_blocker_ignores_wrapped_current_prompt_text() {
 }
 
 #[test]
+fn codex_sparkle_prompt_preserves_live_states() {
+    for marker in ["› ", "›⠁", "›⠂", "›⠄", "›⠈", "›⠐", "›⠠", "›⡀", "›⢀"]
+    {
+        let screen = format!("Do you want to proceed? [y/n]\n{marker}unsent draft\n");
+        let result = osc_explain(Agent::Codex, &screen, "project | Ready", "");
+        assert_eq!(result.state, AgentState::Idle, "{marker}");
+
+        let working = format!(
+            "Do you want to proceed? [y/n]\n• Working (4s • esc to interrupt)\n{marker}draft\n"
+        );
+        let result = osc_explain(Agent::Codex, &working, "project", "");
+        assert_eq!(result.state, AgentState::Working, "{marker}");
+
+        let approval = format!("{screen}Press enter to confirm or esc to cancel\n");
+        let result = osc_explain(Agent::Codex, &approval, "project", "");
+        assert_eq!(result.state, AgentState::Blocked, "{marker}");
+        assert!(result.visible_blocker);
+
+        for response_marker in ['•', '■', '✗', '✓'] {
+            let response = format!("{screen}{response_marker} Do you want to proceed? [y/n]\n");
+            let result = osc_explain(Agent::Codex, &response, "project", "");
+            assert_eq!(
+                result.state,
+                AgentState::Blocked,
+                "{marker} {response_marker}"
+            );
+        }
+    }
+}
+
+#[test]
+fn codex_weak_blocker_does_not_ignore_arbitrary_prompt_suffixes() {
+    for line in ["›text", "›⠋draft", "›⠀draft", " ›⠁draft", "quoted ›⠁draft"] {
+        let screen = format!("Do you want to proceed? [y/n]\n{line}\n");
+        let result = osc_explain(Agent::Codex, &screen, "project", "");
+        assert_eq!(result.state, AgentState::Blocked, "{line}");
+    }
+}
+
+#[test]
 fn codex_transcript_viewer_outranks_working_fallback() {
     let screen = "• Working (4s • esc to interrupt)\n\
         › transcript\n\

--- a/src/detect/manifests/codex.toml
+++ b/src/detect/manifests/codex.toml
@@ -1,7 +1,7 @@
 id = "codex"
-version = "2026.09.05.1"
+version = "2026.09.12.1"
 min_engine_version = 3
-updated_at = "2026-09-05T00:00:00Z"
+updated_at = "2026-09-12T00:00:00Z"
 
 [[rules]]
 id = "osc_title_blocked"
@@ -69,6 +69,8 @@ id = "weak_blocker"
 state = "blocked"
 priority = 600
 region = "whole_recent_without_current_prompt_marker"
+# Sparkles can replace the space after ›. A later response marker makes that prompt stale.
+not = [{ regex = ['(?m)^›[⠁⠂⠄⠈⠐⠠⡀⢀][^\n]*(?:\n(?:[^•■✗✓\n][^\n]*)?)*\z'] }]
 any = [
   { contains = ["[y/n]"] },
   { contains = ["yes (y)"] },


### PR DESCRIPTION
## Summary
Codex 0.154 composer sparkles can make an idle pane flicker red when an old `[y/n]` question remains above it. Fix this through the hot-reloadable Codex manifest, so installed Herdr 0.9.0 clients can receive it without a binary update.

The weak-question rule ignores a composer whose `›` is immediately followed by one of the eight sparkle glyphs, only while no later response marker makes that composer stale. Strong approval rules and working-state priorities are unchanged. Bundled and remotely distributed manifests both advance to `2026.09.12.1`.

This replaces the initial Rust parser change; the PR now has no production Rust changes.

Refs #3988

## Validation
- `just check` passed, including Windows lint: 3,404 Rust tests passed, 4 skipped.
- Regression checks cover all eight glyphs, idle drafts, working fallback, live approval controls, later response markers, and rejection of unrelated suffixes.
- 82 offline cases passed using installed Herdr 0.9.0, not the patched parser.
- Live Codex 0.154.0 / Astra on stock Herdr 0.9.0: before hot reload, 12 blocked / 18 idle readings. After reloading only the isolated manifest override, 7 initial unknown readings followed by 93 consecutive idle readings and no blocked readings. Captured 23 sparkle-adjacent composer frames after reload. Codex was not restarted and no prompt was submitted.
- Disposable session and isolated overrides cleaned up; user configuration untouched.