### PR TITLE
fix: deflake windows endpoint flush drain test

### DIFF
--- a/src/client/endpoint/writer.rs
+++ b/src/client/endpoint/writer.rs
@@ -373,16 +373,18 @@ mod tests {
             done.send((first, second)).unwrap();
         });
         let input = ClientMessage::Input {
-            data: vec![b'x'; 1024 * 1024],
+            // Comfortably above MAX_BATCH_BYTES, but small enough that the polling peer's
+            // Windows 2ms read cadence drains it well within the flush deadline under CI load.
+            data: vec![b'x'; 256 * 1024],
         };
         transport.send(&input).unwrap();
         transport.send(&ClientMessage::Detach).unwrap();
         // Large-frame correctness must not depend on the registry's short exit grace period.
         transport
-            .flush(Instant::now() + Duration::from_secs(10))
+            .flush(Instant::now() + Duration::from_secs(30))
             .unwrap();
         drop(transport);
-        let (first, second) = received.recv_timeout(Duration::from_secs(10)).unwrap();
+        let (first, second) = received.recv_timeout(Duration::from_secs(30)).unwrap();
         assert_eq!(first, input);
         assert_eq!(second, ClientMessage::Detach);
         reader.join().unwrap();


### PR DESCRIPTION
## Summary
- `native_endpoint_flush_drains_large_frames_before_detach` is a pre-existing Windows CI flake: it failed identically on unchanged `master` (`e3a46f4f`, run 34723234540) and again on the Grok PR (#2683).
- The test's polling peer drains at production's 2ms Windows read cadence (`wait_client_stream_readable`), so a 1 MiB frame took ~5.5s locally and exceeded the test's 10s flush deadline under CI load.

## Change
- Use a 256 KiB input frame, still 4x the 64 KiB `MAX_BATCH_BYTES`, so the test keeps exercising the large-frame / multi-batch path.
- Raise the flush and reader deadlines to 30s so the correctness assertion no longer depends on CI scheduling.

## Validation
- `cargo nextest run -E 'test(client::endpoint::writer)'`: 9/9 pass in ~1.4s (the flaky test alone was ~5.5s).
- 5 consecutive runs of the flaky test pass.
- `just check`: fmt, clippy `-D warnings`, 2,948 tests, maintenance / UI-hot-path / integration-asset / docs-contract suites, and `cargo build --locked` all pass.
