### PR TITLE
ci: migrate remaining pinned actions to node24

### DIFF
--- a/.github/workflows/build-artifacts-manual.yml
+++ b/.github/workflows/build-artifacts-manual.yml
@@ -70,7 +70,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        uses: vercel-labs/setup-zig@83c1594f26b86da8a9a8ddd9b5ee5f3af0f96943 # v1.0.2
         with:
           version: 0.16.0
 
@@ -154,7 +154,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        uses: vercel-labs/setup-zig@83c1594f26b86da8a9a8ddd9b5ee5f3af0f96943 # v1.0.2
         with:
           version: 0.16.0
 
@@ -207,7 +207,7 @@ jobs:
           targets: x86_64-pc-windows-msvc
 
       - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        uses: vercel-labs/setup-zig@83c1594f26b86da8a9a8ddd9b5ee5f3af0f96943 # v1.0.2
         with:
           version: 0.16.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ env:
   # Keep file/line backtraces without generating type and variable debug information.
   CARGO_PROFILE_DEV_DEBUG: "1"
   CARGO_PROFILE_TEST_DEBUG: "1"
+  # vercel-labs/setup-zig does not cache the Zig global cache, so redirect it into the
+  # workspace .zig-cache that the Zig build cache steps persist. Remove this (and the
+  # widened condition on "Restore Zig build cache") if we switch to a setup action that
+  # owns Zig caching, e.g. step-security/setup-zig. See PR #4023.
+  ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -113,7 +118,6 @@ jobs:
           "ZIG=$(Join-Path $stable 'zig.exe')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Restore Zig build cache
-        if: runner.os == 'macOS' || matrix.kind == 'windows'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .zig-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,9 @@ jobs:
           bun-version: 1.3.14
 
       - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        uses: vercel-labs/setup-zig@83c1594f26b86da8a9a8ddd9b5ee5f3af0f96943 # v1.0.2
         with:
           version: 0.16.0
-          use-cache: ${{ runner.os == 'Linux' }}
-          # Linux builds both SIMD/ReleaseFast and scalar/ReleaseSafe variants.
-          cache-size-limit: 4096
 
       # Zig's C-header cache keys include the compiler installation path.
       - name: Stabilize Zig installation path on Unix
@@ -117,7 +114,7 @@ jobs:
 
       - name: Restore Zig build cache
         if: runner.os == 'macOS' || matrix.kind == 'windows'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .zig-cache
           key: zig-build-v1-${{ runner.os }}-${{ runner.arch }}-0.16.0-${{ github.run_id }}-${{ github.run_attempt }}
@@ -134,7 +131,7 @@ jobs:
       # rebuilds workspace targets; only rustc's validated query state is retained.
       - name: Restore Windows incremental compiler state
         if: matrix.kind == 'windows'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: target/debug/incremental
           key: ci-incremental-v1-${{ runner.os }}-${{ runner.arch }}-${{ env.RUST_TOOLCHAIN_VERSION }}-${{ env.CARGO_PROFILE_DEV_DEBUG }}-${{ env.CARGO_PROFILE_TEST_DEBUG }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', '.cargo/config.toml', 'build.rs') }}-${{ github.sha }}
@@ -192,10 +189,9 @@ jobs:
           targets: x86_64-pc-windows-msvc
 
       - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        uses: vercel-labs/setup-zig@83c1594f26b86da8a9a8ddd9b5ee5f3af0f96943 # v1.0.2
         with:
           version: 0.16.0
-          use-cache: false
 
       - name: Stabilize Zig installation path
         shell: pwsh
@@ -207,7 +203,7 @@ jobs:
           "ZIG=$(Join-Path $stable 'zig.exe')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Restore Zig build cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .zig-cache
           key: zig-build-v1-conpty-package-windows-2022-${{ runner.arch }}-0.16.0-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Install Zig
         if: steps.plan.outputs.should_publish == 'true'
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        uses: vercel-labs/setup-zig@83c1594f26b86da8a9a8ddd9b5ee5f3af0f96943 # v1.0.2
         with:
           version: 0.16.0
 
@@ -161,7 +161,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        uses: vercel-labs/setup-zig@83c1594f26b86da8a9a8ddd9b5ee5f3af0f96943 # v1.0.2
         with:
           version: 0.16.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        uses: vercel-labs/setup-zig@83c1594f26b86da8a9a8ddd9b5ee5f3af0f96943 # v1.0.2
         with:
           version: 0.16.0
 


### PR DESCRIPTION
## Why
GitHub removes Node 20 from Actions runners on **September 23, 2026**. Two pinned actions still declare `using: node20`:

- `actions/cache@v4` — used 3× in `ci.yml`
- `mlugg/setup-zig@v2.2.1` — used 8× across `ci.yml`, `preview.yml`, `release.yml`, `build-artifacts-manual.yml`

Every other pinned action is already `node24` or `composite`.

## Change
- `actions/cache` v4 → **v6.1.0** (`55cc8345…`): drop-in.
- `mlugg/setup-zig` v2.2.1 → **`vercel-labs/setup-zig` v1.0.2** (`83c1594f…`): node24.

## Trade-off / limitations of `vercel-labs/setup-zig`
`mlugg/setup-zig`'s latest release (`v2.2.1`) and upstream `main` (Codeberg) both still target `node20` and it has been dormant since 2026-01, so there is no upstream node24 upgrade. `vercel-labs/setup-zig` only accepts `version`, which changes caching:

- Removed `use-cache: ${{ runner.os == 'Linux' }}` and `cache-size-limit: 4096`.
- `mlugg` redirected both Zig caches into the workspace `.zig-cache` (which the repo caches on macOS/Windows via the `Restore Zig build cache` step). With `vercel-labs`, only the default local `.zig-cache` is used; the Zig **global** cache is no longer cached, and Linux has no `.zig-cache` cache step, so Linux loses Zig caching entirely. Expect less cache-warm/slower Linux builds.
- `vercel-labs` has no `post` step, so there is no action-owned cache save.

## Alternatives
- **`step-security/setup-zig@v2.2.2`** (`1e9fbd45…`) — exact drop-in: same `version`/`use-cache`/`cache-size-limit` interface, node24, actively maintained by StepSecurity. Preserves the current caching behavior. Trade-off: low-star third-party repo.
- **`xyzzylabs/setup-zig@v1.0.4`** (`ab632f9c…`) — node24 drop-in with minisign verification, very active. Trade-off: unknown author.
- **Keep `mlugg/setup-zig`** — canonical action; it currently runs forced on node24 and CI passes, but the warning persists and upstream is dormant.
- **Compensating cache step** — if we keep `vercel-labs`, add an `actions/cache` step for Zig's default global cache directory.

## Validation
- All 10 workflow YAML files parse; both new pinned refs resolve and target `node24`.
- The CI run on this PR exercises the new action on ubuntu/macos/windows.
