### PR TITLE
fix: skip host theme re-query when focus reports an unchanged color s…

### DIFF
--- a/src/client/catalog_reload.rs
+++ b/src/client/catalog_reload.rs
@@ -139,6 +139,8 @@ mod tests {
             mouse_scroll_lines: 3,
             remote_image_paste_key: None,
             redraw_on_focus_gained: false,
+            #[cfg(any(unix, test))]
+            direct_host_appearance: None,
             repaint_pending: false,
             presentation_frozen: false,
             draw_host_cursor: false,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -401,6 +401,8 @@ async fn run_client_loop(
         mouse_scroll_lines: config.mouse_scroll_lines,
         remote_image_paste_key: config.remote_image_paste_key,
         redraw_on_focus_gained: config.redraw_on_focus_gained,
+        #[cfg(any(unix, test))]
+        direct_host_appearance: None,
         repaint_pending: false,
         presentation_frozen: false,
         draw_host_cursor,
@@ -846,7 +848,8 @@ async fn run_client_loop(
                     if crate::raw_input::events_require_host_terminal_appearance_query(&events) {
                         query_host_terminal_appearance();
                     }
-                    if crate::raw_input::events_require_host_terminal_theme_query(&events) {
+                    if direct_host_theme_query_required(&mut state.direct_host_appearance, &events)
+                    {
                         query_host_terminal_theme();
                     }
                     if let Some((width_px, height_px)) = reported_cell_size_from_events(&events) {
@@ -2053,6 +2056,28 @@ async fn run_client_loop(
     let _ = io::stdout().flush();
 
     Ok(())
+}
+
+/// A direct attach re-queries the host theme only when a scheme report carries
+/// an appearance that differs from the last reported one. The appearance query
+/// sent on focus gain is answered with the current scheme even when nothing
+/// changed; re-querying the full theme then makes the host terminal answer
+/// hundreds of palette queries, which stalls its display for seconds.
+#[cfg(any(not(windows), test))]
+fn direct_host_theme_query_required(
+    last_appearance: &mut Option<crate::terminal_theme::HostAppearance>,
+    events: &[crate::raw_input::RawInputEvent],
+) -> bool {
+    let mut required = false;
+    for event in events {
+        if let crate::raw_input::RawInputEvent::HostColorSchemeChanged(appearance) = event {
+            if *last_appearance != Some(*appearance) {
+                *last_appearance = Some(*appearance);
+                required = true;
+            }
+        }
+    }
+    required
 }
 
 #[cfg(test)]

--- a/src/client/shell/input.rs
+++ b/src/client/shell/input.rs
@@ -253,10 +253,16 @@ impl ClientShellState {
                         .push(ClientMessage::ClientShellFocus { focused: false });
                 }
                 RawInputEvent::HostColorSchemeChanged(appearance) => {
+                    // Focus gain re-arms an appearance query whose reply reports the
+                    // current scheme even when nothing changed. Re-querying the full
+                    // theme then makes the host terminal answer hundreds of palette
+                    // queries, which stalls its display for seconds. Only re-query
+                    // when the scheme actually changed (or was unknown).
+                    let appearance_changed = self.host_appearance != Some(appearance);
                     self.host_appearance = Some(appearance);
                     self.host_appearance_explicit = true;
-                    outcome.query_host_theme = true;
-                    if self.config.theme_runtime.auto_switch {
+                    outcome.query_host_theme = appearance_changed;
+                    if appearance_changed && self.config.theme_runtime.auto_switch {
                         self.config.palette = crate::app::client_palette_for_appearance(
                             &self.config.theme_runtime,
                             appearance,

--- a/src/client/shell/tests/input.rs
+++ b/src/client/shell/tests/input.rs
@@ -105,6 +105,37 @@ fn full_host_palette_response_is_sent_as_one_theme_update() {
 }
 
 #[test]
+fn host_color_scheme_report_requeries_theme_only_on_change() {
+    let mut state = ClientShellState::new(ClientShellConfig::from_config(&Config::default()));
+    state.config.theme_runtime.auto_switch = true;
+
+    // First report establishes the scheme: full theme query follows.
+    let initial = state.handle_raw_events(vec![RawInputEvent::HostColorSchemeChanged(
+        crate::terminal_theme::HostAppearance::Dark,
+    )]);
+    assert!(initial.query_host_theme);
+
+    // The reply to the focus-gain appearance query repeats the current scheme
+    // and must not re-trigger the full theme (palette) query or a repaint.
+    let repeated = state.handle_raw_events(vec![RawInputEvent::HostColorSchemeChanged(
+        crate::terminal_theme::HostAppearance::Dark,
+    )]);
+    assert!(!repeated.query_host_theme);
+    assert!(!repeated.repaint);
+
+    // A genuine scheme change re-queries the theme and repaints.
+    let changed = state.handle_raw_events(vec![RawInputEvent::HostColorSchemeChanged(
+        crate::terminal_theme::HostAppearance::Light,
+    )]);
+    assert!(changed.query_host_theme);
+    assert!(changed.repaint);
+    assert_eq!(
+        state.host_appearance,
+        Some(crate::terminal_theme::HostAppearance::Light)
+    );
+}
+
+#[test]
 fn modal_paste_shortcut_modifiers_are_platform_specific() {
     let key = |code, modifiers| crate::input::TerminalKey::new(code, modifiers);
 

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -34,6 +34,9 @@ pub(super) struct ClientState {
     pub(super) remote_image_paste_key:
         Option<(crossterm::event::KeyCode, crossterm::event::KeyModifiers)>,
     pub(super) redraw_on_focus_gained: bool,
+    /// Last host color scheme reported during a direct terminal attach.
+    #[cfg(any(unix, test))]
+    pub(super) direct_host_appearance: Option<crate::terminal_theme::HostAppearance>,
     pub(super) repaint_pending: bool,
     /// During a source-off-first handoff the currently blitted frame remains authoritative until
     /// an acknowledged target snapshot/surface pair commits.

--- a/src/client/tests/mod.rs
+++ b/src/client/tests/mod.rs
@@ -392,11 +392,30 @@ fn write_host_color_scheme_report_mode_emits_mode_sequences() {
 }
 
 #[test]
-fn color_scheme_change_event_requests_host_theme_query() {
-    let events = crate::raw_input::parse_raw_input_bytes_sync(b"\x1b[?997;1n");
+fn color_scheme_report_requests_host_theme_query_only_on_change() {
+    let dark = crate::raw_input::parse_raw_input_bytes_sync(b"\x1b[?997;1n");
+    let light = crate::raw_input::parse_raw_input_bytes_sync(b"\x1b[?997;2n");
 
-    assert!(crate::raw_input::events_require_host_terminal_theme_query(
-        &events
+    let mut last_appearance = None;
+    // The first report establishes the scheme, so it needs a full theme query.
+    assert!(crate::client::direct_host_theme_query_required(
+        &mut last_appearance,
+        &dark
+    ));
+    // A repeated report with the same scheme (for example the reply to the
+    // focus-gain appearance query) must not re-query the theme.
+    assert!(!crate::client::direct_host_theme_query_required(
+        &mut last_appearance,
+        &dark
+    ));
+    // A genuine scheme change re-queries the theme again.
+    assert!(crate::client::direct_host_theme_query_required(
+        &mut last_appearance,
+        &light
+    ));
+    assert!(!crate::client::direct_host_theme_query_required(
+        &mut last_appearance,
+        &light
     ));
 }
 

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -542,13 +542,6 @@ pub(crate) fn events_require_host_terminal_appearance_query(events: &[RawInputEv
         .any(|event| matches!(event, RawInputEvent::OuterFocusGained))
 }
 
-#[cfg(any(not(windows), test))]
-pub(crate) fn events_require_host_terminal_theme_query(events: &[RawInputEvent]) -> bool {
-    events
-        .iter()
-        .any(|event| matches!(event, RawInputEvent::HostColorSchemeChanged(_)))
-}
-
 fn extract_one_event(buffer: &[u8]) -> Option<(RawInputEvent, usize)> {
     if buffer.is_empty() {
         return None;
@@ -1330,7 +1323,6 @@ mod tests {
         assert!(!events_require_host_terminal_appearance_query(
             &scheme_report
         ));
-        assert!(events_require_host_terminal_theme_query(&scheme_report));
     }
 
     #[test]
@@ -1345,7 +1337,6 @@ mod tests {
                 events[0],
                 RawInputEvent::HostColorSchemeChanged(HostAppearance::Dark | HostAppearance::Light)
             ));
-            assert!(events_require_host_terminal_theme_query(&events));
         }
     }
 
@@ -1359,7 +1350,6 @@ mod tests {
             let events = parse_raw_input_bytes_sync(bytes);
             assert_eq!(events.len(), 1, "bytes: {bytes:?}");
             assert!(matches!(events[0], RawInputEvent::Unsupported));
-            assert!(!events_require_host_terminal_theme_query(&events));
         }
     }
 


### PR DESCRIPTION

## Background

Herdr refreshes the host terminal appearance on focus gain (#2416): when the outer terminal is focused again, the client sends a color-scheme query (CSI ? 996 n) so a light/dark switch made while Herdr was in the background is picked up. The reply (e.g. CSI ? 997 ; 1 n) is parsed as HostColorSchemeChanged, the same event used for spontaneous mode 2031 change notifications.

## Reproduction

1. Run the Herdr TUI in iTerm2 on macOS (also reproducible on Linux with a slowly responding terminal).
2. Cmd+Tab to another app, wait a moment, Cmd+Tab back.
3. Immediately type a key.

Expected: the key echoes instantly.
Actual: the first keystroke appears only after ~2 seconds. A plain shell in the same terminal does not show the delay.

## Root cause

The HostColorSchemeChanged handler treated every scheme report as a change and unconditionally re-queried the full host theme. On macOS and Linux the theme query includes 256 OSC 4 palette queries plus OSC 10/11 (src/terminal_theme.rs host_terminal_theme_query_sequence), so every focus gain made the terminal answer 258 queries. iTerm2 answers them in batches over ~1.5-2s; while it churns through the replies its display stalls, so the first keystroke echoes late even though Herdr's input path parsed it instantly (confirmed with HERDR_LOG=herdr=debug: the key event was parsed on time during the reply flood; palette replies kept arriving for ~1.5s after each focus gain).

## Fix

Track the last reported host appearance and re-query the theme only when a scheme report actually changes it (or when it was unknown, e.g. at startup). Applied in both affected paths:

- client shell (TUI): compare in the HostColorSchemeChanged handler and skip the theme re-query and the auto-switch repaint when the scheme is unchanged;
- direct terminal attach: new direct_host_appearance state on ClientState and a direct_host_theme_query_required helper replacing the unconditional events_require_host_terminal_theme_query policy, which is removed.

The cheap focus-gain appearance query (one small request/reply) is kept: on terminals without mode 2031 push notifications it is the only way to notice a scheme change made while unfocused, and its reply now also decides whether the expensive palette re-query is warranted. A genuine scheme change still triggers the full theme and palette refresh.

Trade-off: palette-only changes that keep the same light/dark scheme (e.g. switching between two dark terminal profiles while Herdr is unfocused) are no longer refreshed on focus; they are picked up on the next real scheme change. That is the cost of removing a 258-query storm from every focus gain.

## Validation

- new regression tests cover first report -> query, repeated unchanged report -> no query, changed report -> query, for both the shell and direct-attach paths;
- cargo nextest run --no-fail-fast: 3218 passed, 4 skipped (ssh_check_message_is_visible_while_authentication_waits flaked once under parallel load and passes in isolation);
- cargo clippy --target x86_64-pc-windows-msvc -D warnings passes for the cfg-gated Windows build.